### PR TITLE
Bundler install path config 

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: true

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ DerivedData
 
 # Bundler
 /vendor/bundle/
-.bundle
 
 # CocoaPods
 #

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ __Distribution Site__ : <https://clipy-app.com>
 
 ### How to Build
 0. Move to the project root directory
-1. Install [CocoaPods](http://cocoapods.org) and [fastlane](https://github.com/fastlane/fastlane) using Bundler. Run `bundle install --path=vendor/bundle`
+1. Install [CocoaPods](http://cocoapods.org) and [fastlane](https://github.com/fastlane/fastlane) using Bundler. Run `bundle install`
 2. Run `pod install` on your terminal.
 2. Open Clipy.xcworkspace on Xcode.
 3. build.


### PR DESCRIPTION
Bundler install path config should be kept in git so we don't need to specify a path when running `bundle install` for the first time.