### PR TITLE
Remove .bundle folder

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,0 @@
----
-BUNDLE_PATH: vendor/bundle
-BUNDLE_DISABLE_SHARED_GEMS: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ DerivedData
 .env
 
 # Bundler
-/vendor/bundle/
+vendor
+.bundle
 
 # CocoaPods
 #


### PR DESCRIPTION
Deleted .bundle folder because it is no longer necessary to `bundle install` to start Clipy.