### PR TITLE
Add permission check of Accessibility from macOS 10.14 Mojave

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -68,8 +68,9 @@
 		FA6167921D3ABEB10049FA14 /* FolderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderSpec.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */; };
-		FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */; };
 		FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */; };
 		FAC0DCED1DE3230900309C49 /* NSColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEC1DE3230900309C49 /* NSColor+Hex.swift */; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
@@ -200,6 +201,7 @@
 		FA6167911D3ABEB10049FA14 /* FolderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FolderSpec.swift; sourceTree = "<group>"; };
 		FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DraggedDataSpec.swift; sourceTree = "<group>"; };
 		FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnippetSpec.swift; sourceTree = "<group>"; };
+		FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityService.swift; sourceTree = "<group>"; };
 		FAAA885C1E6853B80088FB34 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/CPYBetaPreferenceViewController.xib; sourceTree = "<group>"; };
 		FAAA88621E6858030088FB34 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/CPYBetaPreferenceViewController.strings; sourceTree = "<group>"; };
 		FAAA886C1E685DC70088FB34 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/CPYExcludeAppPreferenceViewController.xib; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */,
 				FAC0DCF01DE576F300309C49 /* PasteService.swift */,
 				FA1189321E4CD58C00244F12 /* ExcludeAppService.swift */,
+				FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -657,7 +660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
-				FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB51E1DDCB4C0007F95C8 /* CPYTypePreferenceViewController.xib in Resources */,
 				FA1DB4901DDCA5D9007F95C8 /* Images.xcassets in Resources */,
 				FA1DB51D1DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.xib in Resources */,
@@ -666,7 +669,7 @@
 				FA1DB51B1DDCB4C0007F95C8 /* CPYGeneralPreferenceViewController.xib in Resources */,
 				FA1DB51A1DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.xib in Resources */,
 				FA1DB5191DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.xib in Resources */,
-				FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5151C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB4941DDCB22C007F95C8 /* dsa_pub.pem in Resources */,
 				FA1DB4981DDCB2CB007F95C8 /* Localizable.strings in Resources */,
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
@@ -857,6 +860,7 @@
 				FA1DB4E51DDCB49C007F95C8 /* CPYUtilities.swift in Sources */,
 				FA1DB4B81DDCB452007F95C8 /* NSLock+Clipy.swift in Sources */,
 				FA1DB4BA1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift in Sources */,
+				FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */,
 				FA1DB4D31DDCB479007F95C8 /* CPYClip.swift in Sources */,
 				FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */,
 				C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */,

--- a/Clipy/Generated/LocalizedStrings.swift
+++ b/Clipy/Generated/LocalizedStrings.swift
@@ -33,6 +33,10 @@ internal enum L10n {
   internal static let launchOnSystemStartup = L10n.tr("Localizable", "Launch on system startup")
   /// Menu
   internal static let menu = L10n.tr("Localizable", "Menu")
+  /// Open System Preferences
+  internal static let openSystemPreferences = L10n.tr("Localizable", "Open System Preferences")
+  /// Please allow Accessibility.
+  internal static let pleaseAllowAccessibility = L10n.tr("Localizable", "Please allow Accessibility")
   /// Please fill in the contents of the snippet
   internal static let pleaseFillInTheContentsOfTheSnippet = L10n.tr("Localizable", "Please fill in the contents of the snippet")
   /// Preferences...
@@ -43,6 +47,8 @@ internal enum L10n {
   internal static let shortcuts = L10n.tr("Localizable", "Shortcuts")
   /// Snippet
   internal static let snippet = L10n.tr("Localizable", "Snippet")
+  /// To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.
+  internal static let toDoThisActionPleaseAllowAccessibilityInSecurityPrivacyPreferencesLocatedInSystemPreferences = L10n.tr("Localizable", "To do this action please allow Accessibility in Security Privacy preferences located in System Preferences")
   /// Type
   internal static let type = L10n.tr("Localizable", "Type")
   /// Updates

--- a/Clipy/Resources/de.lproj/Localizable.strings
+++ b/Clipy/Resources/de.lproj/Localizable.strings
@@ -51,3 +51,9 @@
 "Add" = "Hinzufügen";
 
 "Please fill in the contents of the snippet" = "Bitte geben Sie den Inhalt des Snippets ein";
+
+"Please allow Accessibility" = "Please allow Accessibility.";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.";
+
+"Open System Preferences" = "Open System Preferences";

--- a/Clipy/Resources/en.lproj/Localizable.strings
+++ b/Clipy/Resources/en.lproj/Localizable.strings
@@ -51,3 +51,9 @@
 "Add" = "Add";
 
 "Please fill in the contents of the snippet" = "Please fill in the contents of the snippet";
+
+"Please allow Accessibility" = "Please allow Accessibility.";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.";
+
+"Open System Preferences" = "Open System Preferences";

--- a/Clipy/Resources/it.lproj/Localizable.strings
+++ b/Clipy/Resources/it.lproj/Localizable.strings
@@ -52,3 +52,8 @@
 
 "Please fill in the contents of the snippet" = "Si prega di compilare il contenuto dello snippet";
 
+"Please allow Accessibility" = "Please allow Accessibility.";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.";
+
+"Open System Preferences" = "Open System Preferences";

--- a/Clipy/Resources/ja.lproj/Localizable.strings
+++ b/Clipy/Resources/ja.lproj/Localizable.strings
@@ -51,3 +51,9 @@
 "Add" = "追加";
 
 "Please fill in the contents of the snippet" = "スニペットの内容を記入してください";
+
+"Please allow Accessibility" = "アクセシビリティを有効にしてください。";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "この動作を行うためにはシステム環境設定の\"セキュリティとプライバシー\"環境設定で、Clipyへのアクセシビリティのアクセスを許可してください。";
+
+"Open System Preferences" = "\"システム環境設定\"を開く";

--- a/Clipy/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Clipy/Resources/zh-Hans.lproj/Localizable.strings
@@ -51,3 +51,9 @@
 "Add" = "添加";
 
 "Please fill in the contents of the snippet" = "请填写代码段的内容";
+
+"Please allow Accessibility" = "Please allow Accessibility.";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.";
+
+"Open System Preferences" = "Open System Preferences";

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -175,6 +175,8 @@ extension AppDelegate: NSApplicationDelegate {
         CPYUtilities.registerUserDefaultKeys()
         // SDKs
         CPYUtilities.initSDKs()
+        // Check Accessibility Permission
+        AppEnvironment.current.accessibilityService.isAccessibilityEnabled(isPrompt: true)
 
         // Show Login Item
         if !AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.loginItem) && !AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.suppressAlertForLoginItem) {

--- a/Clipy/Sources/Environments/AppEnvironment.swift
+++ b/Clipy/Sources/Environments/AppEnvironment.swift
@@ -41,6 +41,7 @@ struct AppEnvironment {
                      dataCleanService: DataCleanService = current.dataCleanService,
                      pasteService: PasteService = current.pasteService,
                      excludeAppService: ExcludeAppService = current.excludeAppService,
+                     accessibilityService: AccessibilityService = current.accessibilityService,
                      menuManager: MenuManager = current.menuManager,
                      defaults: UserDefaults = current.defaults) {
         push(environment: Environment(clipService: clipService,
@@ -48,6 +49,7 @@ struct AppEnvironment {
                                       dataCleanService: dataCleanService,
                                       pasteService: pasteService,
                                       excludeAppService: excludeAppService,
+                                      accessibilityService: accessibilityService,
                                       menuManager: menuManager,
                                       defaults: defaults))
     }
@@ -57,6 +59,7 @@ struct AppEnvironment {
                                dataCleanService: DataCleanService = current.dataCleanService,
                                pasteService: PasteService = current.pasteService,
                                excludeAppService: ExcludeAppService = current.excludeAppService,
+                               accessibilityService: AccessibilityService = current.accessibilityService,
                                menuManager: MenuManager = current.menuManager,
                                defaults: UserDefaults = current.defaults) {
         replaceCurrent(environment: Environment(clipService: clipService,
@@ -64,6 +67,7 @@ struct AppEnvironment {
                                                 dataCleanService: dataCleanService,
                                                 pasteService: pasteService,
                                                 excludeAppService: excludeAppService,
+                                                accessibilityService: accessibilityService,
                                                 menuManager: menuManager,
                                                 defaults: defaults))
     }
@@ -74,7 +78,14 @@ struct AppEnvironment {
             excludeApplications = applications
         }
         let excludeAppService = ExcludeAppService(applications: excludeApplications)
-        return Environment(excludeAppService: excludeAppService)
+        return Environment(clipService: current.clipService,
+                           hotKeyService: current.hotKeyService,
+                           dataCleanService: current.dataCleanService,
+                           pasteService: current.pasteService,
+                           excludeAppService: excludeAppService,
+                           accessibilityService: current.accessibilityService,
+                           menuManager: current.menuManager,
+                           defaults: current.defaults)
     }
 
  }

--- a/Clipy/Sources/Environments/Environment.swift
+++ b/Clipy/Sources/Environments/Environment.swift
@@ -20,6 +20,7 @@ struct Environment {
     let dataCleanService: DataCleanService
     let pasteService: PasteService
     let excludeAppService: ExcludeAppService
+    let accessibilityService: AccessibilityService
     let menuManager: MenuManager
 
     let defaults: UserDefaults
@@ -30,6 +31,7 @@ struct Environment {
          dataCleanService: DataCleanService = DataCleanService(),
          pasteService: PasteService = PasteService(),
          excludeAppService: ExcludeAppService = ExcludeAppService(applications: []),
+         accessibilityService: AccessibilityService = AccessibilityService(),
          menuManager: MenuManager = MenuManager(),
          defaults: UserDefaults = .standard) {
 
@@ -38,6 +40,7 @@ struct Environment {
         self.dataCleanService = dataCleanService
         self.pasteService = pasteService
         self.excludeAppService = excludeAppService
+        self.accessibilityService = accessibilityService
         self.menuManager = menuManager
         self.defaults = defaults
     }

--- a/Clipy/Sources/Services/AccessibilityService.swift
+++ b/Clipy/Sources/Services/AccessibilityService.swift
@@ -1,0 +1,48 @@
+// 
+//  AccessibilityService.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+// 
+//  Created by Econa77 on 2018/10/03.
+// 
+//  Copyright © 2015-2018 Clipy Project.
+//
+
+import Foundation
+import Cocoa
+
+final class AccessibilityService {}
+
+// MARK: - Permission
+extension AccessibilityService {
+    @discardableResult
+    func isAccessibilityEnabled(isPrompt: Bool) -> Bool {
+        /// Accessibility permission is required for paste command from macOS 10.14 Mojave.
+        /// For macOS 10.14 and later only, check accessibility permission at startup and paste
+        guard #available(macOS 10.14, *) else { return true }
+
+        let checkOptionPromptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let opts = [checkOptionPromptKey: isPrompt] as CFDictionary
+        return AXIsProcessTrustedWithOptions(opts)
+    }
+
+    func showAccessibilityAuthenticationAlert() {
+        let alert = NSAlert()
+        alert.messageText = L10n.pleaseAllowAccessibility
+        alert.informativeText = L10n.toDoThisActionPleaseAllowAccessibilityInSecurityPrivacyPreferencesLocatedInSystemPreferences
+        alert.addButton(withTitle: L10n.openSystemPreferences)
+        NSApp.activate(ignoringOtherApps: true)
+
+        if alert.runModal() == NSApplication.ModalResponse.alertFirstButtonReturn {
+            guard !openAccessibilitySettingWindow() else { return }
+            isAccessibilityEnabled(isPrompt: true)
+        }
+    }
+
+    func openAccessibilitySettingWindow() -> Bool {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else { return false }
+        return NSWorkspace.shared.open(url)
+    }
+}

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -140,9 +140,14 @@ extension PasteService {
 // MARK: - Paste
 extension PasteService {
     func paste() {
-        if !AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.inputPasteCommand) { return }
-        let vKeyCode = Sauce.shared.keyCode(by: .v)
+        guard AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.inputPasteCommand) else { return }
+        // Check Accessibility Permission
+        guard AppEnvironment.current.accessibilityService.isAccessibilityEnabled(isPrompt: false) else {
+            AppEnvironment.current.accessibilityService.showAccessibilityAuthenticationAlert()
+            return
+        }
 
+        let vKeyCode = Sauce.shared.keyCode(by: .v)
         DispatchQueue.main.async {
             let source = CGEventSource(stateID: .combinedSessionState)
             // Disable local keyboard events while pasting


### PR DESCRIPTION
From macOS 10.14 Mojave, accessibility permission is required when pasting command is executed. 
Added permission check at application startup and pasting 👍 