### PR TITLE
Add Polish language

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -68,8 +68,8 @@
 		FA6167921D3ABEB10049FA14 /* FolderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderSpec.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */; };
-		FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */; };
 		FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
@@ -149,6 +149,16 @@
 		9DBBF976436A0651CB8BD4B2 /* Pods-Clipy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clipy.release.xcconfig"; path = "Pods/Target Support Files/Pods-Clipy/Pods-Clipy.release.xcconfig"; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		CAFD12AF1F207DBC00DF1CEB /* Observable+Void.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Void.swift"; sourceTree = "<group>"; };
+		D6B1E794218DF2B200CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYPreferencesWindowController.strings; sourceTree = "<group>"; };
+		D6B1E795218DF2B200CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYBetaPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E796218DF2B200CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYExcludeAppPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E797218DF2B200CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYGeneralPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E798218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYMenuPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E799218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYShortcutsPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E79A218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYTypePreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E79B218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYUpdatesPreferenceViewController.strings; sourceTree = "<group>"; };
+		D6B1E79C218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CPYSnippetsEditorWindowController.strings; sourceTree = "<group>"; };
+		D6B1E79D218DF2B300CDBC2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceSpec.swift; sourceTree = "<group>"; };
 		FA0D5CE71DDCC61600AC9052 /* ClipService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipService.swift; sourceTree = "<group>"; };
 		FA10897B20EC22E200A3FEFC /* AssetsImages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetsImages.swift; sourceTree = "<group>"; };
@@ -639,6 +649,7 @@
 				it,
 				de,
 				"zh-Hans",
+				pl,
 			);
 			mainGroup = FAC43DBD1B35D8B100C06102;
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
@@ -657,7 +668,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
-				FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB51E1DDCB4C0007F95C8 /* CPYTypePreferenceViewController.xib in Resources */,
 				FA1DB4901DDCA5D9007F95C8 /* Images.xcassets in Resources */,
 				FA1DB51D1DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.xib in Resources */,
@@ -666,7 +677,7 @@
 				FA1DB51B1DDCB4C0007F95C8 /* CPYGeneralPreferenceViewController.xib in Resources */,
 				FA1DB51A1DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.xib in Resources */,
 				FA1DB5191DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.xib in Resources */,
-				FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5151C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB4941DDCB22C007F95C8 /* dsa_pub.pem in Resources */,
 				FA1DB4981DDCB2CB007F95C8 /* Localizable.strings in Resources */,
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
@@ -934,6 +945,7 @@
 				31ACA9F91EC5B85C00BD34C0 /* it */,
 				8460049F1FD5511A00BA733E /* de */,
 				54ADE1032008F64100239852 /* zh-Hans */,
+				D6B1E79D218DF2B300CDBC2C /* pl */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -946,6 +958,7 @@
 				31ACA9F01EC5B85B00BD34C0 /* it */,
 				846004961FD5511800BA733E /* de */,
 				54ADE0FA2008F63F00239852 /* zh-Hans */,
+				D6B1E794218DF2B200CDBC2C /* pl */,
 			);
 			name = CPYPreferencesWindowController.xib;
 			sourceTree = "<group>";
@@ -958,6 +971,7 @@
 				31ACA9F11EC5B85B00BD34C0 /* it */,
 				846004971FD5511900BA733E /* de */,
 				54ADE0FB2008F64000239852 /* zh-Hans */,
+				D6B1E795218DF2B200CDBC2C /* pl */,
 			);
 			name = CPYBetaPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -970,6 +984,7 @@
 				31ACA9F21EC5B85B00BD34C0 /* it */,
 				846004981FD5511900BA733E /* de */,
 				54ADE0FC2008F64000239852 /* zh-Hans */,
+				D6B1E796218DF2B200CDBC2C /* pl */,
 			);
 			name = CPYExcludeAppPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -982,6 +997,7 @@
 				31ACA9F31EC5B85B00BD34C0 /* it */,
 				846004991FD5511900BA733E /* de */,
 				54ADE0FD2008F64000239852 /* zh-Hans */,
+				D6B1E797218DF2B200CDBC2C /* pl */,
 			);
 			name = CPYGeneralPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -994,6 +1010,7 @@
 				31ACA9F41EC5B85B00BD34C0 /* it */,
 				8460049A1FD5511900BA733E /* de */,
 				54ADE0FE2008F64000239852 /* zh-Hans */,
+				D6B1E798218DF2B300CDBC2C /* pl */,
 			);
 			name = CPYMenuPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -1006,6 +1023,7 @@
 				31ACA9F51EC5B85B00BD34C0 /* it */,
 				8460049B1FD5511900BA733E /* de */,
 				54ADE0FF2008F64000239852 /* zh-Hans */,
+				D6B1E799218DF2B300CDBC2C /* pl */,
 			);
 			name = CPYShortcutsPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -1018,6 +1036,7 @@
 				31ACA9F61EC5B85C00BD34C0 /* it */,
 				8460049C1FD5511900BA733E /* de */,
 				54ADE1002008F64000239852 /* zh-Hans */,
+				D6B1E79A218DF2B300CDBC2C /* pl */,
 			);
 			name = CPYTypePreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -1030,6 +1049,7 @@
 				31ACA9F71EC5B85C00BD34C0 /* it */,
 				8460049D1FD5511A00BA733E /* de */,
 				54ADE1012008F64100239852 /* zh-Hans */,
+				D6B1E79B218DF2B300CDBC2C /* pl */,
 			);
 			name = CPYUpdatesPreferenceViewController.xib;
 			sourceTree = "<group>";
@@ -1042,6 +1062,7 @@
 				31ACA9F81EC5B85C00BD34C0 /* it */,
 				8460049E1FD5511A00BA733E /* de */,
 				54ADE1022008F64100239852 /* zh-Hans */,
+				D6B1E79C218DF2B300CDBC2C /* pl */,
 			);
 			name = CPYSnippetsEditorWindowController.xib;
 			sourceTree = "<group>";

--- a/Clipy/Resources/pl.lproj/Localizable.strings
+++ b/Clipy/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,59 @@
+//
+//  Localizable.strings
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Econa77 on 2015/06/21.
+//
+//  Copyright © 2015-2018 Clipy Project.
+//
+
+"Launch Clipy on system startup?" = "Włączać Clipy przy starcie systemu?";
+
+"You can change this setting in the Preferences if you want" = "To ustawienie może być zmienione później w Preferencjach.";
+
+"Launch on system startup" = "Włączanie przy starcie systemu";
+
+"Don't Launch" = "Nie startuj";
+
+"Clear History" = "Wyczyść historię";
+
+"Are you sure you want to clear your clipboard history?" = "Jesteś pewny, że chcesz wykasować historię schowka?";
+
+"Cancel" = "Anuluj";
+
+"Edit Snippets" = "Edytuj snippety...";
+
+"Preferences" = "Preferencje...";
+
+"Quit Clipy" = "Zamknij Clipy";
+
+"History" = "Historia";
+
+"Snippet" = "Snippet";
+
+"General" = "Ogólne";
+
+"Menu" = "Menu";
+
+"Type" = "Typ";
+
+"Shortcuts" = "Skróty";
+
+"Updates" = "Aktualizacje";
+
+"Delete Item" = "Usuń element";
+
+"Are you sure want to delete this item?" = "Jesteś pewien, że chcesz usunąć ten element?";
+
+"Add" = "Dodaj";
+
+"Please fill in the contents of the snippet" = "Proszę wypełnij zawartość snippetu";
+
+"Please allow Accessibility" = "Proszę zezwól na ustawienia Dostępności.";
+
+"To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" = "Żeby to zrobić zezwól na Dostępność w ustawieniach Ochrony i prywatności w Preferencjach systemowych.";
+
+"Open System Preferences" = "Otwórz Preferencje systemowe";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYBetaPreferenceViewController.strings
@@ -1,0 +1,57 @@
+
+/* Class = "NSTextFieldCell"; title = "Screenshot"; ObjectID = "0f7-ic-bHq"; */
+"0f7-ic-bHq.title" = "Screenshot";
+
+/* Class = "NSTextFieldCell"; title = "Action"; ObjectID = "6RM-Ow-USQ"; */
+"6RM-Ow-USQ.title" = "Akcja";
+
+/* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
+"HZd-yn-p4o.title" = "Command";
+
+/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
+"M5n-Mr-02l.title" = "Wklej i usuń historię";
+
+/* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
+"M9s-9f-OKA.title" = "Alt";
+
+/* Class = "NSMenuItem"; title = "Shift"; ObjectID = "NFq-oQ-VKz"; */
+"NFq-oQ-VKz.title" = "Shift";
+
+/* Class = "NSMenuItem"; title = "Alt"; ObjectID = "Ncl-nV-zr8"; */
+"Ncl-nV-zr8.title" = "Alt";
+
+/* Class = "NSTextFieldCell"; title = "Beta settings might be moved to a different pane in future versions."; ObjectID = "c4z-RD-3UN"; */
+"c4z-RD-3UN.title" = "Możliwe, że ustawienia beta zostaną przesunięte do innego okna w przyszłej wersji";
+
+/* Class = "NSMenuItem"; title = "Command"; ObjectID = "gRa-Te-dcH"; */
+"gRa-Te-dcH.title" = "Command";
+
+/* Class = "NSMenuItem"; title = "Control"; ObjectID = "kZF-3Q-Tge"; */
+"kZF-3Q-Tge.title" = "Control";
+
+/* Class = "NSMenuItem"; title = "Shift"; ObjectID = "oNH-8M-ZSE"; */
+"oNH-8M-ZSE.title" = "Shift";
+
+/* Class = "NSMenuItem"; title = "Alt"; ObjectID = "orJ-AB-Oxl"; */
+"orJ-AB-Oxl.title" = "Alt";
+
+/* Class = "NSButtonCell"; title = "Save screenshots in history"; ObjectID = "pgE-3j-ZEy"; */
+"pgE-3j-ZEy.title" = "Zapisz screenshot w historii";
+
+/* Class = "NSButtonCell"; title = "Paste as PlainText"; ObjectID = "r0C-kF-Q0z"; */
+"r0C-kF-Q0z.title" = "Wklej jako tekst";
+
+/* Class = "NSMenuItem"; title = "Shift"; ObjectID = "riQ-CH-Kcr"; */
+"riQ-CH-Kcr.title" = "Shift";
+
+/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
+"sYs-Da-TSj.title" = "Wykasuj history";
+
+/* Class = "NSMenuItem"; title = "Control"; ObjectID = "vtQ-7v-nLJ"; */
+"vtQ-7v-nLJ.title" = "Control";
+
+/* Class = "NSMenuItem"; title = "Command"; ObjectID = "yZK-TZ-SNb"; */
+"yZK-TZ-SNb.title" = "Command";
+
+/* Class = "NSMenuItem"; title = "Control"; ObjectID = "z3A-El-En9"; */
+"z3A-El-En9.title" = "Control";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYExcludeAppPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYExcludeAppPreferenceViewController.strings
@@ -1,0 +1,6 @@
+
+/* Class = "NSTextFieldCell"; title = "Exclude these applications:"; ObjectID = "Jko-fZ-aTE"; */
+"Jko-fZ-aTE.title" = "Wyklucz te aplikacje:";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "XXp-Rw-8h6"; */
+"XXp-Rw-8h6.title" = "Tekst";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYGeneralPreferenceViewController.strings
@@ -1,0 +1,39 @@
+
+/* Class = "NSButtonCell"; title = "Input \"⌘ + V\" after menu item selection"; ObjectID = "0yt-u0-ROt"; */
+"0yt-u0-ROt.title" = "Automatyczne \"⌘ + V\" po wybraniu elementu z menu";
+
+/* Class = "NSTextFieldCell"; title = "Appearance"; ObjectID = "FM4-mw-DCx"; */
+"FM4-mw-DCx.title" = "Wygląd";
+
+/* Class = "NSTextFieldCell"; title = "Status Bar icon style:"; ObjectID = "Faj-kQ-G1v"; */
+"Faj-kQ-G1v.title" = "Styl icony w belce menu (menu bar):";
+
+/* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
+"Lps-06-dPB.title" = "Sortuj historię według:";
+
+/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "Wysyłaj raporty o zawieszeniu się programu i logi błędów (działa od następnego włączenia programu)";
+
+/* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
+"Nab-CO-ytH.title" = "Maksymalna wielkość historii schowka:";
+
+/* Class = "NSTextFieldCell"; title = "Clipboard History"; ObjectID = "OOT-F5-Pal"; */
+"OOT-F5-Pal.title" = "Historia schowka";
+
+/* Class = "NSButtonCell"; title = "Launch on Login"; ObjectID = "Su3-mF-z1T"; */
+"Su3-mF-z1T.title" = "Włączanie przy starcie systemu";
+
+/* Class = "NSMenuItem"; title = "Date Created"; ObjectID = "YmS-J6-ERc"; */
+"YmS-J6-ERc.title" = "Data utworzenia";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "aEh-u0-hQR"; */
+"aEh-u0-hQR.title" = "Żaden";
+
+/* Class = "NSTextFieldCell"; title = "items"; ObjectID = "eeq-cw-v00"; */
+"eeq-cw-v00.title" = "elementy";
+
+/* Class = "NSMenuItem"; title = "Last Used"; ObjectID = "ju3-6a-6xj"; */
+"ju3-6a-6xj.title" = "Ustatnio użyte";
+
+/* Class = "NSTextFieldCell"; title = "Behavior"; ObjectID = "nDk-8y-89n"; */
+"nDk-8y-89n.title" = "Zachowanie";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYMenuPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYMenuPreferenceViewController.strings
@@ -1,0 +1,69 @@
+
+/* Class = "NSTextFieldCell"; title = "pixel"; ObjectID = "2Ra-jY-ADW"; */
+"2Ra-jY-ADW.title" = "piksel";
+
+/* Class = "NSTextFieldCell"; title = "items"; ObjectID = "4dH-7h-Ssv"; */
+"4dH-7h-Ssv.title" = "element";
+
+/* Class = "NSTextFieldCell"; title = "chars"; ObjectID = "67F-2m-Txz"; */
+"67F-2m-Txz.title" = "znaki";
+
+/* Class = "NSTextFieldCell"; title = "pixel"; ObjectID = "90g-HQ-9Ua"; */
+"90g-HQ-9Ua.title" = "piksel";
+
+/* Class = "NSButtonCell"; title = "Show Image"; ObjectID = "Drj-kg-Km5"; */
+"Drj-kg-Km5.title" = "Pokaż obraz";
+
+/* Class = "NSTextFieldCell"; title = "Number of items place inside a folder:"; ObjectID = "FP7-VI-YVJ"; */
+"FP7-VI-YVJ.title" = "Ilość elementów w każdym folderze:";
+
+/* Class = "NSTextFieldCell"; title = "items"; ObjectID = "Ovp-if-Azp"; */
+"Ovp-if-Azp.title" = "elementy";
+
+/* Class = "NSTextFieldCell"; title = "Max length of tool tip string:"; ObjectID = "QFO-xC-Z3p"; */
+"QFO-xC-Z3p.title" = "Maksymalna długość tekstu w wyświetlonym oknie pomocy:";
+
+/* Class = "NSButtonCell"; title = "Show alert panel before clear history"; ObjectID = "U2I-bu-kTR"; */
+"U2I-bu-kTR.title" = "Pokaż ostrzeżenie przed wyczyszczeniem historii";
+
+/* Class = "NSTextFieldCell"; title = "Height:"; ObjectID = "WKb-6V-Q9w"; */
+"WKb-6V-Q9w.title" = "Wysokość:";
+
+/* Class = "NSButtonCell"; title = "Place already copied history at the top"; ObjectID = "a32-zW-R74"; */
+"a32-zW-R74.title" = "Umieść skopiowany element z historii na samej górze";
+
+/* Class = "NSButtonCell"; title = "Show tool tip on a menu item"; ObjectID = "h4n-Nv-zj1"; */
+"h4n-Nv-zj1.title" = "Pokaż okno pomocy przy elementach menu";
+
+/* Class = "NSTextFieldCell"; title = "Number of characters in the menu:"; ObjectID = "hBb-sd-DcP"; */
+"hBb-sd-DcP.title" = "Ilość znaków w elementach menu:";
+
+/* Class = "NSButtonCell"; title = "Add key equivalents to numeric keys"; ObjectID = "hE2-DL-MKl"; */
+"hE2-DL-MKl.title" = "Dodaj skróty numeryczne";
+
+/* Class = "NSButtonCell"; title = "Show color code preview"; ObjectID = "hgW-RK-5oy"; */
+"hgW-RK-5oy.title" = "Pokaż kolorowy podgląd kodu";
+
+/* Class = "NSButtonCell"; title = "Move instead of copying (removes the older one from the list)"; ObjectID = "lsx-Y0-zFR"; */
+"lsx-Y0-zFR.title" = "Przenieś zamiast kopiuj (usuwa starszy element z listy)";
+
+/* Class = "NSButtonCell"; title = "Mark menu items with numbers"; ObjectID = "nMF-6D-hXu"; */
+"nMF-6D-hXu.title" = "Oznacz elementy menu numerami";
+
+/* Class = "NSTextFieldCell"; title = "chars"; ObjectID = "nzx-q5-ifH"; */
+"nzx-q5-ifH.title" = "znaki";
+
+/* Class = "NSButtonCell"; title = "Add a menu item to clear clipboard history"; ObjectID = "p80-3o-bgA"; */
+"p80-3o-bgA.title" = "Dodaj element menu do wyczyszczenia historii schowka";
+
+/* Class = "NSTextFieldCell"; title = "Width:"; ObjectID = "saf-vP-Qwl"; */
+"saf-vP-Qwl.title" = "Szerokość:";
+
+/* Class = "NSButtonCell"; title = "Menu items' title starts with 0"; ObjectID = "seq-HO-d27"; */
+"seq-HO-d27.title" = "Numerowanie elementów menu od 0";
+
+/* Class = "NSTextFieldCell"; title = "Number of items place inline:"; ObjectID = "wef-NB-6p6"; */
+"wef-NB-6p6.title" = "Ilość elementów przed folderami:";
+
+/* Class = "NSButtonCell"; title = "Display icons in menu items"; ObjectID = "yrU-qO-OwD"; */
+"yrU-qO-OwD.title" = "Wyświetl ikony w menu";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYShortcutsPreferenceViewController.strings
@@ -1,0 +1,18 @@
+
+/* Class = "NSTextFieldCell"; title = "Main:"; ObjectID = "5sL-G8-1io"; */
+"5sL-G8-1io.title" = "Menu główne:";
+
+/* Class = "NSTextFieldCell"; title = "History:"; ObjectID = "Abl-cO-JwU"; */
+"Abl-cO-JwU.title" = "Historia:";
+
+/* Class = "NSTextFieldCell"; title = "History"; ObjectID = "Txl-Qh-RzP"; */
+"Txl-Qh-RzP.title" = "Historia";
+
+/* Class = "NSTextFieldCell"; title = "Menu"; ObjectID = "X5L-5V-1eH"; */
+"X5L-5V-1eH.title" = "Menu";
+
+/* Class = "NSTextFieldCell"; title = "Clear History:"; ObjectID = "f3b-Ht-X5w"; */
+"f3b-Ht-X5w.title" = "Wyczyść historię:";
+
+/* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
+"fXr-ry-5ds.title" = "Snippety:";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYTypePreferenceViewController.strings
@@ -1,0 +1,24 @@
+
+/* Class = "NSButtonCell"; title = "PDF"; ObjectID = "27s-8p-tdh"; */
+"27s-8p-tdh.title" = "PDF";
+
+/* Class = "NSButtonCell"; title = "Plain Text"; ObjectID = "9wr-mR-kmC"; */
+"9wr-mR-kmC.title" = "Plik tekstowy";
+
+/* Class = "NSButtonCell"; title = "Rich Text Format Directory (RTFD)"; ObjectID = "Nvy-pc-6hl"; */
+"Nvy-pc-6hl.title" = "Rich Text Format Directory (RTFD)";
+
+/* Class = "NSButtonCell"; title = "Filenames"; ObjectID = "iO6-7x-OcH"; */
+"iO6-7x-OcH.title" = "Nazwy plików";
+
+/* Class = "NSBox"; title = "Select clipboard types to store:"; ObjectID = "lSu-gq-grM"; */
+"lSu-gq-grM.title" = "Wybierz typy elementów schowka:";
+
+/* Class = "NSButtonCell"; title = "TIFF Image"; ObjectID = "lZ0-qQ-qWk"; */
+"lZ0-qQ-qWk.title" = "Obraz TIFF";
+
+/* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
+"oXv-rM-kj5.title" = "URL";
+
+/* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
+"xyj-FL-88b.title" = "Rich Text Format (RTF)";

--- a/Clipy/Sources/Preferences/Panels/pl.lproj/CPYUpdatesPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pl.lproj/CPYUpdatesPreferenceViewController.strings
@@ -1,0 +1,21 @@
+
+/* Class = "NSButtonCell"; title = "Check Now"; ObjectID = "DDI-ts-HPE"; */
+"DDI-ts-HPE.title" = "Sprawdź teraz";
+
+/* Class = "NSMenuItem"; title = "Daily"; ObjectID = "HwP-AM-nID"; */
+"HwP-AM-nID.title" = "Codziennie";
+
+/* Class = "NSButtonCell"; title = "Automatically check for updates:"; ObjectID = "Kdw-AL-Nnj"; */
+"Kdw-AL-Nnj.title" = "Sprawdź automatycznie dostępność aktualizacji:";
+
+/* Class = "NSMenuItem"; title = "Weekly"; ObjectID = "NBD-wq-yMq"; */
+"NBD-wq-yMq.title" = "Co tydzień";
+
+/* Class = "NSTextFieldCell"; title = "v1.0.0"; ObjectID = "hhl-AS-dQ0"; */
+"hhl-AS-dQ0.title" = "v1.0.0";
+
+/* Class = "NSTextFieldCell"; title = "date"; ObjectID = "nG5-PB-zcE"; */
+"nG5-PB-zcE.title" = "data";
+
+/* Class = "NSMenuItem"; title = "Monthly"; ObjectID = "o5Q-Ao-iQN"; */
+"o5Q-Ao-iQN.title" = "Co miesiąc";

--- a/Clipy/Sources/Preferences/pl.lproj/CPYPreferencesWindowController.strings
+++ b/Clipy/Sources/Preferences/pl.lproj/CPYPreferencesWindowController.strings
@@ -1,0 +1,27 @@
+
+/* Class = "NSWindow"; title = "Clipy - Setting"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Clipy - Ustawienia";
+
+/* Class = "NSTextFieldCell"; title = "Beta"; ObjectID = "Fxs-BH-hPx"; */
+"Fxs-BH-hPx.title" = "Beta";
+
+/* Class = "NSTextFieldCell"; title = "Updates"; ObjectID = "N5e-ba-0Q0"; */
+"N5e-ba-0Q0.title" = "Aktualizacje";
+
+/* Class = "NSTextFieldCell"; title = "No Pane is Selected."; ObjectID = "Vy6-Ui-lLf"; */
+"Vy6-Ui-lLf.title" = "Żadne okno nie zostało wybrane.";
+
+/* Class = "NSTextFieldCell"; title = "Type"; ObjectID = "avh-w8-RcC"; */
+"avh-w8-RcC.title" = "Typ";
+
+/* Class = "NSTextFieldCell"; title = "Exclude"; ObjectID = "odU-xs-hZL"; */
+"odU-xs-hZL.title" = "Wyklucz";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "qS1-uo-9im"; */
+"qS1-uo-9im.title" = "Ogólne";
+
+/* Class = "NSTextFieldCell"; title = "Shortcuts"; ObjectID = "qx8-Vm-eow"; */
+"qx8-Vm-eow.title" = "Skróty";
+
+/* Class = "NSTextFieldCell"; title = "Menu"; ObjectID = "vEM-JU-92T"; */
+"vEM-JU-92T.title" = "Menu";

--- a/Clipy/Sources/Snippets/pl.lproj/CPYSnippetsEditorWindowController.strings
+++ b/Clipy/Sources/Snippets/pl.lproj/CPYSnippetsEditorWindowController.strings
@@ -1,0 +1,36 @@
+
+/* Class = "NSTextFieldCell"; title = "Import"; ObjectID = "Ett-SG-3wO"; */
+"Ett-SG-3wO.title" = "Importuj";
+
+/* Class = "NSTextFieldCell"; title = "Text"; ObjectID = "J4q-sY-gcS"; */
+"J4q-sY-gcS.title" = "Tekst";
+
+/* Class = "NSTextFieldCell"; title = "Delete"; ObjectID = "Lxb-5c-zOc"; */
+"Lxb-5c-zOc.title" = "Usuń";
+
+/* Class = "NSWindow"; title = "Clipy - Snippets Editor"; ObjectID = "QvC-M9-y7g"; */
+"QvC-M9-y7g.title" = "Clipy - Edytor snippetów";
+
+/* Class = "NSTextFieldCell"; title = "Export"; ObjectID = "Uqj-Zh-vde"; */
+"Uqj-Zh-vde.title" = "Eksportuj";
+
+/* Class = "NSTextFieldCell"; title = "Enable/Disable"; ObjectID = "WZs-f9-lGW"; */
+"WZs-f9-lGW.title" = "Włącz/Wyłącz";
+
+/* Class = "NSTextFieldCell"; title = "Add Folder"; ObjectID = "hoO-RC-sTG"; */
+"hoO-RC-sTG.title" = "Dodaj folder";
+
+/* Class = "NSTextFieldCell"; title = "Shortcut"; ObjectID = "pfw-sA-4aA"; */
+"pfw-sA-4aA.title" = "Skrót";
+
+/* Class = "NSTextFieldCell"; title = "folder title"; ObjectID = "rI9-rT-YTs"; */
+"rI9-rT-YTs.title" = "nazwa folderu";
+
+/* Class = "NSTextFieldCell"; title = "Share snippets"; ObjectID = "wwo-lh-lMK"; */
+"wwo-lh-lMK.title" = "Udostępnij snippety";
+
+/* Class = "NSTextFieldCell"; title = "Add Snippet"; ObjectID = "xPC-Uv-z03"; */
+"xPC-Uv-z03.title" = "Dodaj snippet";
+
+/* Class = "NSTextFieldCell"; title = "Coming Soon"; ObjectID = "yzF-k8-xUT"; */
+"yzF-k8-xUT.title" = "Już wkrótce";


### PR DESCRIPTION
Added Polish language.

There are some differences in project.pbxproj, which I don't understand, like (lines 71 and 72 https://github.com/Clipy/Clipy/pull/323/commits/ea9ed05932bbc5ea7a318e640e0ba241dfe0b495#diff-0556d61b816fdb7b583fc02e76b28931L71):
FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };

I would need confirmation that this is fine.

Apart from that I could not verify the changes in the running program as I am sitting already on Mac OS Mojave with Xcode 10.1 where Clipy does not build. But I made the translation based on English and German, so it should be of good quality.

The error during build is:

	PhaseScriptExecution [CP]\ Embed\ Pods\ Frameworks /Users/Jedrzej/Library/Developer/Xcode/DerivedData/Clipy-gavyfmprnrhelzcgtqylwajzjyir/Build/Intermediates.noindex/Clipy.build/Debug/Clipy.build/Script-07B47785AE0AC2185B570C28.sh (in target: Clipy)
	    cd /Users/Jedrzej/GitHub/Clipy
	    /bin/sh -c /Users/Jedrzej/Library/Developer/Xcode/DerivedData/Clipy-gavyfmprnrhelzcgtqylwajzjyir/Build/Intermediates.noindex/Clipy.build/Debug/Clipy.build/Script-07B47785AE0AC2185B570C28.sh

	mkdir -p /Users/Jedrzej/Library/Developer/Xcode/DerivedData/Clipy-gavyfmprnrhelzcgtqylwajzjyir/Build/Products/Debug/Clipy.app/Contents/Frameworks
	rsync --delete -av --filter P .*.?????? --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "/Users/Jedrzej/Library/Developer/Xcode/DerivedData/Clipy-gavyfmprnrhelzcgtqylwajzjyir/Build/Products/Debug/AEXML/AEXML.framework" "/Users/Jedrzej/Library/Developer/Xcode/DerivedData/Clipy-gavyfmprnrhelzcgtqylwajzjyir/Build/Products/Debug/Clipy.app/Contents/Frameworks"
	building file list ... done
	AEXML.framework/
	AEXML.framework/AEXML -> Versions/Current/AEXML
	AEXML.framework/Resources -> Versions/Current/Resources
	AEXML.framework/Versions/
	AEXML.framework/Versions/Current -> A
	AEXML.framework/Versions/A/
	AEXML.framework/Versions/A/AEXML
	AEXML.framework/Versions/A/Resources/
	AEXML.framework/Versions/A/Resources/Info.plist

	sent 212100 bytes  received 106 bytes  424412.00 bytes/sec
	total size is 211658  speedup is 1.00
	/Users/Jedrzej/GitHub/Clipy/Pods/Target Support Files/Pods-Clipy/Pods-Clipy-frameworks.sh: line 104: EXPANDED_CODE_SIGN_IDENTITY: unbound variable
	Command PhaseScriptExecution failed with a nonzero exit code
