### PR TITLE
Make Clipy work on Big Sur

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -792,7 +792,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftGen/bin/swiftgen\"";
+			shellScript = "\"${PODS_ROOT}/SwiftGen/bin/swiftgen\"\n";
 		};
 		FAAA88991E686CED0088FB34 /* BartyCrouch */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -820,7 +820,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -67,8 +67,8 @@
 		FA6167921D3ABEB10049FA14 /* FolderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderSpec.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */; };
-		FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */; };
 		FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
@@ -647,7 +647,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
-				FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB51E1DDCB4C0007F95C8 /* CPYTypePreferenceViewController.xib in Resources */,
 				FA1DB4901DDCA5D9007F95C8 /* Images.xcassets in Resources */,
 				FA1DB51D1DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.xib in Resources */,
@@ -656,7 +656,7 @@
 				FA1DB51B1DDCB4C0007F95C8 /* CPYGeneralPreferenceViewController.xib in Resources */,
 				FA1DB51A1DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.xib in Resources */,
 				FA1DB5191DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.xib in Resources */,
-				FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5151C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB4941DDCB22C007F95C8 /* dsa_pub.pem in Resources */,
 				FA1DB4981DDCB2CB007F95C8 /* Localizable.strings in Resources */,
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
@@ -806,7 +806,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/BartyCrouch/bartycrouch\" interfaces -p \"$PROJECT_DIR\"";
+			shellScript = "\"${PODS_ROOT}/BartyCrouch/bartycrouch\" interfaces -p \"$PROJECT_DIR\"\n";
 		};
 		FAAD02201CA98E20007C6EEE /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Clipy/Generated/AssetsImages.swift
+++ b/Clipy/Generated/AssetsImages.swift
@@ -65,6 +65,7 @@ internal struct ImageAsset {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -76,13 +77,25 @@ internal struct ImageAsset {
     let image = Image(named: name)
     #endif
     guard let result = image else {
-      fatalError("Unable to load image named \(name).")
+      fatalError("Unable to load image asset named \(name).")
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
   convenience init!(asset: ImageAsset) {

--- a/Clipy/Generated/Colors.swift
+++ b/Clipy/Generated/Colors.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSColor
   internal typealias Color = NSColor
 #elseif os(iOS) || os(tvOS) || os(watchOS)
@@ -52,9 +52,7 @@ private struct RGBAComponents {
   }
 
   private var components: [CGFloat] {
-    shifts.map {
-      CGFloat($0 & 0xff)
-    }
+    shifts.map { CGFloat($0 & 0xff) }
   }
 
   var normalized: [CGFloat] {

--- a/Clipy/Generated/LocalizedStrings.swift
+++ b/Clipy/Generated/LocalizedStrings.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -11,53 +11,53 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// Add
-  internal static let add = L10n.tr("Localizable", "Add")
+  internal static let add = L10n.tr("Localizable", "Add", fallback: "Add")
   /// Are you sure want to delete this item?
-  internal static let areYouSureWantToDeleteThisItem = L10n.tr("Localizable", "Are you sure want to delete this item?")
+  internal static let areYouSureWantToDeleteThisItem = L10n.tr("Localizable", "Are you sure want to delete this item?", fallback: "Are you sure want to delete this item?")
   /// Are you sure you want to clear your clipboard history?
-  internal static let areYouSureYouWantToClearYourClipboardHistory = L10n.tr("Localizable", "Are you sure you want to clear your clipboard history?")
+  internal static let areYouSureYouWantToClearYourClipboardHistory = L10n.tr("Localizable", "Are you sure you want to clear your clipboard history?", fallback: "Are you sure you want to clear your clipboard history?")
   /// Cancel
-  internal static let cancel = L10n.tr("Localizable", "Cancel")
+  internal static let cancel = L10n.tr("Localizable", "Cancel", fallback: "Cancel")
   /// Clear History
-  internal static let clearHistory = L10n.tr("Localizable", "Clear History")
+  internal static let clearHistory = L10n.tr("Localizable", "Clear History", fallback: "Clear History")
   /// Delete Item
-  internal static let deleteItem = L10n.tr("Localizable", "Delete Item")
+  internal static let deleteItem = L10n.tr("Localizable", "Delete Item", fallback: "Delete Item")
   /// Don't Launch
-  internal static let donTLaunch = L10n.tr("Localizable", "Don't Launch")
+  internal static let donTLaunch = L10n.tr("Localizable", "Don't Launch", fallback: "Don't Launch")
   /// Edit Snippets...
-  internal static let editSnippets = L10n.tr("Localizable", "Edit Snippets")
+  internal static let editSnippets = L10n.tr("Localizable", "Edit Snippets", fallback: "Edit Snippets...")
   /// General
-  internal static let general = L10n.tr("Localizable", "General")
+  internal static let general = L10n.tr("Localizable", "General", fallback: "General")
   /// History
-  internal static let history = L10n.tr("Localizable", "History")
+  internal static let history = L10n.tr("Localizable", "History", fallback: "History")
   /// Launch Clipy on system startup?
-  internal static let launchClipyOnSystemStartup = L10n.tr("Localizable", "Launch Clipy on system startup?")
+  internal static let launchClipyOnSystemStartup = L10n.tr("Localizable", "Launch Clipy on system startup?", fallback: "Launch Clipy on system startup?")
   /// Launch on system startup
-  internal static let launchOnSystemStartup = L10n.tr("Localizable", "Launch on system startup")
+  internal static let launchOnSystemStartup = L10n.tr("Localizable", "Launch on system startup", fallback: "Launch on system startup")
   /// Menu
-  internal static let menu = L10n.tr("Localizable", "Menu")
+  internal static let menu = L10n.tr("Localizable", "Menu", fallback: "Menu")
   /// Open System Preferences
-  internal static let openSystemPreferences = L10n.tr("Localizable", "Open System Preferences")
+  internal static let openSystemPreferences = L10n.tr("Localizable", "Open System Preferences", fallback: "Open System Preferences")
   /// Please allow Accessibility.
-  internal static let pleaseAllowAccessibility = L10n.tr("Localizable", "Please allow Accessibility")
+  internal static let pleaseAllowAccessibility = L10n.tr("Localizable", "Please allow Accessibility", fallback: "Please allow Accessibility.")
   /// Please fill in the contents of the snippet
-  internal static let pleaseFillInTheContentsOfTheSnippet = L10n.tr("Localizable", "Please fill in the contents of the snippet")
+  internal static let pleaseFillInTheContentsOfTheSnippet = L10n.tr("Localizable", "Please fill in the contents of the snippet", fallback: "Please fill in the contents of the snippet")
   /// Preferences...
-  internal static let preferences = L10n.tr("Localizable", "Preferences")
+  internal static let preferences = L10n.tr("Localizable", "Preferences", fallback: "Preferences...")
   /// Quit Clipy
-  internal static let quitClipy = L10n.tr("Localizable", "Quit Clipy")
+  internal static let quitClipy = L10n.tr("Localizable", "Quit Clipy", fallback: "Quit Clipy")
   /// Shortcuts
-  internal static let shortcuts = L10n.tr("Localizable", "Shortcuts")
+  internal static let shortcuts = L10n.tr("Localizable", "Shortcuts", fallback: "Shortcuts")
   /// Snippet
-  internal static let snippet = L10n.tr("Localizable", "Snippet")
+  internal static let snippet = L10n.tr("Localizable", "Snippet", fallback: "Snippet")
   /// To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.
-  internal static let toDoThisActionPleaseAllowAccessibilityInSecurityPrivacyPreferencesLocatedInSystemPreferences = L10n.tr("Localizable", "To do this action please allow Accessibility in Security Privacy preferences located in System Preferences")
+  internal static let toDoThisActionPleaseAllowAccessibilityInSecurityPrivacyPreferencesLocatedInSystemPreferences = L10n.tr("Localizable", "To do this action please allow Accessibility in Security Privacy preferences located in System Preferences", fallback: "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences.")
   /// Type
-  internal static let type = L10n.tr("Localizable", "Type")
+  internal static let type = L10n.tr("Localizable", "Type", fallback: "Type")
   /// Updates
-  internal static let updates = L10n.tr("Localizable", "Updates")
+  internal static let updates = L10n.tr("Localizable", "Updates", fallback: "Updates")
   /// You can change this setting in the Preferences if you want.
-  internal static let youCanChangeThisSettingInThePreferencesIfYouWant = L10n.tr("Localizable", "You can change this setting in the Preferences if you want")
+  internal static let youCanChangeThisSettingInThePreferencesIfYouWant = L10n.tr("Localizable", "You can change this setting in the Preferences if you want", fallback: "You can change this setting in the Preferences if you want.")
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
@@ -65,8 +65,8 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -153,9 +153,13 @@ class AppDelegate: NSObject, NSMenuItemValidation {
 
     private func toggleAddingToLoginItems(_ isEnable: Bool) {
         let appPath = Bundle.main.bundlePath
-        LoginServiceKit.removeLoginItems(at: appPath)
-        guard isEnable else { return }
-        LoginServiceKit.addLoginItems(at: appPath)
+
+        if isEnable {
+            // adds if not exists
+            LoginServiceKit.addLoginItems(at: appPath)
+        } else {
+            LoginServiceKit.removeLoginItems(at: appPath)
+        }
     }
 
     private func reflectLoginItemState() {

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -147,7 +147,7 @@ extension PasteService {
             return
         }
 
-        let vKeyCode = Sauce.shared.keyCode(by: .v)
+        let vKeyCode = Sauce.shared.keyCode(for: .v)
         DispatchQueue.main.async {
             let source = CGEventSource(stateID: .combinedSessionState)
             // Disable local keyboard events while pasting

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ target 'Clipy' do
   pod 'RxCocoa'
   pod 'RxSwift'
   pod 'LoginServiceKit', :git => 'https://github.com/Clipy/LoginServiceKit.git'
-  pod 'KeyHolder'
+  pod 'KeyHolder', :git => 'https://github.com/Clipy/KeyHolder.git'
   pod 'Magnet'
   pod 'RxScreeen'
   pod 'AEXML'

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ target 'Clipy' do
   pod 'LetsMove'
   pod 'SwiftHEXColors'
   # Utility
-  pod 'BartyCrouch'
+  pod 'BartyCrouch', '3.13.0'
   pod 'SwiftLint'
   pod 'SwiftGen'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - AEXML (4.6.0)
+  - AEXML (4.6.1)
   - BartyCrouch (3.13.0)
-  - KeyHolder (4.0.0):
+  - KeyHolder (4.1.0):
     - Magnet (~> 3.3.0)
   - LetsMove (1.25)
-  - LoginServiceKit (2.2.0)
+  - LoginServiceKit (2.4.0)
   - Magnet (3.3.0):
     - Sauce (~> 2.2.0)
-  - Nimble (9.2.0)
+  - Nimble (10.0.0)
   - PINCache (3.0.3):
     - PINCache/Arc-exception-safe (= 3.0.3)
     - PINCache/Core (= 3.0.3)
@@ -15,29 +15,29 @@ PODS:
     - PINCache/Core
   - PINCache/Core (3.0.3):
     - PINOperation (~> 1.2.1)
-  - PINOperation (1.2.1)
-  - Quick (4.0.0)
-  - Realm (10.7.6):
-    - Realm/Headers (= 10.7.6)
-  - Realm/Headers (10.7.6)
-  - RealmSwift (10.7.6):
-    - Realm (= 10.7.6)
-  - RxCocoa (5.1.1):
-    - RxRelay (~> 5)
-    - RxSwift (~> 5)
-  - RxRelay (5.1.1):
-    - RxSwift (~> 5)
-  - RxScreeen (2.0.0):
-    - RxCocoa (~> 5.0)
-    - RxSwift (~> 5.0)
+  - PINOperation (1.2.2)
+  - Quick (5.0.1)
+  - Realm (10.34.1):
+    - Realm/Headers (= 10.34.1)
+  - Realm/Headers (10.34.1)
+  - RealmSwift (10.34.1):
+    - Realm (= 10.34.1)
+  - RxCocoa (6.5.0):
+    - RxRelay (= 6.5.0)
+    - RxSwift (= 6.5.0)
+  - RxRelay (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxScreeen (2.1.0):
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
     - Screeen (~> 2.0.1)
-  - RxSwift (5.1.2)
+  - RxSwift (6.5.0)
   - Sauce (2.2.0)
   - Screeen (2.0.1)
-  - Sparkle (1.26.0)
-  - SwiftGen (6.4.0)
+  - Sparkle (1.27.1)
+  - SwiftGen (6.6.2)
   - SwiftHEXColors (1.4.1)
-  - SwiftLint (0.43.1)
+  - SwiftLint (0.50.3)
 
 DEPENDENCIES:
   - AEXML
@@ -90,36 +90,36 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KeyHolder:
-    :commit: 7bc6ed8589e4e7e4075c52ed77c13ae9932031f9
+    :commit: 66cd7ef7b94a276493ba831992a8c212760d8ab4
     :git: https://github.com/Clipy/KeyHolder.git
   LoginServiceKit:
-    :commit: 51da47408cdffcd3c82c3ad1f3d2e58b13583ea1
+    :commit: a8e68051aca8bbb702e62ab36006a301966ab053
     :git: https://github.com/Clipy/LoginServiceKit.git
 
 SPEC CHECKSUMS:
-  AEXML: 2fbb73d8724797ed2cde888731e176fa4d44dd83
+  AEXML: 1e255ecc6597212f97a7454a69ebd3ede64ac1cf
   BartyCrouch: 69e5e6ec67e77951dc1c22aa48abbf05d175b81c
-  KeyHolder: 5e346f4134dbb3a9ac50e95f1eb1d443831ad7b6
+  KeyHolder: 7fce073043392cddc3e3126f3f9bdaa5ecf1f19e
   LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
-  LoginServiceKit: 3c86ce2f2bcd1e373326839d6d863d8a6a5915b4
+  LoginServiceKit: f1fcedb23076c3a0384f0c7c06978bc49459a1be
   Magnet: a44a5a14eecc77433cbaad1431b78f7d20725bf2
-  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
+  Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
-  PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
-  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
-  RealmSwift: e31c4ddbcc42ac879313d656b86f9ca539f6f4f4
-  RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
-  RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
-  RxScreeen: e0806b8a4b747cde7100be4e09b6e133a6017cfd
-  RxSwift: 1e2e1f9570186967f617e49128ed26ccf1bafc8e
+  PINOperation: daa34d4aa1d8449089be7d405b9d974abc4724c6
+  Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
+  Realm: fe824cd5b183cd55a50a6bcb4bce3ac1650e60b6
+  RealmSwift: c7f668f82982fc8b62366b78b8dc761f15141df6
+  RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
+  RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
+  RxScreeen: 18efe5daecca6db6e7e18400c436fb4d252a2f7b
+  RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
   Sauce: 3ade51738563f86b08888cf4b91ae5943012088b
   Screeen: e5c570d3df139b8d5d0e1ffd41094204787d9f1a
-  Sparkle: d56d028f4b0c123577825f5d1004f6140d77f90e
-  SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
+  Sparkle: 23f98b268284c8c03e6228230fc8f1807ef041d5
+  SwiftGen: 1366a7f71aeef49954ca5a63ba4bef6b0f24138c
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
-  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
+  SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
 
 PODFILE CHECKSUM: 8dfaab3970e3a80eec87ed28401e067a7c996722
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - AEXML (4.6.0)
-  - BartyCrouch (3.13.0)
+  - BartyCrouch (4.6.0)
   - KeyHolder (4.0.0):
     - Magnet (~> 3.2)
   - LetsMove (1.25)
   - LoginServiceKit (2.2.0)
-  - Magnet (3.2.0):
-    - Sauce (~> 2.1)
-  - Nimble (9.0.0)
+  - Magnet (3.3.0):
+    - Sauce (~> 2.2.0)
+  - Nimble (9.2.0)
   - PINCache (3.0.3):
     - PINCache/Arc-exception-safe (= 3.0.3)
     - PINCache/Core (= 3.0.3)
@@ -16,12 +16,12 @@ PODS:
   - PINCache/Core (3.0.3):
     - PINOperation (~> 1.2.1)
   - PINOperation (1.2.1)
-  - Quick (3.0.0)
-  - Realm (10.7.2):
-    - Realm/Headers (= 10.7.2)
-  - Realm/Headers (10.7.2)
-  - RealmSwift (10.7.2):
-    - Realm (= 10.7.2)
+  - Quick (4.0.0)
+  - Realm (10.7.6):
+    - Realm/Headers (= 10.7.6)
+  - Realm/Headers (10.7.6)
+  - RealmSwift (10.7.6):
+    - Realm (= 10.7.6)
   - RxCocoa (5.1.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
@@ -31,13 +31,13 @@ PODS:
     - RxCocoa (~> 5.0)
     - RxSwift (~> 5.0)
     - Screeen (~> 2.0.1)
-  - RxSwift (5.1.1)
-  - Sauce (2.1.0)
+  - RxSwift (5.1.2)
+  - Sauce (2.2.0)
   - Screeen (2.0.1)
   - Sparkle (1.26.0)
   - SwiftGen (6.4.0)
   - SwiftHEXColors (1.4.1)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - AEXML
@@ -89,33 +89,33 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   LoginServiceKit:
-    :commit: cf58b91b0ac247bd8bf5dccb5434ca60a930c1e1
+    :commit: 51da47408cdffcd3c82c3ad1f3d2e58b13583ea1
     :git: https://github.com/Clipy/LoginServiceKit.git
 
 SPEC CHECKSUMS:
   AEXML: 2fbb73d8724797ed2cde888731e176fa4d44dd83
-  BartyCrouch: 69e5e6ec67e77951dc1c22aa48abbf05d175b81c
+  BartyCrouch: c045303db193de949afc48fc2b661bf2deba0393
   KeyHolder: 457d8dde330a17452672756ae0e3b9c2e180a7e2
   LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
   LoginServiceKit: 3c86ce2f2bcd1e373326839d6d863d8a6a5915b4
-  Magnet: 8316a30fe91fdc6f2816ec0f04e20c72e341ca2e
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
+  Magnet: a44a5a14eecc77433cbaad1431b78f7d20725bf2
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
   PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
-  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
-  Realm: e523da9ade306c5ae87e85dc09fdef148d3e1cc1
-  RealmSwift: 4f6758c3adbdcc87f7b7777107226532a077f61c
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
+  Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
+  RealmSwift: e31c4ddbcc42ac879313d656b86f9ca539f6f4f4
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxScreeen: e0806b8a4b747cde7100be4e09b6e133a6017cfd
-  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
-  Sauce: a4075a04b6041e7a0c992a952cc79f7a0ebdb8e3
+  RxSwift: 1e2e1f9570186967f617e49128ed26ccf1bafc8e
+  Sauce: 3ade51738563f86b08888cf4b91ae5943012088b
   Screeen: e5c570d3df139b8d5d0e1ffd41094204787d9f1a
   Sparkle: d56d028f4b0c123577825f5d1004f6140d77f90e
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: 57ecd94a3cf36d020cb8926562e41104c4fea206
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - AEXML (4.6.0)
-  - BartyCrouch (4.6.0)
+  - BartyCrouch (3.13.0)
   - KeyHolder (4.0.0):
     - Magnet (~> 3.3.0)
   - LetsMove (1.25)
@@ -41,7 +41,7 @@ PODS:
 
 DEPENDENCIES:
   - AEXML
-  - BartyCrouch
+  - BartyCrouch (= 3.13.0)
   - KeyHolder (from `https://github.com/Clipy/KeyHolder.git`)
   - LetsMove
   - LoginServiceKit (from `https://github.com/Clipy/LoginServiceKit.git`)
@@ -98,7 +98,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AEXML: 2fbb73d8724797ed2cde888731e176fa4d44dd83
-  BartyCrouch: c045303db193de949afc48fc2b661bf2deba0393
+  BartyCrouch: 69e5e6ec67e77951dc1c22aa48abbf05d175b81c
   KeyHolder: 5e346f4134dbb3a9ac50e95f1eb1d443831ad7b6
   LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
   LoginServiceKit: 3c86ce2f2bcd1e373326839d6d863d8a6a5915b4
@@ -120,6 +120,6 @@ SPEC CHECKSUMS:
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 663ed0a3f45c817c2bd2d64b761aaf51c358d225
+PODFILE CHECKSUM: 8dfaab3970e3a80eec87ed28401e067a7c996722
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - AEXML (4.6.0)
   - BartyCrouch (4.6.0)
   - KeyHolder (4.0.0):
-    - Magnet (~> 3.2)
+    - Magnet (~> 3.3.0)
   - LetsMove (1.25)
   - LoginServiceKit (2.2.0)
   - Magnet (3.3.0):
@@ -42,7 +42,7 @@ PODS:
 DEPENDENCIES:
   - AEXML
   - BartyCrouch
-  - KeyHolder
+  - KeyHolder (from `https://github.com/Clipy/KeyHolder.git`)
   - LetsMove
   - LoginServiceKit (from `https://github.com/Clipy/LoginServiceKit.git`)
   - Magnet
@@ -63,7 +63,6 @@ SPEC REPOS:
   trunk:
     - AEXML
     - BartyCrouch
-    - KeyHolder
     - LetsMove
     - Magnet
     - Nimble
@@ -84,10 +83,15 @@ SPEC REPOS:
     - SwiftLint
 
 EXTERNAL SOURCES:
+  KeyHolder:
+    :git: https://github.com/Clipy/KeyHolder.git
   LoginServiceKit:
     :git: https://github.com/Clipy/LoginServiceKit.git
 
 CHECKOUT OPTIONS:
+  KeyHolder:
+    :commit: 7bc6ed8589e4e7e4075c52ed77c13ae9932031f9
+    :git: https://github.com/Clipy/KeyHolder.git
   LoginServiceKit:
     :commit: 51da47408cdffcd3c82c3ad1f3d2e58b13583ea1
     :git: https://github.com/Clipy/LoginServiceKit.git
@@ -95,7 +99,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AEXML: 2fbb73d8724797ed2cde888731e176fa4d44dd83
   BartyCrouch: c045303db193de949afc48fc2b661bf2deba0393
-  KeyHolder: 457d8dde330a17452672756ae0e3b9c2e180a7e2
+  KeyHolder: 5e346f4134dbb3a9ac50e95f1eb1d443831ad7b6
   LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
   LoginServiceKit: 3c86ce2f2bcd1e373326839d6d863d8a6a5915b4
   Magnet: a44a5a14eecc77433cbaad1431b78f7d20725bf2
@@ -116,6 +120,6 @@ SPEC CHECKSUMS:
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 57ecd94a3cf36d020cb8926562e41104c4fea206
+PODFILE CHECKSUM: 663ed0a3f45c817c2bd2d64b761aaf51c358d225
 
 COCOAPODS: 1.10.1

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ __Distribution Site__ : <https://clipy-app.com>
 ### How to Build
 0. Move to the project root directory
 1. `bundle install --path=vendor/bundle && bundle exec pod install`
-2. Open `Clipy.xcworkspace` on Xcode.
-3. build.
+2. `pod update`
+3. Open `Clipy.xcworkspace` on Xcode.
+4. build.
 
 ### Contributing
 1. Fork it ( https://github.com/Clipy/Clipy/fork )


### PR DESCRIPTION
Initially was unable to launch Clipy on Big Sur using `dmg` 1.2.1 (#471), so I built it with Xcode 12.5 and had to do some fixes to make it run, after first build it asked me to give permissions and finally icon appeared in MacOS menu 