### PR TITLE
Rosetta hint in readme for Apple Silicon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Clipy is a Clipboard extension app for macOS.
 
 ---
 
-__Requirement__: macOS 10.10 Yosemite or higher
+__Requirement__: 
+
+- macOS 10.10 Yosemite or higher
+- for Apple Silicon: Install Rosetta (https://support.apple.com/en-us/102527) first
 
 __Distribution Site__ : <https://clipy-app.com>
 


### PR DESCRIPTION
added a hint and link for the Rosetta requirement on Apple Silicon devices

related to issue #548 

https://github.com/Clipy/Clipy/issues/548#issuecomment-2198201252