### PR TITLE
fix: A "login item added" notification appears each time  #517, #519, #527

### DIFF
--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -153,6 +153,8 @@ class AppDelegate: NSObject, NSMenuItemValidation {
 
     private func toggleAddingToLoginItems(_ isEnable: Bool) {
         let appPath = Bundle.main.bundlePath
+        let isExistLoginItems = LoginServiceKit.isExistLoginItems(at: appPath)
+        if isEnable && isExistLoginItems { return }
         LoginServiceKit.removeLoginItems(at: appPath)
         guard isEnable else { return }
         LoginServiceKit.addLoginItems(at: appPath)


### PR DESCRIPTION
Fix issue #517, #519, #527


「ログイン項目に追加されました」の通知が起動するごとに表示される問題に対応しました。