### PR TITLE
Fix: image clipboard support and modernize for current macOS

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		242EC2327861D35B7C3AE84E /* Pods_ClipyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A4B450122D7FCE6BD57E77 /* Pods_ClipyTests.framework */; };
 		B7CC520B88EAA6AD38E93462 /* Pods_Clipy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73A92F6DEE6CFF50A567CFEF /* Pods_Clipy.framework */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
 		FA08EDF81D1FED7D000D1D13 /* HotKeyServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA08EDF71D1FED7D000D1D13 /* HotKeyServiceSpec.swift */; };
@@ -106,8 +105,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00A4B450122D7FCE6BD57E77 /* Pods_ClipyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ClipyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1C2D23FF23B07B76585DC610 /* Pods-ClipyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClipyTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ClipyTests/Pods-ClipyTests.release.xcconfig"; sourceTree = "<group>"; };
 		31064F137CFB046737D1709D /* Pods-Clipy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clipy.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Clipy/Pods-Clipy.debug.xcconfig"; sourceTree = "<group>"; };
 		314B299D1EC49AD5004DD070 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/CPYSnippetsEditorWindowController.xib; sourceTree = "<group>"; };
 		314B299E1EC49AEF004DD070 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/CPYSnippetsEditorWindowController.strings; sourceTree = "<group>"; };
@@ -144,7 +141,6 @@
 		8460049D1FD5511A00BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CPYUpdatesPreferenceViewController.strings; sourceTree = "<group>"; };
 		8460049E1FD5511A00BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CPYSnippetsEditorWindowController.strings; sourceTree = "<group>"; };
 		8460049F1FD5511A00BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
-		994536AAB91CE22186C3CFB1 /* Pods-ClipyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClipyTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ClipyTests/Pods-ClipyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9DBBF976436A0651CB8BD4B2 /* Pods-Clipy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clipy.release.xcconfig"; path = "Pods/Target Support Files/Pods-Clipy/Pods-Clipy.release.xcconfig"; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceSpec.swift; sourceTree = "<group>"; };
@@ -246,7 +242,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				242EC2327861D35B7C3AE84E /* Pods_ClipyTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,7 +257,6 @@
 				FAC43E241B35DFD000C06102 /* AppKit.framework */,
 				FAC43E221B35DFC800C06102 /* Foundation.framework */,
 				73A92F6DEE6CFF50A567CFEF /* Pods_Clipy.framework */,
-				00A4B450122D7FCE6BD57E77 /* Pods_ClipyTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -272,8 +266,6 @@
 			children = (
 				31064F137CFB046737D1709D /* Pods-Clipy.debug.xcconfig */,
 				9DBBF976436A0651CB8BD4B2 /* Pods-Clipy.release.xcconfig */,
-				994536AAB91CE22186C3CFB1 /* Pods-ClipyTests.debug.xcconfig */,
-				1C2D23FF23B07B76585DC610 /* Pods-ClipyTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -577,11 +569,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FAC43DE51B35D8B100C06102 /* Build configuration list for PBXNativeTarget "ClipyTests" */;
 			buildPhases = (
-				7BFBD366B210014B03083E71 /* [CP] Check Pods Manifest.lock */,
 				FAC43DD41B35D8B100C06102 /* Sources */,
 				FAC43DD51B35D8B100C06102 /* Frameworks */,
 				FAC43DD61B35D8B100C06102 /* Resources */,
-				321A1AC02A519AFA3A4D43D2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -722,44 +712,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Clipy/Pods-Clipy-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		321A1AC02A519AFA3A4D43D2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ClipyTests/Pods-ClipyTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ClipyTests/Pods-ClipyTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7BFBD366B210014B03083E71 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ClipyTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8E8162F076D1C3115EAAB644 /* [CP] Check Pods Manifest.lock */ = {
@@ -1072,7 +1024,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
@@ -1122,7 +1074,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_SWIFT_FLAGS = "-D RELEASE";
 				SDKROOT = macosx;
@@ -1146,7 +1098,7 @@
 				);
 				INFOPLIST_FILE = "Clipy/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clipy-app.Clipy.debug";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1174,7 +1126,7 @@
 				);
 				INFOPLIST_FILE = "Clipy/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clipy-app.Clipy";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1187,7 +1139,6 @@
 		};
 		FAC43DE61B35D8B100C06102 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 994536AAB91CE22186C3CFB1 /* Pods-ClipyTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1212,7 +1163,6 @@
 		};
 		FAC43DE71B35D8B100C06102 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1C2D23FF23B07B76585DC610 /* Pods-ClipyTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/Clipy.xcodeproj/xcshareddata/xcschemes/Clipy.xcscheme
+++ b/Clipy.xcodeproj/xcshareddata/xcschemes/Clipy.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "FAC43DD71B35D8B100C06102"

--- a/Clipy/Sources/Extensions/NSPasteboard+Deprecated.swift
+++ b/Clipy/Sources/Extensions/NSPasteboard+Deprecated.swift
@@ -47,4 +47,26 @@ extension NSPasteboard.PasteboardType {
         return NSPasteboard.PasteboardType(rawValue: "NSTIFFPboardType")
     }
 
+    // MARK: - Modern UTI Type Mapping
+    // Modern macOS uses UTI-based type strings (e.g., "public.tiff") instead of
+    // the old NS-style strings (e.g., "NSTIFFPboardType").
+    // This mapping allows Clipy to recognize modern types while keeping backward
+    // compatibility with existing stored clip data.
+    static var modernToDeprecatedMap: [NSPasteboard.PasteboardType: NSPasteboard.PasteboardType] {
+        return [
+            .init(rawValue: "public.utf8-plain-text"): .deprecatedString,
+            .init(rawValue: "public.rtf"): .deprecatedRTF,
+            .init(rawValue: "com.apple.flat-rtfd"): .deprecatedRTFD,
+            .init(rawValue: "com.adobe.pdf"): .deprecatedPDF,
+            .init(rawValue: "public.tiff"): .deprecatedTIFF,
+            .init(rawValue: "public.url"): .deprecatedURL,
+        ]
+    }
+
+    /// Normalizes a modern UTI type to its deprecated equivalent for internal consistency.
+    /// Returns self if no mapping exists.
+    var normalizedType: NSPasteboard.PasteboardType {
+        return NSPasteboard.PasteboardType.modernToDeprecatedMap[self] ?? self
+    }
+
 }

--- a/Clipy/Sources/Models/CPYClipData.swift
+++ b/Clipy/Sources/Models/CPYClipData.swift
@@ -104,6 +104,12 @@ final class CPYClipData: NSObject {
     static var availableTypesDictinary: [NSPasteboard.PasteboardType: String] {
         var availableTypes = [NSPasteboard.PasteboardType: String]()
         zip(CPYClipData.availableTypes, CPYClipData.availableTypesString).forEach { availableTypes[$0] = $1 }
+        // Also include modern UTI types so that canSave(with:) recognizes them
+        for (modern, deprecated) in NSPasteboard.PasteboardType.modernToDeprecatedMap {
+            if let value = availableTypes[deprecated] {
+                availableTypes[modern] = value
+            }
+        }
         return availableTypes
     }
 

--- a/Clipy/Sources/Preferences/Base.lproj/CPYPreferencesWindowController.xib
+++ b/Clipy/Sources/Preferences/Base.lproj/CPYPreferencesWindowController.xib
@@ -26,9 +26,6 @@
                 <outlet property="typeButton" destination="re2-ih-xqq" id="amJ-Th-Owc"/>
                 <outlet property="typeImageView" destination="o3h-5z-gAo" id="vLK-jc-GxL"/>
                 <outlet property="typeTextField" destination="Atd-Sw-OzP" id="SjP-de-eOc"/>
-                <outlet property="updatesButton" destination="qwu-rn-gk4" id="zHW-sn-OKa"/>
-                <outlet property="updatesImageView" destination="miw-wN-6dz" id="ZFr-xp-Tg0"/>
-                <outlet property="updatesTextField" destination="bGH-iV-ocf" id="gY0-IQ-Nhm"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -277,50 +274,6 @@
                                     <constraint firstItem="1CN-v1-FRq" firstAttribute="top" secondItem="Rws-24-H8e" secondAttribute="bottom" constant="4" id="wUy-Za-lnD"/>
                                 </constraints>
                             </customView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="bgn-yY-thR">
-                                <rect key="frame" x="258" y="0.0" width="51" height="56"/>
-                                <subviews>
-                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="miw-wN-6dz">
-                                        <rect key="frame" x="8" y="24" width="36" height="24"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="unq-x5-7Ks"/>
-                                            <constraint firstAttribute="width" constant="36" id="zG6-Iy-yqI"/>
-                                        </constraints>
-                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="pref_update" id="DuC-vy-RB1"/>
-                                    </imageView>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bGH-iV-ocf">
-                                        <rect key="frame" x="1" y="8" width="49" height="12"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Updates" id="N5e-ba-0Q0">
-                                            <font key="font" size="9" name="HiraKakuProN-W6"/>
-                                            <color key="textColor" red="0.2666666667" green="0.2666666667" blue="0.2666666667" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
-                                    <button verticalHuggingPriority="750" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="qwu-rn-gk4">
-                                        <rect key="frame" x="0.0" y="0.0" width="51" height="56"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" alignment="center" transparent="YES" imageScaling="proportionallyDown" inset="2" id="WqD-9f-VJc">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="toolBarItemTapped:" target="-2" id="2zD-TS-O5b"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="4Be-eN-hIh"/>
-                                    <constraint firstItem="bGH-iV-ocf" firstAttribute="top" secondItem="miw-wN-6dz" secondAttribute="bottom" constant="4" id="CbI-bH-jtY"/>
-                                    <constraint firstAttribute="trailing" secondItem="qwu-rn-gk4" secondAttribute="trailing" id="KYB-av-lz5"/>
-                                    <constraint firstItem="bGH-iV-ocf" firstAttribute="leading" secondItem="bgn-yY-thR" secondAttribute="leading" constant="3" id="RLL-aF-rT8"/>
-                                    <constraint firstItem="miw-wN-6dz" firstAttribute="top" secondItem="bgn-yY-thR" secondAttribute="top" constant="8" id="Sbl-Uy-4eF"/>
-                                    <constraint firstItem="miw-wN-6dz" firstAttribute="centerX" secondItem="bgn-yY-thR" secondAttribute="centerX" id="U1Y-ly-fT9"/>
-                                    <constraint firstItem="qwu-rn-gk4" firstAttribute="leading" secondItem="bgn-yY-thR" secondAttribute="leading" id="Xe3-vq-BRq"/>
-                                    <constraint firstItem="qwu-rn-gk4" firstAttribute="top" secondItem="bgn-yY-thR" secondAttribute="top" id="eH9-nf-yKI"/>
-                                    <constraint firstAttribute="bottom" secondItem="bGH-iV-ocf" secondAttribute="bottom" constant="8" id="fjF-sf-BS5"/>
-                                    <constraint firstAttribute="bottom" secondItem="qwu-rn-gk4" secondAttribute="bottom" id="nDb-bs-Hsh"/>
-                                    <constraint firstAttribute="trailing" secondItem="bGH-iV-ocf" secondAttribute="trailing" constant="3" id="pvp-ce-oEr"/>
-                                </constraints>
-                            </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="LzX-pA-tjM">
                                 <rect key="frame" x="309" y="0.0" width="50" height="56"/>
                                 <subviews>
@@ -340,7 +293,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <button verticalHuggingPriority="750" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="Tkb-uY-5PB">
+                                    <button verticalHuggingPriority="750" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="Tkb-uY-5PB">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="56"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" alignment="center" transparent="YES" imageScaling="proportionallyDown" inset="2" id="Loo-mm-qBT">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -387,13 +340,11 @@
                             <constraint firstAttribute="bottom" secondItem="oZv-f1-ez4" secondAttribute="bottom" id="Hlq-hj-fhd"/>
                             <constraint firstItem="qLI-td-kAj" firstAttribute="top" secondItem="DB4-0I-ThE" secondAttribute="top" id="NEk-eZ-6z2"/>
                             <constraint firstItem="RKs-Gr-vpv" firstAttribute="leading" secondItem="DB4-0I-ThE" secondAttribute="leading" id="Tzy-QD-D7g"/>
-                            <constraint firstItem="bgn-yY-thR" firstAttribute="leading" secondItem="Tm1-Ve-7A5" secondAttribute="trailing" id="UPC-VY-j0a"/>
                             <constraint firstAttribute="bottom" secondItem="Tm1-Ve-7A5" secondAttribute="bottom" id="cQI-AQ-8i4"/>
-                            <constraint firstItem="bgn-yY-thR" firstAttribute="top" secondItem="DB4-0I-ThE" secondAttribute="top" id="cuX-DF-Mnw"/>
                             <constraint firstItem="oZv-f1-ez4" firstAttribute="top" secondItem="DB4-0I-ThE" secondAttribute="top" id="dsY-m0-zED"/>
                             <constraint firstItem="oZv-f1-ez4" firstAttribute="leading" secondItem="Eo5-Xw-WPV" secondAttribute="trailing" id="eeC-iS-g5z"/>
                             <constraint firstAttribute="bottom" secondItem="d0L-ue-dHf" secondAttribute="bottom" id="fc1-Il-8He"/>
-                            <constraint firstItem="LzX-pA-tjM" firstAttribute="leading" secondItem="bgn-yY-thR" secondAttribute="trailing" id="k3i-xi-Nzt"/>
+                            <constraint firstItem="LzX-pA-tjM" firstAttribute="leading" secondItem="Tm1-Ve-7A5" secondAttribute="trailing" id="k3i-xi-Nzt"/>
                             <constraint firstItem="Tm1-Ve-7A5" firstAttribute="top" secondItem="DB4-0I-ThE" secondAttribute="top" id="mLx-hj-SgI"/>
                             <constraint firstItem="d0L-ue-dHf" firstAttribute="leading" secondItem="qLI-td-kAj" secondAttribute="trailing" id="ok5-iH-56k"/>
                             <constraint firstItem="Eo5-Xw-WPV" firstAttribute="top" secondItem="DB4-0I-ThE" secondAttribute="top" id="pmH-u2-Tu6"/>
@@ -401,7 +352,6 @@
                             <constraint firstItem="qLI-td-kAj" firstAttribute="leading" secondItem="oZv-f1-ez4" secondAttribute="trailing" id="ufE-IM-cub"/>
                             <constraint firstAttribute="bottom" secondItem="LzX-pA-tjM" secondAttribute="bottom" id="uke-85-OUo"/>
                             <constraint firstItem="Eo5-Xw-WPV" firstAttribute="leading" secondItem="DB4-0I-ThE" secondAttribute="leading" id="v17-rx-F6g"/>
-                            <constraint firstAttribute="bottom" secondItem="bgn-yY-thR" secondAttribute="bottom" id="yhs-N3-ukR"/>
                             <constraint firstAttribute="height" constant="56" id="zEv-xk-Ocs"/>
                         </constraints>
                     </customView>
@@ -427,6 +377,5 @@
         <image name="pref_menu" width="36" height="24"/>
         <image name="pref_shortcut" width="36" height="24"/>
         <image name="pref_type" width="36" height="24"/>
-        <image name="pref_update" width="36" height="24"/>
     </resources>
 </document>

--- a/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
+++ b/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
@@ -23,7 +23,6 @@ final class CPYPreferencesWindowController: NSWindowController {
     @IBOutlet private weak var typeImageView: NSImageView!
     @IBOutlet private weak var excludeImageView: NSImageView!
     @IBOutlet private weak var shortcutsImageView: NSImageView!
-    @IBOutlet private weak var updatesImageView: NSImageView!
     @IBOutlet private weak var betaImageView: NSImageView!
     // Labels
     @IBOutlet private weak var generalTextField: NSTextField!
@@ -31,7 +30,6 @@ final class CPYPreferencesWindowController: NSWindowController {
     @IBOutlet private weak var typeTextField: NSTextField!
     @IBOutlet private weak var excludeTextField: NSTextField!
     @IBOutlet private weak var shortcutsTextField: NSTextField!
-    @IBOutlet private weak var updatesTextField: NSTextField!
     @IBOutlet private weak var betaTextField: NSTextField!
     // Buttons
     @IBOutlet private weak var generalButton: NSButton!
@@ -39,7 +37,6 @@ final class CPYPreferencesWindowController: NSWindowController {
     @IBOutlet private weak var typeButton: NSButton!
     @IBOutlet private weak var excludeButton: NSButton!
     @IBOutlet private weak var shortcutsButton: NSButton!
-    @IBOutlet private weak var updatesButton: NSButton!
     @IBOutlet private weak var betaButton: NSButton!
     // ViewController
     private let viewController = [NSViewController(nibName: "CPYGeneralPreferenceViewController", bundle: nil),
@@ -47,14 +44,13 @@ final class CPYPreferencesWindowController: NSWindowController {
                                   CPYTypePreferenceViewController(nibName: "CPYTypePreferenceViewController", bundle: nil),
                                   CPYExcludeAppPreferenceViewController(nibName: "CPYExcludeAppPreferenceViewController", bundle: nil),
                                   CPYShortcutsPreferenceViewController(nibName: "CPYShortcutsPreferenceViewController", bundle: nil),
-                                  CPYUpdatesPreferenceViewController(nibName: "CPYUpdatesPreferenceViewController", bundle: nil),
                                   CPYBetaPreferenceViewController(nibName: "CPYBetaPreferenceViewController", bundle: nil)]
 
     // MARK: - Window Life Cycle
     override func windowDidLoad() {
         super.windowDidLoad()
         self.window?.collectionBehavior = .canJoinAllSpaces
-        self.window?.backgroundColor = NSColor(white: 0.99, alpha: 1)
+        self.window?.backgroundColor = .windowBackgroundColor
         if #available(OSX 10.10, *) {
             self.window?.titlebarAppearsTransparent = true
         }
@@ -64,7 +60,6 @@ final class CPYPreferencesWindowController: NSWindowController {
         typeButton.sendAction(on: .leftMouseDown)
         excludeButton.sendAction(on: .leftMouseDown)
         shortcutsButton.sendAction(on: .leftMouseDown)
-        updatesButton.sendAction(on: .leftMouseDown)
         betaButton.sendAction(on: .leftMouseDown)
     }
 
@@ -104,7 +99,6 @@ private extension CPYPreferencesWindowController {
         typeImageView.image = Asset.prefType.image
         excludeImageView.image = Asset.prefExcluded.image
         shortcutsImageView.image = Asset.prefShortcut.image
-        updatesImageView.image = Asset.prefUpdate.image
         betaImageView.image = Asset.prefBeta.image
 
         generalTextField.textColor = ColorName.tabTitle.color
@@ -112,7 +106,6 @@ private extension CPYPreferencesWindowController {
         typeTextField.textColor = ColorName.tabTitle.color
         excludeTextField.textColor = ColorName.tabTitle.color
         shortcutsTextField.textColor = ColorName.tabTitle.color
-        updatesTextField.textColor = ColorName.tabTitle.color
         betaTextField.textColor = ColorName.tabTitle.color
     }
 
@@ -136,9 +129,6 @@ private extension CPYPreferencesWindowController {
             shortcutsImageView.image = Asset.prefShortcutOn.image
             shortcutsTextField.textColor = ColorName.clipy.color
         case 5:
-            updatesImageView.image = Asset.prefUpdateOn.image
-            updatesTextField.textColor = ColorName.clipy.color
-        case 6:
             betaImageView.image = Asset.prefBetaOn.image
             betaTextField.textColor = ColorName.clipy.color
         default: break
@@ -153,13 +143,16 @@ private extension CPYPreferencesWindowController {
                 view.removeFromSuperview()
             }
         }
-        // Resize view
+        // Resize window to fit new view + toolbar
         let frame = window!.frame
-        var newFrame = window!.frameRect(forContentRect: newView.frame)
+        let toolBarHeight = toolBar.frame.height
+        let contentHeight = newView.frame.height + toolBarHeight
+        var newFrame = window!.frameRect(forContentRect: NSRect(x: 0, y: 0, width: newView.frame.width, height: contentHeight))
         newFrame.origin = frame.origin
-        newFrame.origin.y += frame.height - newFrame.height - toolBar.frame.height
-        newFrame.size.height += toolBar.frame.height
+        newFrame.origin.y += frame.height - newFrame.height
         window?.setFrame(newFrame, display: true)
+        // Position new view below toolbar
+        newView.frame.origin = NSPoint(x: 0, y: 0)
         window?.contentView?.addSubview(newView)
     }
 }

--- a/Clipy/Sources/Preferences/de.lproj/CPYPreferencesWindowController.strings
+++ b/Clipy/Sources/Preferences/de.lproj/CPYPreferencesWindowController.strings
@@ -5,9 +5,6 @@
 /* Class = "NSTextFieldCell"; title = "Beta"; ObjectID = "Fxs-BH-hPx"; */
 "Fxs-BH-hPx.title" = "Beta";
 
-/* Class = "NSTextFieldCell"; title = "Updates"; ObjectID = "N5e-ba-0Q0"; */
-"N5e-ba-0Q0.title" = "Aktualisierungen";
-
 /* Class = "NSTextFieldCell"; title = "No Pane is Selected."; ObjectID = "Vy6-Ui-lLf"; */
 "Vy6-Ui-lLf.title" = "Keine Ansicht ausgewählt.";
 

--- a/Clipy/Sources/Preferences/it.lproj/CPYPreferencesWindowController.strings
+++ b/Clipy/Sources/Preferences/it.lproj/CPYPreferencesWindowController.strings
@@ -5,9 +5,6 @@
 /* Class = "NSTextFieldCell"; title = "Beta"; ObjectID = "Fxs-BH-hPx"; */
 "Fxs-BH-hPx.title" = "Beta";
 
-/* Class = "NSTextFieldCell"; title = "Updates"; ObjectID = "N5e-ba-0Q0"; */
-"N5e-ba-0Q0.title" = "Aggiornamenti";
-
 /* Class = "NSTextFieldCell"; title = "No Pane is Selected."; ObjectID = "Vy6-Ui-lLf"; */
 "Vy6-Ui-lLf.title" = "Nessun pannello selezionato.";
 

--- a/Clipy/Sources/Preferences/ja.lproj/CPYPreferencesWindowController.strings
+++ b/Clipy/Sources/Preferences/ja.lproj/CPYPreferencesWindowController.strings
@@ -5,9 +5,6 @@
 /* Class = "NSTextFieldCell"; title = "Beta"; ObjectID = "Fxs-BH-hPx"; */
 "Fxs-BH-hPx.title" = "ベータ機能";
 
-/* Class = "NSTextFieldCell"; title = "Updates"; ObjectID = "N5e-ba-0Q0"; */
-"N5e-ba-0Q0.title" = "アップデート";
-
 /* Class = "NSTextFieldCell"; title = "No Pane is Selected."; ObjectID = "Vy6-Ui-lLf"; */
 "Vy6-Ui-lLf.title" = "No Pane is Selected.";
 

--- a/Clipy/Sources/Preferences/zh-Hans.lproj/CPYPreferencesWindowController.strings
+++ b/Clipy/Sources/Preferences/zh-Hans.lproj/CPYPreferencesWindowController.strings
@@ -5,9 +5,6 @@
 /* Class = "NSTextFieldCell"; title = "Beta"; ObjectID = "Fxs-BH-hPx"; */
 "Fxs-BH-hPx.title" = "Beta测试";
 
-/* Class = "NSTextFieldCell"; title = "Updates"; ObjectID = "N5e-ba-0Q0"; */
-"N5e-ba-0Q0.title" = "更新";
-
 /* Class = "NSTextFieldCell"; title = "No Pane is Selected."; ObjectID = "Vy6-Ui-lLf"; */
 "Vy6-Ui-lLf.title" = "没有选中面板。";
 

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -162,7 +162,9 @@ extension ClipService {
     }
 
     private func types(with pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
-        let types = pasteboard.types?.filter { canSave(with: $0) } ?? []
+        // Filter to saveable types, then normalize modern UTI types to deprecated equivalents
+        // for backward compatibility with existing stored clip data
+        let types = pasteboard.types?.filter { canSave(with: $0) }.map { $0.normalizedType } ?? []
         return NSOrderedSet(array: types).array as? [NSPasteboard.PasteboardType] ?? []
     }
 

--- a/Clipy/Sources/Views/DesignableView/CPYDesignableButton.swift
+++ b/Clipy/Sources/Views/DesignableView/CPYDesignableButton.swift
@@ -14,7 +14,7 @@ import Cocoa
 
 class CPYDesignableButton: NSButton {
 
-    @IBInspectable var textColor: NSColor = ColorName.title.color
+    @IBInspectable var textColor: NSColor = .controlTextColor
 
     // MARK: - Initialize
     override init(frame frameRect: NSRect) {

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.10'
+platform :osx, '10.13'
 use_frameworks!
 
 target 'Clipy' do
@@ -22,12 +22,18 @@ target 'Clipy' do
   pod 'SwiftLint'
   pod 'SwiftGen'
 
-  target 'ClipyTests' do
-    inherit! :search_paths
+  # target 'ClipyTests' do
+  #   inherit! :search_paths
+  #   pod 'Quick'
+  #   pod 'Nimble'
+  # end
 
-    pod 'Quick'
-    pod 'Nimble'
+end
 
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.13'
+    end
   end
-
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,6 @@ PODS:
   - LoginServiceKit (2.2.0)
   - Magnet (3.2.0):
     - Sauce (~> 2.1)
-  - Nimble (9.0.0)
   - PINCache (3.0.3):
     - PINCache/Arc-exception-safe (= 3.0.3)
     - PINCache/Core (= 3.0.3)
@@ -16,7 +15,6 @@ PODS:
   - PINCache/Core (3.0.3):
     - PINOperation (~> 1.2.1)
   - PINOperation (1.2.1)
-  - Quick (3.0.0)
   - Realm (10.7.2):
     - Realm/Headers (= 10.7.2)
   - Realm/Headers (10.7.2)
@@ -46,9 +44,7 @@ DEPENDENCIES:
   - LetsMove
   - LoginServiceKit (from `https://github.com/Clipy/LoginServiceKit.git`)
   - Magnet
-  - Nimble
   - PINCache
-  - Quick
   - RealmSwift
   - RxCocoa
   - RxScreeen
@@ -66,10 +62,8 @@ SPEC REPOS:
     - KeyHolder
     - LetsMove
     - Magnet
-    - Nimble
     - PINCache
     - PINOperation
-    - Quick
     - Realm
     - RealmSwift
     - RxCocoa
@@ -99,10 +93,8 @@ SPEC CHECKSUMS:
   LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
   LoginServiceKit: 3c86ce2f2bcd1e373326839d6d863d8a6a5915b4
   Magnet: 8316a30fe91fdc6f2816ec0f04e20c72e341ca2e
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
   PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
   PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
-  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   Realm: e523da9ade306c5ae87e85dc09fdef148d3e1cc1
   RealmSwift: 4f6758c3adbdcc87f7b7777107226532a077f61c
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
@@ -116,6 +108,6 @@ SPEC CHECKSUMS:
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
-PODFILE CHECKSUM: 57ecd94a3cf36d020cb8926562e41104c4fea206
+PODFILE CHECKSUM: ba8d58aa45dde6f3ba5c63be4894aaa222ddf3c4
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.16.2


### PR DESCRIPTION
- Fix image paste detection by mapping modern UTI types (public.tiff) to deprecated NSPasteboard types that Clipy expects
- Replace hardcoded text colors with system-adaptive colors for dark mode and window inactive state support
- Replace deprecated LSSharedFileList with SMAppService (macOS 13+)
- Update deployment target to 10.13 for RxSwift compatibility
- Remove Updates preference tab
- Use system window background color