### PR TITLE
Fix repeated login item notification

### DIFF
--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -152,10 +152,11 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     }
 
     private func toggleAddingToLoginItems(_ isEnable: Bool) {
-        let appPath = Bundle.main.bundlePath
-        LoginServiceKit.removeLoginItems(at: appPath)
-        guard isEnable else { return }
-        LoginServiceKit.addLoginItems(at: appPath)
+        if isEnable {
+            LoginServiceKit.addLoginItems()
+        } else {
+            LoginServiceKit.removeLoginItems()
+        }
     }
 
     private func reflectLoginItemState() {


### PR DESCRIPTION
## Summary
- Use LoginServiceKit's default add/remove APIs instead of always removing the bundle path before re-adding it.
- Avoid re-triggering the login item addition notification on every launch when the login item setting is enabled.

## Issue
Fixes #517