### PR TITLE
Migrate SwiftLint to SwiftPM plugin

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -1265,8 +1265,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
-				kind = exactVersion;
-				version = 0.63.2;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.63.2;
 			};
 		};
 		C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */ = {

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -569,7 +569,6 @@
 				FAC43DC31B35D8B100C06102 /* Frameworks */,
 				FAC43DC41B35D8B100C06102 /* Resources */,
 				FAC43E1D1B35DF4A00C06102 /* Embed Frameworks */,
-				FAAD02201CA98E20007C6EEE /* SwiftLint */,
 				07B47785AE0AC2185B570C28 /* [CP] Embed Pods Frameworks */,
 				FAAA88991E686CED0088FB34 /* BartyCrouch */,
 				FA10897F20EC24F700A3FEFC /* SwiftGen */,
@@ -577,6 +576,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C5A4B2022FC9D76000B71510 /* PBXTargetDependency */,
 			);
 			name = Clipy;
 			productName = Clipy;
@@ -595,6 +595,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C5A4B2032FC9D76000B71510 /* PBXTargetDependency */,
 				FAC43DDA1B35D8B100C06102 /* PBXTargetDependency */,
 			);
 			name = ClipyTests;
@@ -646,6 +647,7 @@
 				C5D3A75D2FB86A0200C9DCB6 /* XCRemoteSwiftPackageReference "Magnet" */,
 				C5D3A7602FB86A1C00C9DCB6 /* XCRemoteSwiftPackageReference "KeyHolder" */,
 				C5D3A7632FB86A2C00C9DCB6 /* XCRemoteSwiftPackageReference "LoginServiceKit" */,
+				C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
 			projectDirPath = "";
@@ -796,20 +798,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/BartyCrouch/bartycrouch\" interfaces -p \"$PROJECT_DIR\"";
 		};
-		FAAD02201CA98E20007C6EEE /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -881,6 +869,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		C5A4B2022FC9D76000B71510 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
+		};
+		C5A4B2032FC9D76000B71510 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
+		};
 		FAC43DDA1B35D8B100C06102 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FAC43DC51B35D8B100C06102 /* Clipy */;
@@ -1265,6 +1261,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
+			requirement = {
+				kind = exactVersion;
+				version = 0.63.2;
+			};
+		};
 		C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/clipy/sauce";
@@ -1308,6 +1312,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
 		C5D3A75B2FB869EA00C9DCB6 /* Sauce */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "84c70c71c71681e44da66125567e23db1e6d4e4a0c46fad75d989766920fa0d5",
+  "originHash" : "c4aa73829824eeffbb0dbdca6c6123204094fc669eec00057662499a89caf20e",
   "pins" : [
     {
       "identity" : "keyholder",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "357a72be0060765a8e93b9a70b283fc63c75f4a9",
         "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     }
   ],

--- a/Clipy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "84c70c71c71681e44da66125567e23db1e6d4e4a0c46fad75d989766920fa0d5",
+  "originHash" : "c4aa73829824eeffbb0dbdca6c6123204094fc669eec00057662499a89caf20e",
   "pins" : [
     {
       "identity" : "keyholder",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "357a72be0060765a8e93b9a70b283fc63c75f4a9",
         "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     }
   ],

--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,6 @@ target 'Clipy' do
   pod 'SwiftHEXColors'
   # Utility
   pod 'BartyCrouch'
-  pod 'SwiftLint'
   pod 'SwiftGen'
 
   target 'ClipyTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,7 +24,6 @@ PODS:
   - Sparkle (1.26.0)
   - SwiftGen (6.4.0)
   - SwiftHEXColors (1.4.1)
-  - SwiftLint (0.63.2)
 
 DEPENDENCIES:
   - AEXML
@@ -37,7 +36,6 @@ DEPENDENCIES:
   - Sparkle
   - SwiftGen
   - SwiftHEXColors
-  - SwiftLint
 
 SPEC REPOS:
   trunk:
@@ -54,7 +52,6 @@ SPEC REPOS:
     - Sparkle
     - SwiftGen
     - SwiftHEXColors
-    - SwiftLint
 
 SPEC CHECKSUMS:
   AEXML: 2fbb73d8724797ed2cde888731e176fa4d44dd83
@@ -70,8 +67,7 @@ SPEC CHECKSUMS:
   Sparkle: d56d028f4b0c123577825f5d1004f6140d77f90e
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
   SwiftHEXColors: 1cb6e5d55c52749aa33db8f088ac55eb71ca4c7f
-  SwiftLint: 4fa4a9b437ccc4fc72f6c0bc98556e8e9e05bccf
 
-PODFILE CHECKSUM: 324426ab405a476779cb69f4af338bb9a9f0e7e7
+PODFILE CHECKSUM: 651855f4f99d6d7df2beed921c6e94449b872ab0
 
 COCOAPODS: 1.16.2

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,8 @@ platform :mac do
       scheme: "Clipy",
       skip_build: true,
       verbose: true,
-      clean: true
+      clean: true,
+      xcargs: "-skipPackagePluginValidation"
     )
   end
 


### PR DESCRIPTION
## Summary
- Remove SwiftLint from CocoaPods dependencies.
- Add SwiftLintPlugins via Swift Package Manager at 0.63.2.
- Run SwiftLint through SwiftLintBuildToolPlugin for both Clipy and ClipyTests targets.

## Impact
This keeps the SwiftLint version aligned with the previous CocoaPods setup while moving lint execution into Xcode's build tool plugin flow.
