### PR TITLE
Remove LetsMove dependency

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -713,14 +713,12 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Clipy/Pods-Clipy-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/LetsMove/LetsMove.framework",
 				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
 				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
 				"${PODS_ROOT}/Sparkle/Sparkle.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LetsMove.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework",

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -18,7 +18,6 @@ import LoginServiceKit
 import Magnet
 import Screeen
 import RealmSwift
-import LetsMove
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSMenuItemValidation {
@@ -201,12 +200,6 @@ extension AppDelegate: NSApplicationDelegate {
         AppEnvironment.current.menuManager.setup()
         // Screenshot
         screenshotObserver.delegate = self
-    }
-
-    func applicationWillFinishLaunching(_ notification: Notification) {
-        #if RELEASE
-            PFMoveToApplicationsFolderIfNecessary()
-        #endif
     }
 
 }

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,6 @@ target 'Clipy' do
   # Application
   pod 'Sparkle'
   pod 'RealmSwift'
-  pod 'LetsMove'
   # Utility
   pod 'BartyCrouch'
   pod 'SwiftGen'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - BartyCrouch (3.13.0)
-  - LetsMove (1.25)
   - Realm (10.7.2):
     - Realm/Headers (= 10.7.2)
   - Realm/Headers (10.7.2)
@@ -11,7 +10,6 @@ PODS:
 
 DEPENDENCIES:
   - BartyCrouch
-  - LetsMove
   - RealmSwift
   - Sparkle
   - SwiftGen
@@ -19,7 +17,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - BartyCrouch
-    - LetsMove
     - Realm
     - RealmSwift
     - Sparkle
@@ -27,12 +24,11 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   BartyCrouch: 69e5e6ec67e77951dc1c22aa48abbf05d175b81c
-  LetsMove: 7b9fe44737707d984fbd3f47af46609a9a07b461
   Realm: e523da9ade306c5ae87e85dc09fdef148d3e1cc1
   RealmSwift: 4f6758c3adbdcc87f7b7777107226532a077f61c
   Sparkle: d56d028f4b0c123577825f5d1004f6140d77f90e
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
 
-PODFILE CHECKSUM: 04a2a48a4edb9f01baf59ad0d9505d4107c2c857
+PODFILE CHECKSUM: 9e039ad573fba79af088b83ef1cc8d54704e23fe
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

Closes #600.

This removes the LetsMove dependency from Clipy and stops calling `PFMoveToApplicationsFolderIfNecessary()` during release startup.

## Details

- Removed `pod 'LetsMove'` from the Podfile and refreshed `Podfile.lock` with CocoaPods.
- Removed the `LetsMove` import and launch-time move call from `AppDelegate`.
- Removed the LetsMove framework paths from the CocoaPods embed framework phase.

## Impact

Clipy no longer attempts to automatically move itself into `/Applications` at launch. This avoids relying on an unmaintained dependency and avoids OS-specific behavior around App Translocation and quarantine handling. Users should install Clipy by moving the app into Applications manually from the distributed DMG.