### PR TITLE
Update Sparkle and move it to Swift Package Manager

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B7CC520B88EAA6AD38E93462 /* Pods_Clipy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73A92F6DEE6CFF50A567CFEF /* Pods_Clipy.framework */; };
+		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
 		C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75E2FB86A0200C9DCB6 /* Magnet */; };
 		C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A7612FB86A1C00C9DCB6 /* KeyHolder */; };
@@ -77,8 +78,8 @@
 		FA6167921D3ABEB10049FA14 /* FolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderTests.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataTests.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetTests.swift */; };
-		FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
-		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
 		FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */; };
 		FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
@@ -255,6 +256,7 @@
 				C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */,
 				C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */,
 				FAC43E231B35DFC800C06102 /* Foundation.framework in Frameworks */,
+				C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */,
 				C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */,
 				C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */,
 				C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */,
@@ -662,6 +664,7 @@
 				C5D76DA32FBA98A90083839F /* XCRemoteSwiftPackageReference "AEXML" */,
 				C5D76DA62FBA9C140083839F /* XCRemoteSwiftPackageReference "pincache" */,
 				C5D76DA92FBA9D2E0083839F /* XCRemoteSwiftPackageReference "SwiftHEXColors" */,
+				C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
 			projectDirPath = "";
@@ -679,7 +682,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
-				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
+				FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */,
 				FA1DB51E1DDCB4C0007F95C8 /* CPYTypePreferenceViewController.xib in Resources */,
 				FA1DB4901DDCA5D9007F95C8 /* Images.xcassets in Resources */,
 				FA1DB51D1DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.xib in Resources */,
@@ -688,7 +691,7 @@
 				FA1DB51B1DDCB4C0007F95C8 /* CPYGeneralPreferenceViewController.xib in Resources */,
 				FA1DB51A1DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.xib in Resources */,
 				FA1DB5191DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.xib in Resources */,
-				FA6DD5151C7DEDB600317E73 /* (null) in Resources */,
+				FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */,
 				FA1DB4941DDCB22C007F95C8 /* dsa_pub.pem in Resources */,
 				FA1DB4981DDCB2CB007F95C8 /* Localizable.strings in Resources */,
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
@@ -715,13 +718,11 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Clipy/Pods-Clipy-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
 				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
-				"${PODS_ROOT}/Sparkle/Sparkle.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -869,11 +870,11 @@
 /* Begin PBXTargetDependency section */
 		C5A4B2022FC9D76000B71510 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
+			productRef = C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		C5A4B2032FC9D76000B71510 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
+			productRef = C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		FAC43DDA1B35D8B100C06102 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1267,6 +1268,14 @@
 				minimumVersion = 0.63.2;
 			};
 		};
+		C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.9.2;
+			};
+		};
 		C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/clipy/sauce";
@@ -1342,10 +1351,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */ = {
+		C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+		C5A6BA732FBC5A6E00C8B9EB /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 		C5D3A75B2FB869EA00C9DCB6 /* Sauce */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a23ff6b9e596edeb7efa33a24d0e61c4b344a9a1624a28b0bf1e32dad78fc06c",
+  "originHash" : "3149a24e34eb92635d9d3d3298efe86c13ab5b25b521da7e5f6983b88a3bea0a",
   "pins" : [
     {
       "identity" : "aexml",
@@ -80,6 +80,15 @@
       "state" : {
         "revision" : "357a72be0060765a8e93b9a70b283fc63c75f4a9",
         "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     },
     {

--- a/Clipy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a23ff6b9e596edeb7efa33a24d0e61c4b344a9a1624a28b0bf1e32dad78fc06c",
+  "originHash" : "b9b28b0a64ae9aa62b7e58d213be126b8c4b02b8314fea98742fb63f242ee4e9",
   "pins" : [
     {
       "identity" : "aexml",
@@ -80,6 +80,15 @@
       "state" : {
         "revision" : "357a72be0060765a8e93b9a70b283fc63c75f4a9",
         "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     },
     {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -23,8 +23,9 @@ import RealmSwift
 class AppDelegate: NSObject, NSMenuItemValidation {
 
     // MARK: - Properties
-    let screenshotObserver = ScreenShotObserver()
-    let disposeBag = DisposeBag()
+    private(set) var updaterController: SPUStandardUpdaterController?
+    private let screenshotObserver = ScreenShotObserver()
+    private let disposeBag = DisposeBag()
 
     // MARK: - Init
     override func awakeFromNib() {
@@ -182,10 +183,12 @@ extension AppDelegate: NSApplicationDelegate {
         }
 
         // Sparkle
-        let updater = SUUpdater.shared()
-        updater?.feedURL = Constants.Application.appcastURL
-        updater?.automaticallyChecksForUpdates = AppEnvironment.current.defaults.bool(forKey: Constants.Update.enableAutomaticCheck)
-        updater?.updateCheckInterval = TimeInterval(AppEnvironment.current.defaults.integer(forKey: Constants.Update.checkInterval))
+        self.updaterController = SPUStandardUpdaterController(
+            startingUpdater: AppEnvironment.current.defaults.bool(forKey: Constants.Update.enableAutomaticCheck),
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        updaterController?.updater.updateCheckInterval = TimeInterval(AppEnvironment.current.defaults.integer(forKey: Constants.Update.checkInterval))
 
         // Binding Events
         bind()

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYUpdatesPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYUpdatesPreferenceViewController.xib
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="CPYUpdatesPreferenceViewController" customModule="Clipy" customModuleProvider="target">
             <connections>
+                <outlet property="lastUpdateCheckDateTextField" destination="bfd-d7-m1a" id="Cfq-L5-lDE"/>
                 <outlet property="versionTextField" destination="IJH-aY-lUJ" id="6Rg-gc-H50"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -17,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="134"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bfd-d7-m1a">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bfd-d7-m1a">
                     <rect key="frame" x="60" y="40" width="361" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="date" id="nG5-PB-zcE">
@@ -26,9 +28,6 @@
                         <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
-                    <connections>
-                        <binding destination="BFl-Kb-QuK" name="value" keyPath="lastUpdateCheckDate" id="RZL-GJ-KxE"/>
-                    </connections>
                 </textField>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bnR-ek-Gzp">
                     <rect key="frame" x="159" y="62" width="162" height="32"/>
@@ -38,7 +37,7 @@
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="checkForUpdates:" target="BFl-Kb-QuK" id="i13-OM-Vnw"/>
+                        <action selector="checkForUpdates:" target="-2" id="tDA-KR-qYc"/>
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="evV-Ot-cOb">
@@ -57,7 +56,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Monthly" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="2592000" imageScaling="proportionallyDown" inset="2" selectedItem="o5Q-Ao-iQN" id="EYE-Mb-K0U">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="scf-zc-AI1">
                             <items>
                                 <menuItem title="Daily" tag="86400" id="HwP-AM-nID"/>
@@ -71,7 +70,7 @@
                         <binding destination="Z9l-MW-Uqh" name="selectedTag" keyPath="values.kCPYUpdateCheckIntervalKey" id="QmO-Rj-lIC"/>
                     </connections>
                 </popUpButton>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IJH-aY-lUJ">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IJH-aY-lUJ">
                     <rect key="frame" x="171" y="12" width="140" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="v1.0.0" id="hhl-AS-dQ0">
@@ -84,6 +83,5 @@
             <point key="canvasLocation" x="629" y="589"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="Z9l-MW-Uqh"/>
-        <customObject id="BFl-Kb-QuK" customClass="SUUpdater"/>
     </objects>
 </document>

--- a/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
@@ -11,16 +11,33 @@
 //
 
 import Cocoa
+import Combine
+import Sparkle
 
 class CPYUpdatesPreferenceViewController: NSViewController {
 
     // MARK: - Properties
+    @IBOutlet private weak var lastUpdateCheckDateTextField: NSTextField!
     @IBOutlet private weak var versionTextField: NSTextField!
+
+    private var updaterController: SPUStandardUpdaterController? {
+        guard let appDelegate = NSApp.delegate as? AppDelegate else { return nil }
+        return appDelegate.updaterController
+    }
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Initialize
     override func loadView() {
         super.loadView()
+        updaterController?.updater.publisher(for: \.lastUpdateCheckDate)
+            .compactMap { $0 }
+            .assign(to: \NSControl.objectValue, on: lastUpdateCheckDateTextField)
+            .store(in: &cancellables)
         versionTextField.stringValue = "v\(Bundle.main.appVersion ?? "")"
     }
 
+    @IBAction private func checkForUpdates(_ sender: Any) {
+        guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
+        appDelegate.updaterController?.checkForUpdates(sender)
+    }
 }

--- a/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
@@ -31,7 +31,7 @@ class CPYUpdatesPreferenceViewController: NSViewController {
         super.loadView()
         updaterController?.updater.publisher(for: \.lastUpdateCheckDate)
             .compactMap { $0 }
-            .assign(to: \NSControl.objectValue, on: lastUpdateCheckDateTextField)
+            .assign(to: \.objectValue, on: lastUpdateCheckDateTextField)
             .store(in: &cancellables)
         versionTextField.stringValue = "v\(Bundle.main.appVersion ?? "")"
     }

--- a/Clipy/Supporting Files/Info.plist
+++ b/Clipy/Supporting Files/Info.plist
@@ -36,5 +36,7 @@
 	<string>https://clipy-app.com/appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>SUPublicEDKey</key>
+	<string>IxLVywb2tpxuJi02oxH/bAZ2OEyhY6/MoVTLMaQnbSU=</string>
 </dict>
 </plist>

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,6 @@ inhibit_all_warnings!
 target 'Clipy' do
 
   # Application
-  pod 'Sparkle'
   pod 'RealmSwift'
   # Utility
   pod 'BartyCrouch'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,13 +5,11 @@ PODS:
   - Realm/Headers (10.7.2)
   - RealmSwift (10.7.2):
     - Realm (= 10.7.2)
-  - Sparkle (1.26.0)
   - SwiftGen (6.4.0)
 
 DEPENDENCIES:
   - BartyCrouch
   - RealmSwift
-  - Sparkle
   - SwiftGen
 
 SPEC REPOS:
@@ -19,16 +17,14 @@ SPEC REPOS:
     - BartyCrouch
     - Realm
     - RealmSwift
-    - Sparkle
     - SwiftGen
 
 SPEC CHECKSUMS:
   BartyCrouch: 69e5e6ec67e77951dc1c22aa48abbf05d175b81c
   Realm: e523da9ade306c5ae87e85dc09fdef148d3e1cc1
   RealmSwift: 4f6758c3adbdcc87f7b7777107226532a077f61c
-  Sparkle: d56d028f4b0c123577825f5d1004f6140d77f90e
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
 
-PODFILE CHECKSUM: 9e039ad573fba79af088b83ef1cc8d54704e23fe
+PODFILE CHECKSUM: dcdd942d418c7834a3e0a4a249f619a9c2490b2c
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary
- Move Sparkle from CocoaPods to Swift Package Manager and pin Sparkle 2.9.2.
- Replace the legacy `SUUpdater` usage with `SPUStandardUpdaterController`.
- Add the EdDSA public key while retaining the existing DSA key for migration compatibility.
- Rewire the updates preference panel to call the new updater controller.