### PR TITLE
Add SQLiteData initial setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
 
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'
       run: |
-        /Applications/Xcode_26.2.app/Contents/Developer/usr/bin/xcodebuild \
+        /Applications/Xcode_26.5.app/Contents/Developer/usr/bin/xcodebuild \
           build \
           -project Clipy.xcodeproj \
           -scheme Clipy \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,8 @@ jobs:
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO \
-          -skipPackagePluginValidation
+          -skipPackagePluginValidation \
+          -skipMacroValidation
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,6 +35,7 @@ disabled_rules:
 identifier_name:
   excluded:
     - i
+    - id
 line_length: 300
 type_body_length:
   - 300
@@ -45,3 +46,7 @@ file_length:
 function_body_length:
   warning: 100
   error: 200
+type_name:
+  excluded:
+    - id
+    - ID

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -103,13 +103,11 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		FAC43E1D1B35DF4A00C06102 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolder = Frameworks;
 			files = (
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -225,7 +223,6 @@
 /* Begin PBXFrameworksBuildPhase section */
 		FAC43DC31B35D8B100C06102 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */,
 				C5E3D0512FB43570005D632A /* Screeen in Frameworks */,
@@ -246,14 +243,11 @@
 				C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */,
 				C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		FAC43DD51B35D8B100C06102 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -593,7 +587,6 @@
 				};
 			};
 			buildConfigurationList = FAC43DC11B35D8B100C06102 /* Build configuration list for PBXProject "Clipy" */;
-			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -620,6 +613,7 @@
 				C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */,
 				C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */,
 			);
+			preferredProjectObjectVersion = 46;
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -633,7 +627,6 @@
 /* Begin PBXResourcesBuildPhase section */
 		FAC43DC41B35D8B100C06102 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
 				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
@@ -651,21 +644,17 @@
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
 				FA1DB5221DDCB4C0007F95C8 /* CPYSnippetsEditorWindowController.xib in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		FAC43DD61B35D8B100C06102 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		FAC43DC21B35D8B100C06102 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */,
 				FA1DB4A61DDCB443007F95C8 /* MenuType.swift in Sources */,
@@ -712,18 +701,15 @@
 				FAE911BB1DE054F1008A4BEC /* NSCoding+Archive.swift in Sources */,
 				FA3778951F3B6920003B5BAB /* Environment.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		FAC43DD41B35D8B100C06102 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				FA6167921D3ABEB10049FA14 /* FolderTests.swift in Sources */,
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */,
 				FA6167961D3ACDD80049FA14 /* SnippetTests.swift in Sources */,
 				FA6167941D3ACCB90049FA14 /* DraggedDataTests.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -855,7 +841,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		FAC43DE01B35D8B100C06102 /* Debug */ = {
+		FAC43DE01B35D8B100C06102 /* Debug configuration for PBXProject "Clipy" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -913,7 +899,7 @@
 			};
 			name = Debug;
 		};
-		FAC43DE11B35D8B100C06102 /* Release */ = {
+		FAC43DE11B35D8B100C06102 /* Release configuration for PBXProject "Clipy" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -964,7 +950,7 @@
 			};
 			name = Release;
 		};
-		FAC43DE31B35D8B100C06102 /* Debug */ = {
+		FAC43DE31B35D8B100C06102 /* Debug configuration for PBXNativeTarget "Clipy" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -992,7 +978,7 @@
 			};
 			name = Debug;
 		};
-		FAC43DE41B35D8B100C06102 /* Release */ = {
+		FAC43DE41B35D8B100C06102 /* Release configuration for PBXNativeTarget "Clipy" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -1021,7 +1007,7 @@
 			};
 			name = Release;
 		};
-		FAC43DE61B35D8B100C06102 /* Debug */ = {
+		FAC43DE61B35D8B100C06102 /* Debug configuration for PBXNativeTarget "ClipyTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -1049,7 +1035,7 @@
 			};
 			name = Debug;
 		};
-		FAC43DE71B35D8B100C06102 /* Release */ = {
+		FAC43DE71B35D8B100C06102 /* Release configuration for PBXNativeTarget "ClipyTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -1079,28 +1065,25 @@
 		FAC43DC11B35D8B100C06102 /* Build configuration list for PBXProject "Clipy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FAC43DE01B35D8B100C06102 /* Debug */,
-				FAC43DE11B35D8B100C06102 /* Release */,
+				FAC43DE01B35D8B100C06102 /* Debug configuration for PBXProject "Clipy" */,
+				FAC43DE11B35D8B100C06102 /* Release configuration for PBXProject "Clipy" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		FAC43DE21B35D8B100C06102 /* Build configuration list for PBXNativeTarget "Clipy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FAC43DE31B35D8B100C06102 /* Debug */,
-				FAC43DE41B35D8B100C06102 /* Release */,
+				FAC43DE31B35D8B100C06102 /* Debug configuration for PBXNativeTarget "Clipy" */,
+				FAC43DE41B35D8B100C06102 /* Release configuration for PBXNativeTarget "Clipy" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		FAC43DE51B35D8B100C06102 /* Build configuration list for PBXNativeTarget "ClipyTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FAC43DE61B35D8B100C06102 /* Debug */,
-				FAC43DE71B35D8B100C06102 /* Release */,
+				FAC43DE61B35D8B100C06102 /* Debug configuration for PBXNativeTarget "ClipyTests" */,
+				FAC43DE71B35D8B100C06102 /* Release configuration for PBXNativeTarget "ClipyTests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
@@ -1113,6 +1096,9 @@
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.6.1;
 			};
+			traits = (
+				SQLiteDataTagged,
+			);
 		};
 		C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C576AD7B2FBD345000B71213 /* Localizable.xcstrings */; };
+		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
 		C5D220A82FBD2655005CD45E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D220A72FBD2655005CD45E /* RealmSwift */; };
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
@@ -74,8 +75,8 @@
 		FA6167921D3ABEB10049FA14 /* FolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderTests.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataTests.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetTests.swift */; };
-		FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
-		FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5141C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		FAA4BCCC2163DC9100FF5D18 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4BCCB2163DC9100FF5D18 /* AccessibilityService.swift */; };
 		FAC0DCE91DE15FD900309C49 /* DataCleanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCE81DE15FD900309C49 /* DataCleanService.swift */; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
@@ -226,6 +227,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */,
 				C5E3D0512FB43570005D632A /* Screeen in Frameworks */,
 				FAC43E2B1B35DFDF00C06102 /* WebKit.framework in Frameworks */,
 				C5D76DAB2FBA9D2E0083839F /* SwiftHEXColors in Frameworks */,
@@ -616,6 +618,7 @@
 				C5D76DA92FBA9D2E0083839F /* XCRemoteSwiftPackageReference "SwiftHEXColors" */,
 				C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */,
 				C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */,
+				C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */,
 			);
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
 			projectDirPath = "";
@@ -633,7 +636,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1DB5131DDCB4C0007F95C8 /* CPYPreferencesWindowController.xib in Resources */,
-				FA6DD5141C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5141C7DEDB600317E73 /* (null) in Resources */,
 				FA1DB51E1DDCB4C0007F95C8 /* CPYTypePreferenceViewController.xib in Resources */,
 				FA1DB4901DDCA5D9007F95C8 /* Assets.xcassets in Resources */,
 				FA1DB51D1DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.xib in Resources */,
@@ -642,7 +645,7 @@
 				FA1DB51B1DDCB4C0007F95C8 /* CPYGeneralPreferenceViewController.xib in Resources */,
 				FA1DB51A1DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.xib in Resources */,
 				FA1DB5191DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.xib in Resources */,
-				FA6DD5151C7DEDB600317E73 /* BuildFile in Resources */,
+				FA6DD5151C7DEDB600317E73 /* (null) in Resources */,
 				C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */,
 				FA1DB4941DDCB22C007F95C8 /* dsa_pub.pem in Resources */,
 				FA1DB49F1DDCB417007F95C8 /* MainMenu.xib in Resources */,
@@ -727,11 +730,11 @@
 /* Begin PBXTargetDependency section */
 		C5A4B2022FC9D76000B71510 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
 		};
 		C5A4B2032FC9D76000B71510 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */;
 		};
 		FAC43DDA1B35D8B100C06102 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1103,6 +1106,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/sqlite-data";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 1.6.1;
+			};
+		};
 		C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
@@ -1202,7 +1213,12 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C5A4B2012FC9D76000B71510 /* plugin:SwiftLintBuildToolPlugin */ = {
+		C587AF502FBF4E040043D5E7 /* SQLiteData */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */;
+			productName = SQLiteData;
+		};
+		C5A4B2012FC9D76000B71510 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C54C29D52FC3E20000EF30FB /* SQLiteDataDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */; };
+		C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */; };
+		C54C29D92FC3E22000EF30FB /* SQLIteDataSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D82FC3E21A00EF30FB /* SQLIteDataSchema.swift */; };
 		C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C576AD7B2FBD345000B71213 /* Localizable.xcstrings */; };
 		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
@@ -143,6 +146,9 @@
 		8460049C1FD5511900BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CPYTypePreferenceViewController.strings; sourceTree = "<group>"; };
 		8460049D1FD5511A00BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CPYUpdatesPreferenceViewController.strings; sourceTree = "<group>"; };
 		8460049E1FD5511A00BA733E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CPYSnippetsEditorWindowController.strings; sourceTree = "<group>"; };
+		C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataDatabase.swift; sourceTree = "<group>"; };
+		C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataMigrator.swift; sourceTree = "<group>"; };
+		C54C29D82FC3E21A00EF30FB /* SQLIteDataSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLIteDataSchema.swift; sourceTree = "<group>"; };
 		C576AD7B2FBD345000B71213 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
@@ -264,6 +270,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		C54C29D32FC3E1F500EF30FB /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */,
+				C54C29D82FC3E21A00EF30FB /* SQLIteDataSchema.swift */,
+				C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
 		FA06D2D21DD882BD002FB7C2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -298,6 +314,7 @@
 		FA1DB49C1DDCB3FB007F95C8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C54C29D32FC3E1F500EF30FB /* Database */,
 				FA3778911F3B690D003B5BAB /* Environments */,
 				FA0D5CE61DDCC5D000AC9052 /* Services */,
 				FA1DB4EC1DDCB4C0007F95C8 /* Preferences */,
@@ -658,6 +675,7 @@
 			files = (
 				FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */,
 				FA1DB4A61DDCB443007F95C8 /* MenuType.swift in Sources */,
+				C54C29D52FC3E20000EF30FB /* SQLiteDataDatabase.swift in Sources */,
 				FA1DB4B31DDCB452007F95C8 /* Array+Remove.swift in Sources */,
 				FA3778931F3B691A003B5BAB /* AppEnvironment.swift in Sources */,
 				FAC0DCF11DE576F300309C49 /* PasteService.swift in Sources */,
@@ -686,6 +704,7 @@
 				FA1DB4D41DDCB479007F95C8 /* CPYClipData.swift in Sources */,
 				FA1DB4B71DDCB452007F95C8 /* NSImage+Resize.swift in Sources */,
 				FA1DB4D51DDCB479007F95C8 /* CPYDraggedData.swift in Sources */,
+				C54C29D92FC3E22000EF30FB /* SQLIteDataSchema.swift in Sources */,
 				FA1DB5151DDCB4C0007F95C8 /* CPYExcludeAppPreferenceViewController.swift in Sources */,
 				FA1DB4EA1DDCB49C007F95C8 /* CPYSnippetsEditorCell.swift in Sources */,
 				FA1DB5161DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.swift in Sources */,
@@ -699,6 +718,7 @@
 				FA1DB4BB1DDCB452007F95C8 /* Realm+Migration.swift in Sources */,
 				FA1DB5121DDCB4C0007F95C8 /* CPYPreferencesWindowController.swift in Sources */,
 				FAE911BB1DE054F1008A4BEC /* NSCoding+Archive.swift in Sources */,
+				C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */,
 				FA3778951F3B6920003B5BAB /* Environment.swift in Sources */,
 			);
 		};

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88bc53da7c5a113ab128fb22acf6e3f0910a0f62624405ba04bfdcfd5f7f4d59",
+  "originHash" : "d0a676cc2951f0be7aa5b87d4bedb95f73d39e1cdb020476ab489e88de6ef782",
   "pins" : [
     {
       "identity" : "aexml",
@@ -233,6 +233,15 @@
       "state" : {
         "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
         "version" : "603.0.1"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bdbdfacb3bb663a689aa3b004b8a6aed778e16b203648f510da184502801d423",
+  "originHash" : "88bc53da7c5a113ab128fb22acf6e3f0910a0f62624405ba04bfdcfd5f7f4d59",
   "pins" : [
     {
       "identity" : "aexml",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "db806756c989760b35108146381535aec231092b",
         "version" : "4.7.0"
+      }
+    },
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
       }
     },
     {
@@ -110,6 +128,114 @@
       }
     },
     {
+      "identity" : "sqlite-data",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/sqlite-data",
+      "state" : {
+        "revision" : "da3a94ed49c7a30d82853de551c07a93196e8cab",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-structured-queries",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-structured-queries",
+      "state" : {
+        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
+        "version" : "0.31.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
+      }
+    },
+    {
       "identity" : "swifthexcolors",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/thii/SwiftHEXColors",
@@ -125,6 +251,15 @@
       "state" : {
         "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
         "version" : "0.63.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Clipy/Sources/Database/SQLIteDataSchema.swift
+++ b/Clipy/Sources/Database/SQLIteDataSchema.swift
@@ -1,0 +1,81 @@
+//
+//  SQLIteDataSchema.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/05/22.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import SQLiteData
+import Tagged
+
+@Table
+struct PasteboardHistory: Identifiable {
+    typealias ID = Tagged<Self, String>
+
+    @Column(primaryKey: true)
+    let id: ID
+    let title: String
+    @Column(as: [NSPasteboard.PasteboardType].JSONRepresentation.self)
+    let pasteboardTypes: [NSPasteboard.PasteboardType]
+    let updateAt: Int
+}
+
+@Table
+struct PasteboardHistoryAsset: Identifiable {
+    typealias ID = Tagged<Self, String>
+
+    @Column(primaryKey: true)
+    let id: ID
+    let pasteboardHistoryID: PasteboardHistory.ID
+    let pasteboardType: NSPasteboard.PasteboardType
+    let data: Data
+
+    init(pasteboardHistoryID: PasteboardHistory.ID, pasteboardType: NSPasteboard.PasteboardType, data: Data) {
+        self.id = ID(rawValue: "\(pasteboardHistoryID.rawValue)_\(pasteboardType.rawValue)")
+        self.pasteboardHistoryID = pasteboardHistoryID
+        self.pasteboardType = pasteboardType
+        self.data = data
+    }
+}
+
+@Table
+struct PasteboardHistoryThumbnailAsset: Identifiable {
+    @Column(primaryKey: true)
+    let pasteboardHistoryID: PasteboardHistory.ID
+    let data: Data
+    var id: PasteboardHistory.ID { pasteboardHistoryID }
+}
+
+@Table
+struct SnippetFolder: Identifiable {
+    typealias ID = Tagged<Self, UUID>
+
+    @Column(primaryKey: true)
+    let id: ID
+    let title: String
+    let index: Int
+    let isEnabled: Bool
+}
+
+@Table
+struct Snippet: Identifiable {
+    typealias ID = Tagged<Self, UUID>
+
+    @Column(primaryKey: true)
+    let id: ID
+    let folderID: SnippetFolder.ID
+    let title: String
+    let content: String
+    let index: Int
+    let isEnabled: Bool
+}
+
+extension NSPasteboard.PasteboardType: @retroactive SQLiteType {}
+extension NSPasteboard.PasteboardType: @retroactive QueryBindable {}
+extension NSPasteboard.PasteboardType: @retroactive Codable {}

--- a/Clipy/Sources/Database/SQLiteDataDatabase.swift
+++ b/Clipy/Sources/Database/SQLiteDataDatabase.swift
@@ -1,0 +1,71 @@
+//
+//  SQLiteDataDatabase.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/05/22.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Dependencies
+import Foundation
+import SQLiteData
+import SwiftData
+
+enum SQLiteDataDatabase {
+    static func databaseURL() throws -> URL {
+        var applicationSupportDirectory = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        if let bundleIdentifier = Bundle.main.bundleIdentifier {
+            applicationSupportDirectory.append(path: bundleIdentifier)
+            try? FileManager.default.createDirectory(
+                at: applicationSupportDirectory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+        return applicationSupportDirectory.appendingPathComponent("sqlite.db")
+    }
+
+    @available(macOS 14, *)
+    static var isCloudKitEnabled: Bool {
+        ModelConfiguration(groupContainer: .automatic).cloudKitContainerIdentifier != nil
+    }
+}
+
+extension DependencyValues {
+    mutating func bootstrapDatabase() throws {
+        var configuration = Configuration()
+        configuration.prepareDatabase {
+            #if DEBUG
+                $0.trace { print($0.expandedDescription) }
+            #endif
+        }
+        let database = try SQLiteData.defaultDatabase(
+            path: SQLiteDataDatabase.databaseURL().absoluteString,
+            configuration: configuration
+        )
+
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration()
+        try migrator.migrate(database)
+
+        defaultDatabase = database
+        if #available(macOS 14, *), SQLiteDataDatabase.isCloudKitEnabled {
+            defaultSyncEngine = try SyncEngine(
+                for: database,
+                tables: PasteboardHistory.self, PasteboardHistoryAsset.self, PasteboardHistoryThumbnailAsset.self, SnippetFolder.self, Snippet.self,
+                // Keep iCloud synchronization disabled for now. Setting this to true starts
+                // synchronization, and a future release will make this user-configurable.
+                startImmediately: false
+            )
+        }
+    }
+}

--- a/Clipy/Sources/Database/SQLiteDataMigrator.swift
+++ b/Clipy/Sources/Database/SQLiteDataMigrator.swift
@@ -1,0 +1,104 @@
+//
+//  SQLiteDataMigrator.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/05/22.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+
+extension DatabaseMigrator {
+    mutating func registerMigration() {
+        registerMigration("Create initial tables") { database in
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistories" (
+                  "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+                  "title" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '',
+                  "pasteboardTypes" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '[]',
+                  "updateAt" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT (unixepoch())
+                ) STRICT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistoryAssets" (
+                  "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+                  "pasteboardHistoryID" TEXT NOT NULL,
+                  "pasteboardType" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '',
+                  "data" BLOB NOT NULL,
+                  FOREIGN KEY ("pasteboardHistoryID")
+                    REFERENCES "pasteboardHistories" ("id")
+                    ON DELETE CASCADE
+                ) STRICT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE INDEX "index_pasteboardHistoryAssets_on_pasteboardHistoryID"
+                ON "pasteboardHistoryAssets" ("pasteboardHistoryID")
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistoryThumbnailAssets" (
+                  "pasteboardHistoryID" TEXT PRIMARY KEY NOT NULL,
+                  "data" BLOB NOT NULL,
+                  FOREIGN KEY ("pasteboardHistoryID")
+                    REFERENCES "pasteboardHistories" ("id")
+                    ON DELETE CASCADE
+                ) STRICT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TABLE "snippetFolders" (
+                  "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+                  "title" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '',
+                  "index" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0,
+                  "isEnabled" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 1
+                ) STRICT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TABLE "snippets" (
+                  "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+                  "folderID" TEXT NOT NULL,
+                  "title" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '',
+                  "content" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT '',
+                  "index" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0,
+                  "isEnabled" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 1,
+                  FOREIGN KEY ("folderID")
+                    REFERENCES "snippetFolders" ("id")
+                    ON DELETE CASCADE
+                ) STRICT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE INDEX "index_snippets_on_folderID"
+                ON "snippets" ("folderID")
+                """
+            )
+            .execute(database)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ __Distribution Site__ : <https://clipy-app.com>
 
 ### Development Environment
 * macOS 26 Tahoe
-* Xcode 26.2
+* Xcode 26.5
 
 ### How to Build
 1. Open `Clipy.xcodeproj` on Xcode.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,7 @@ platform :mac do
       skip_build: true,
       verbose: true,
       clean: true,
-      xcargs: "-skipPackagePluginValidation"
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
   end
 


### PR DESCRIPTION
## Summary

This adds the initial SQLiteData setup needed before wiring any runtime usage into the app:

- Adds SQLiteData schema definitions for pasteboard histories, assets, snippet folders, and snippets.
- Adds database bootstrap and migration registration.
- Adds the initial table migration and project references.
- Keeps CloudKit sync from starting immediately.

The app does not use this database path yet. This PR only prepares the SQLiteData foundation.

## Background

For the future iCloud synchronization work, this switches the persistence preparation toward `sqlite-data`, which internally uses GRDB. That gives us a SQLite-backed model while keeping a path open for CloudKit sync in a later step.

## Related

Related: https://github.com/Clipy/Clipy/issues/595