### PR TITLE
Cache Swift packages in GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,14 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    - name: Cache Swift packages
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .spm-cache
+        key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          spm-${{ runner.os }}-
+
     - name: Setup ruby
       uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
       with:
@@ -18,5 +26,7 @@ jobs:
         bundler-cache: true
 
     - name: Run fastlane
+      env:
+        SCAN_CLONED_SOURCE_PACKAGES_PATH: ${{ github.workspace }}/.spm-cache/SourcePackages
+        SCAN_PACKAGE_CACHE_PATH: ${{ github.workspace }}/.spm-cache/PackageCache
       run: bundle exec fastlane test
-    

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,15 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    - name: Cache Swift packages
+      if: matrix.language == 'swift'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .spm-cache
+        key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          spm-${{ runner.os }}-
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
@@ -51,6 +60,8 @@ jobs:
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO \
+          -clonedSourcePackagesDirPath "$GITHUB_WORKSPACE/.spm-cache/SourcePackages" \
+          -packageCachePath "$GITHUB_WORKSPACE/.spm-cache/PackageCache" \
           -skipPackagePluginValidation \
           -skipMacroValidation
 


### PR DESCRIPTION
## Summary

This adds Swift Package Manager caching to GitHub Actions:

- Caches the workflow-local `.spm-cache` directory with `actions/cache`.
- Keys the cache by OS and `Package.resolved` content.
- Restores broader same-OS SPM caches when the exact package lock cache is unavailable.
- Points Fastlane scan to the cached Swift package checkout and package cache paths via Actions environment variables.
- Points the CodeQL Swift build at the same cached paths with `xcodebuild` arguments.

The local Fastlane configuration remains unchanged; the cache behavior is configured only in GitHub Actions.