### PR TITLE
Use Info.plist feed URL for Sparkle

### DIFF
--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -189,6 +189,7 @@ extension AppDelegate: NSApplicationDelegate {
             userDriverDelegate: nil
         )
         updaterController?.updater.updateCheckInterval = TimeInterval(AppEnvironment.current.defaults.integer(forKey: Constants.Update.checkInterval))
+        updaterController?.updater.clearFeedURLFromUserDefaults()
 
         // Binding Events
         bind()

--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -20,7 +20,6 @@ struct Constants {
         #else
             static let name = "Clipy"
         #endif
-        static let appcastURL = URL(string: "https://clipy-app.com/appcast.xml")!
     }
 
     struct Menu {


### PR DESCRIPTION
## Summary
- Remove the hard-coded Sparkle appcast URL constant now that the feed URL is provided by `SUFeedURL` in `Info.plist`.
- Clear any previously persisted Sparkle feed URL from user defaults after the updater starts, so Sparkle falls back to the bundle Info.plist value.

## Notes
- Confirmed `Clipy/Supporting Files/Info.plist` defines `SUFeedURL` as `https://clipy-app.com/appcast.xml`.
- Confirmed no remaining `appcastURL`, `setFeedURL`, or runtime `feedURL` references in app/test sources.
- Ran `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug build` successfully. The build still reports pre-existing warnings unrelated to this change.