### PR TITLE
Verify Apple Silicon build in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,3 +32,23 @@ jobs:
           -skipPackagePluginValidation \
           -skipMacroValidation \
           clean test
+
+    - name: Verify Apple Silicon build
+      run: |
+        xcodebuild \
+          CODE_SIGN_IDENTITY=- \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          ARCHS=arm64 \
+          ONLY_ACTIVE_ARCH=NO \
+          -scheme Clipy \
+          -project Clipy.xcodeproj \
+          -configuration Release \
+          -derivedDataPath "$GITHUB_WORKSPACE/build" \
+          -clonedSourcePackagesDirPath "$GITHUB_WORKSPACE/.spm-cache/SourcePackages" \
+          -packageCachePath "$GITHUB_WORKSPACE/.spm-cache/PackageCache" \
+          -skipPackagePluginValidation \
+          -skipMacroValidation \
+          clean build
+
+        lipo -verify_arch arm64 "$GITHUB_WORKSPACE/build/Build/Products/Release/Clipy.app/Contents/MacOS/Clipy"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,4 +51,5 @@ jobs:
           -skipMacroValidation \
           clean build
 
-        lipo -verify_arch arm64 "$GITHUB_WORKSPACE/build/Build/Products/Release/Clipy.app/Contents/MacOS/Clipy"
+        binary="$GITHUB_WORKSPACE/build/Build/Products/Release/Clipy.app/Contents/MacOS/Clipy"
+        lipo "$binary" -verify_arch arm64


### PR DESCRIPTION
## Summary
- Add a CI step that builds Clipy Release for arm64
- Verify the produced app binary contains an Apple Silicon slice with lipo

## Motivation
Rosetta support for Intel-based apps is being phased out in future macOS releases, so CI should catch regressions that would prevent Clipy from producing an Apple Silicon-native build.

## Testing
- YAML parsed locally
- Local xcodebuild was not run because this machine's Xcode cannot open the current project file format