### PR TITLE
Fix thumbnail aspect fitting

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		C57100052FCEB01000C8F965 /* PasteboardHistoryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100042FCEB01000C8F965 /* PasteboardHistoryRepositoryTests.swift */; };
 		C57100072FCEB02000C8F965 /* PasteboardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100062FCEB02000C8F965 /* PasteboardContent.swift */; };
 		C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */; };
+		C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */; };
 		C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C576AD7B2FBD345000B71213 /* Localizable.xcstrings */; };
 		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
@@ -171,6 +172,7 @@
 		C57100042FCEB01000C8F965 /* PasteboardHistoryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardHistoryRepositoryTests.swift; sourceTree = "<group>"; };
 		C57100062FCEB02000C8F965 /* PasteboardContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardContent.swift; sourceTree = "<group>"; };
 		C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardContentTests.swift; sourceTree = "<group>"; };
+		C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+ResizeTests.swift"; sourceTree = "<group>"; };
 		C576AD7B2FBD345000B71213 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
@@ -344,6 +346,14 @@
 				C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		C571000D2FCEB44000C8F965 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		FA06D2D21DD882BD002FB7C2 /* Resources */ = {
@@ -591,6 +601,7 @@
 			isa = PBXGroup;
 			children = (
 				C5700B472FC5C0DB00C8F965 /* Database */,
+				C571000D2FCEB44000C8F965 /* Extensions */,
 				C571000C2FCEB03000C8F965 /* Models */,
 				C5700B4F2FC5C8C800C8F965 /* Repositories */,
 				FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */,
@@ -814,6 +825,7 @@
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */,
 				FA6167941D3ACCB90049FA14 /* DraggedDataTests.swift in Sources */,
 				C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */,
+				C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */,
 				C57100052FCEB01000C8F965 /* PasteboardHistoryRepositoryTests.swift in Sources */,
 				C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */,
 				C57100012FCAE00000C8F965 /* SnippetRepositoryTests.swift in Sources */,

--- a/Clipy/Sources/Extensions/NSImage+Resize.swift
+++ b/Clipy/Sources/Extensions/NSImage+Resize.swift
@@ -15,64 +15,66 @@ import Cocoa
 
 extension NSImage {
     func resizeImage(_ width: CGFloat, _ height: CGFloat) -> NSImage? {
-
-        let representations = self.representations
-        var bitmapRep: NSBitmapImageRep?
-
-        for rep in representations {
-            if let rep = rep as? NSBitmapImageRep {
-                bitmapRep = rep
-                break
-            }
-        }
-
-        if bitmapRep == nil {
+        guard let newSize = aspectFitSize(width, height, allowsUpscaling: false),
+              let cgImage = self.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
 
-        let origWidth = CGFloat(bitmapRep!.pixelsWide)
-        let origHeight = CGFloat(bitmapRep!.pixelsHigh)
+        let originalPixelWidth = CGFloat(cgImage.width)
+        let originalPixelHeight = CGFloat(cgImage.height)
+        let ratio = min(newSize.width / size.width, newSize.height / size.height)
+        let newPixelWidth = max(1, Int(floor(originalPixelWidth * ratio)))
+        let newPixelHeight = max(1, Int(floor(originalPixelHeight * ratio)))
 
-        let aspect = CGFloat(origWidth) / CGFloat(origHeight)
-
-        let targetWidth = width
-        let targetHeight = height
-        var newWidth: CGFloat
-        var newHeight: CGFloat
-
-        if aspect >= 1 {
-            newWidth = targetWidth
-            newHeight = newWidth / aspect
-
-            if targetHeight < newHeight {
-                newHeight = targetHeight
-                newWidth = targetHeight * aspect
-            }
-        } else {
-            newHeight = targetHeight
-            newWidth = targetHeight * aspect
-
-            if targetWidth < newWidth {
-                newWidth = targetWidth
-                newHeight = targetWidth / aspect
-            }
-        }
-
-        if origWidth < newWidth {
-            newWidth = origWidth
-        }
-        if origHeight < newHeight {
-            newHeight = origHeight
-        }
-
-        let newImageRep = self.bestRepresentation(for: NSRect(x: 0, y: 0, width: newWidth, height: newHeight), context: nil, hints: nil)
-        if newImageRep == nil {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: newPixelWidth,
+            height: newPixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
             return nil
         }
 
-        let thumbnail = NSImage(size: NSSize(width: newWidth, height: newHeight))
-        thumbnail.addRepresentation(newImageRep!)
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newPixelWidth, height: newPixelHeight))
+
+        guard let resizedCGImage = context.makeImage() else {
+            return nil
+        }
+
+        let thumbnail = NSImage(size: newSize)
+        let bitmapRep = NSBitmapImageRep(cgImage: resizedCGImage)
+        bitmapRep.size = newSize
+        thumbnail.addRepresentation(bitmapRep)
 
         return thumbnail
+    }
+
+    func aspectFitImage(_ width: CGFloat, _ height: CGFloat) -> NSImage? {
+        guard let newSize = aspectFitSize(width, height, allowsUpscaling: true),
+              let image = copy() as? NSImage else {
+            return nil
+        }
+
+        image.size = newSize
+        return image
+    }
+
+    private func aspectFitSize(_ width: CGFloat, _ height: CGFloat, allowsUpscaling: Bool) -> NSSize? {
+        guard width > 0, height > 0, size.width > 0, size.height > 0 else {
+            return nil
+        }
+
+        let scale = min(width / size.width, height / size.height)
+        let ratio = allowsUpscaling ? scale : min(scale, 1)
+        return NSSize(
+            width: max(1, floor(size.width * ratio)),
+            height: max(1, floor(size.height * ratio))
+        )
     }
 }

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -357,7 +357,9 @@ private extension MenuManager {
            let thumbnailAsset = historyDetail.thumbnailAsset,
            let image = NSImage(data: thumbnailAsset.data),
            (thumbnailAsset.kind == .image && isShowImage) || (thumbnailAsset.kind == .colorCode && isShowColorCode) {
-            menuItem.image = image
+            let width = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.thumbnailWidth)
+            let height = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.thumbnailHeight)
+            menuItem.image = image.aspectFitImage(CGFloat(width), CGFloat(height))
         }
 
         return menuItem

--- a/ClipyTests/Extensions/NSImage+ResizeTests.swift
+++ b/ClipyTests/Extensions/NSImage+ResizeTests.swift
@@ -1,0 +1,56 @@
+//
+//  NSImage+ResizeTests.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/06/03.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Testing
+@testable import Clipy
+
+@MainActor
+@Suite
+struct NSImageResizeTests {
+    @Test
+    func resizeImageDoesNotShrinkImagesThatAlreadyFit() throws {
+        let image = NSImage.create(with: .blue, size: NSSize(width: 20, height: 10))
+
+        let thumbnail = try #require(image.resizeImage(100, 32))
+
+        #expect(thumbnail.size == NSSize(width: 20, height: 10))
+    }
+
+    @Test
+    func aspectFitImageUsesMenuBoundsWithoutDistortingAspectRatio() throws {
+        let wideImage = NSImage.create(with: .blue, size: NSSize(width: 20, height: 10))
+        let squareImage = NSImage.create(with: .red, size: NSSize(width: 20, height: 20))
+
+        let wideFittedImage = try #require(wideImage.aspectFitImage(100, 32))
+        let squareFittedImage = try #require(squareImage.aspectFitImage(100, 32))
+
+        #expect(wideFittedImage.size == NSSize(width: 64, height: 32))
+        #expect(squareFittedImage.size == NSSize(width: 32, height: 32))
+    }
+
+    @Test
+    func aspectFitImagesKeepAtLeastOnePointForExtremeAspectRatios() throws {
+        let wideImage = NSImage.create(with: .blue, size: NSSize(width: 1_000, height: 1))
+        let tallImage = NSImage.create(with: .red, size: NSSize(width: 1, height: 1_000))
+
+        let wideThumbnail = try #require(wideImage.resizeImage(100, 32))
+        let tallThumbnail = try #require(tallImage.resizeImage(100, 32))
+        let wideFittedImage = try #require(wideImage.aspectFitImage(100, 32))
+        let tallFittedImage = try #require(tallImage.aspectFitImage(100, 32))
+
+        #expect(wideThumbnail.size == NSSize(width: 100, height: 1))
+        #expect(tallThumbnail.size == NSSize(width: 1, height: 32))
+        #expect(wideFittedImage.size == NSSize(width: 100, height: 1))
+        #expect(tallFittedImage.size == NSSize(width: 1, height: 32))
+    }
+}


### PR DESCRIPTION
## Summary
- Resize stored thumbnails using point-based aspect fitting so already-fitting images are not shrunk on Retina displays.
- Size menu item images with an aspect-fit copy instead of assigning distorted dimensions.
- Add focused NSImage resize tests, including extreme aspect-ratio coverage.

## Notes
- Menu regeneration and image caching are intentionally left for a follow-up change.
- Checked with `git diff --check` and `xcodebuild test -project Clipy.xcodeproj -scheme Clipy -destination 'platform=macOS' -derivedDataPath /tmp/ClipyDerivedDataNSImageResizeTests -clonedSourcePackagesDirPath /tmp/ClipySourcePackages -jobs 1 COMPILER_INDEX_STORE_ENABLE=NO`.