### PR TITLE
Add Firebase support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+# Firebase
+GoogleService-Info.plist

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -248,9 +248,22 @@
 		FAE911BA1DE054F1008A4BEC /* NSCoding+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCoding+Archive.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		C51993EC2FD14E8F00364620 /* Exceptions for "GoogleService" folder in "Clipy" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				.gitkeep,
+			);
+			target = FAC43DC51B35D8B100C06102 /* Clipy */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C57447452FD142D0000D64D3 /* GoogleService */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C51993EC2FD14E8F00364620 /* Exceptions for "GoogleService" folder in "Clipy" target */,
+			);
 			path = GoogleService;
 			sourceTree = "<group>";
 		};

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		C57447232FD09FC6000D64D3 /* CPYFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471D2FD09FC6000D64D3 /* CPYFolder.swift */; };
 		C57447242FD09FC6000D64D3 /* DatabaseMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471A2FD09FC6000D64D3 /* DatabaseMigration.swift */; };
 		C57447272FD09FD9000D64D3 /* RealmConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57447252FD09FD9000D64D3 /* RealmConfiguration.swift */; };
+		C574472C2FD13ADF000D64D3 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = C574472B2FD13ADF000D64D3 /* FirebaseCrashlytics */; };
+		C574472F2FD13FD9000D64D3 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = C574472E2FD13FD9000D64D3 /* FirebaseAnalyticsCore */; };
 		C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C576AD7B2FBD345000B71213 /* Localizable.xcstrings */; };
 		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
@@ -246,6 +248,14 @@
 		FAE911BA1DE054F1008A4BEC /* NSCoding+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCoding+Archive.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C57447452FD142D0000D64D3 /* GoogleService */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = GoogleService;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		FAC43DC31B35D8B100C06102 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -255,6 +265,7 @@
 				C53FC6C02FCCA1C400219A25 /* Collections in Frameworks */,
 				FAC43E2B1B35DFDF00C06102 /* WebKit.framework in Frameworks */,
 				C5D76DAB2FBA9D2E0083839F /* SwiftHEXColors in Frameworks */,
+				C574472C2FD13ADF000D64D3 /* FirebaseCrashlytics in Frameworks */,
 				FAC43E291B35DFDA00C06102 /* Cocoa.framework in Frameworks */,
 				FAC43E271B35DFD300C06102 /* Carbon.framework in Frameworks */,
 				C5D76DA52FBA98A90083839F /* AEXML in Frameworks */,
@@ -268,6 +279,7 @@
 				C5700B4C2FC5C3D500C8F965 /* Dependencies in Frameworks */,
 				C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */,
 				C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */,
+				C574472F2FD13FD9000D64D3 /* FirebaseAnalyticsCore in Frameworks */,
 				C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */,
 				C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */,
 			);
@@ -609,6 +621,7 @@
 				FA1DB49D1DDCB405007F95C8 /* Xibs */,
 				FA1DB49C1DDCB3FB007F95C8 /* Sources */,
 				FA1DB4911DDCB205007F95C8 /* Supporting Files */,
+				C57447452FD142D0000D64D3 /* GoogleService */,
 			);
 			path = Clipy;
 			sourceTree = "<group>";
@@ -645,16 +658,22 @@
 				FAC43DC21B35D8B100C06102 /* Sources */,
 				FAC43DC31B35D8B100C06102 /* Frameworks */,
 				FAC43DC41B35D8B100C06102 /* Resources */,
+				C574472D2FD13BAF000D64D3 /* Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				C5A4B2022FC9D76000B71510 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				C57447452FD142D0000D64D3 /* GoogleService */,
+			);
 			name = Clipy;
 			packageProductDependencies = (
 				C5700B4B2FC5C3D500C8F965 /* Dependencies */,
 				C53FC6BF2FCCA1C400219A25 /* Collections */,
+				C574472B2FD13ADF000D64D3 /* FirebaseCrashlytics */,
+				C574472E2FD13FD9000D64D3 /* FirebaseAnalyticsCore */,
 			);
 			productName = Clipy;
 			productReference = FAC43DC61B35D8B100C06102 /* Clipy.app */;
@@ -737,6 +756,7 @@
 				C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */,
 				C5700B4A2FC5C3D500C8F965 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
 				C53FC6BE2FCCA1C400219A25 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				C57447282FD13ADF000D64D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 46;
 			productRefGroup = FAC43DC71B35D8B100C06102 /* Products */;
@@ -776,6 +796,34 @@
 			);
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		C574472D2FD13BAF000D64D3 /* Firebase Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+			);
+			name = "Firebase Crashlytics";
+			shellPath = /bin/sh;
+			shellScript = (
+				"GOOGLE_SERVICE_INFO=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"",
+				"",
+				"if [ ! -f \"$GOOGLE_SERVICE_INFO\" ]; then",
+				"  echo \"Skipping Crashlytics: GoogleService-Info.plist is missing.\"",
+				"  exit 0",
+				"fi",
+				"",
+				"\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"",
+				"",
+			);
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		FAC43DC21B35D8B100C06102 /* Sources */ = {
@@ -1127,6 +1175,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Clipy/Supporting Files/Info.plist";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clipy-app.Clipy.debug";
 			};
 			name = Debug;
@@ -1137,6 +1186,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Clipy/Supporting Files/Info.plist";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clipy-app.Clipy";
 			};
 			name = Release;
@@ -1213,6 +1263,14 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.12.0;
+			};
+		};
+		C57447282FD13ADF000D64D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 12.14.0;
 			};
 		};
 		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
@@ -1339,6 +1397,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5700B4A2FC5C3D500C8F965 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
 			productName = DependenciesTestSupport;
+		};
+		C574472B2FD13ADF000D64D3 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C57447282FD13ADF000D64D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		C574472E2FD13FD9000D64D3 /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C57447282FD13ADF000D64D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
 		};
 		C587AF502FBF4E040043D5E7 /* SQLiteData */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "d0a676cc2951f0be7aa5b87d4bedb95f73d39e1cdb020476ab489e88de6ef782",
+  "originHash" : "a3351c55f7a919ac2fc96e9a127386c7a2e3a53e8d17d5281513c83271fe8de0",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
     {
       "identity" : "aexml",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "db806756c989760b35108146381535aec231092b",
         "version" : "4.7.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
       }
     },
     {
@@ -20,6 +38,51 @@
       }
     },
     {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "8d5b4189f1f482df8d5c58c9985ea70491ef5382",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
+        "version" : "3.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "219e564a8510e983e675c94f77f7f7c50049f22d",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
@@ -29,12 +92,48 @@
       }
     },
     {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
       "identity" : "keyholder",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Clipy/KeyHolder",
       "state" : {
         "revision" : "69cfeabc06965bf98d6aa75c5a06c430795e01e4",
         "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -56,6 +155,15 @@
       }
     },
     {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
       "identity" : "pincache",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pinterest/pincache",
@@ -71,6 +179,15 @@
       "state" : {
         "revision" : "a74f978733bdaf982758bfa23d70a189f4b4c1b6",
         "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -97,7 +97,6 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     }
 
     @objc func selectClipMenuItem(_ sender: NSMenuItem) {
-        CPYUtilities.sendCustomLog(with: "selectClipMenuItem")
         guard let id = sender.representedObject as? PasteboardHistory.ID, let content = pasteboardHistoryRepository.fetchContent(id: id) else {
             NSSound.beep()
             return

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -11,6 +11,7 @@
 //
 
 import Cocoa
+import Firebase
 import IOKit
 
 final class CPYUtilities {
@@ -35,11 +36,12 @@ final class CPYUtilities {
     }()
 
     static func initSDKs() {
-        // Fabric
         AppEnvironment.current.defaults.register(defaults: ["NSApplicationCrashOnExceptions": true])
         guard AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.collectCrashReport) else { return }
-        // TODO: - Migrate Firebase Crashlytics
-        CPYUtilities.sendCustomLog(with: "applicationDidFinishLaunching")
+        guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") else { return }
+        guard let options = FirebaseOptions(contentsOfFile: path) else { return }
+        guard FirebaseApp.app() == nil else { return }
+        FirebaseApp.configure(options: options)
     }
 
     static func registerUserDefaultKeys() {
@@ -98,10 +100,5 @@ final class CPYUtilities {
         let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
         let basePath: String = paths.first ?? NSTemporaryDirectory()
         return (basePath as NSString).appendingPathComponent(Constants.Application.name)
-    }
-
-    static func sendCustomLog(with name: String) {
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.collectCrashReport) else { return }
-        // TODO: - Migrate Firebase Crashlytics
     }
 }

--- a/Clipy/Supporting Files/Info.plist
+++ b/Clipy/Supporting Files/Info.plist
@@ -24,6 +24,8 @@
 	<string>1.2.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSApplicationCrashOnExceptions</key>
+	<true/>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,4 +1,4 @@
-# Privacy Policy / プライバシーポリシー
+# Privacy Policy
 
 Last updated: June 4, 2026
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,111 @@
+# Privacy Policy / プライバシーポリシー
+
+Last updated: June 4, 2026
+
+Clipy is a clipboard extension app for macOS. Clipboard data can contain
+sensitive information, so Clipy will never transmit clipboard contents or
+snippet contents to external services without the user's consent.
+
+This policy clarifies whether Clipy collects personally identifying information,
+whether Clipy collects copied contents, and what network communication Clipy
+performs.
+
+## Summary
+
+- Clipy does not ask users to provide names, email addresses, account
+  information, or other directly identifying personal information.
+- Clipy does not transmit clipboard text, clipboard images, snippets, or other
+  copied contents to Clipy servers, Firebase, or any other third-party service.
+- Clipy's intended network communication is limited to update checks via
+  `clipy-app.com` and diagnostics/usage measurement via Firebase.
+- Firebase Analytics / Firebase Crashlytics are enabled by default and can be
+  disabled in Clipy's Preferences.
+
+## Data Stored Locally
+
+Clipy stores clipboard history, snippets, preferences, and related app data
+locally on your Mac.
+
+Clipboard contents and snippets are not sent to external services by Clipy.
+However, clipboard managers can store sensitive information locally. We
+recommend excluding password managers and other sensitive apps from Clipy's
+history recording when possible.
+
+Clipy does not currently claim that locally stored clipboard history is
+encrypted. If your Mac contains sensitive data, we recommend enabling FileVault
+and using macOS security features appropriately.
+
+## Network Communication
+
+Clipy's intended network communication is limited to the following services:
+
+- `clipy-app.com`: used by Sparkle to check for app updates.
+- Firebase: used for analytics and crash reporting.
+
+Clipy does not intentionally use other network services.
+
+## Firebase Analytics
+
+Clipy uses Firebase Analytics to understand basic app usage, such as the number
+of users, app launches, app version, macOS version, language, and general feature
+usage.
+
+Firebase Analytics is enabled by default. You can disable analytics in Clipy's
+Preferences.
+
+Clipy does not use Firebase Analytics to collect user-created or copied content,
+including clipboard contents, snippet contents, file contents, copied secrets,
+or personal information entered by the user.
+
+## Firebase Crashlytics
+
+Clipy uses Firebase Crashlytics to collect crash reports and error diagnostics.
+Crash reports help us understand and fix stability problems.
+
+Crash reports may include information such as:
+
+- App version
+- macOS version
+- Device model or architecture
+- Stack traces
+- Crash timestamps
+- Firebase installation identifiers
+- Diagnostic logs added by Clipy
+
+Clipy does not intentionally include clipboard contents or snippet contents in
+Crashlytics logs, custom keys, or error reports.
+
+You can disable crash reporting in Clipy's Preferences.
+
+## Update Checks
+
+Clipy uses Sparkle to check for updates from `clipy-app.com`. Update checks may
+send standard request information such as the app version, macOS version, and IP
+address to the update server.
+
+## Third-Party Processing
+
+Firebase is provided by Google. Data sent to Firebase is processed according to
+Google's Firebase terms and privacy documentation.
+
+Sparkle is used for update checks. The update feed is hosted by Clipy on
+`clipy-app.com`.
+
+## User Controls
+
+You can enable or disable analytics and crash reporting from Clipy's Preferences.
+
+When disabled, Clipy will stop intentionally sending analytics and crash
+diagnostic data from future app usage. Some previously sent data may remain in
+Firebase according to Firebase's retention policies.
+
+## Changes
+
+This privacy policy may be updated when Clipy's behavior or third-party services
+change.
+
+## Contact
+
+For privacy or security questions, please open an issue on GitHub.
+
+GitHub: https://github.com/Clipy/Clipy

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ macOS checks Accessibility permission by the app's code signature. If Clipy is b
 For this reason, the default signing settings use the Clipy signing certificate. This certificate is available only to the maintainer, so local builds require switching to ad-hoc signing before building.
 
 #### Build for ad-hoc usage
-
 1. Open `Clipy.xcodeproj` in Xcode.
 2. Switch to ad-hoc build mode:
     1. Open `Configurations/CodeSigning.xcconfig`.
     2. Uncomment `#include "Configurations/CodeSigning-AdHoc.xcconfig"`.
 3. Build the `Clipy` scheme.
+
+If you want to use Firebase features, place your own `GoogleService-Info.plist` in `Clipy/GoogleService`. This file is not required for local builds without Firebase.
 
 ### Localization Contributors
 Clipy is looking for localization contributors.  
@@ -48,14 +49,16 @@ If you distribute derived work, especially in the Mac App Store, I ask you to fo
 
 Thank you for your cooperation.
 
-### Backers
+### Privacy Policy
+Please see [PRIVACY.md](./PRIVACY.md) for information about local data storage,
+network communication, analytics, and crash reporting.
 
+### Backers
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/clipy#backer)]
 
 <a href="https://opencollective.com/clipy#backers"><img src="https://opencollective.com/clipy/backers.svg?avatarHeight=36&width=600" /></a>
 
 ### Sponsors
-
 Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/clipy#sponsor)]
 
 <a href="https://opencollective.com/clipy#sponsors"><img src="https://opencollective.com/clipy/sponsors.svg?avatarHeight=36&width=600" /></a>


### PR DESCRIPTION
## Summary

- Add Firebase SDK dependencies and initialize Firebase only when `GoogleService-Info.plist` is bundled.
- Add a Crashlytics run script that skips symbol upload when Firebase configuration is absent.
- Ignore local `GoogleService-Info.plist` files and document where contributors should place their own Firebase configuration.
- Add Firebase-related privacy documentation.

## Impact

Local OSS checkouts can continue to build without `GoogleService-Info.plist`. Firebase features are enabled only for builds that provide their own configuration file in `Clipy/GoogleService`.

## Related

- https://github.com/Clipy/Clipy/issues/507