### PR TITLE
Improve preference persistence and window space behavior

### DIFF
--- a/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
+++ b/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
@@ -85,10 +85,6 @@ extension CPYPreferencesWindowController {
 // MARK: - NSWindow Delegate
 extension CPYPreferencesWindowController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        if let viewController = viewController[2] as? CPYTypePreferenceViewController {
-            AppEnvironment.current.defaults.set(viewController.storeTypes, forKey: Constants.UserDefaults.storeTypes)
-            AppEnvironment.current.defaults.synchronize()
-        }
         if let window = window, !window.makeFirstResponder(window) {
             window.endEditing(for: nil)
         }

--- a/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
+++ b/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
@@ -53,11 +53,8 @@ final class CPYPreferencesWindowController: NSWindowController {
     // MARK: - Window Life Cycle
     override func windowDidLoad() {
         super.windowDidLoad()
-        self.window?.collectionBehavior = .canJoinAllSpaces
         self.window?.backgroundColor = NSColor(white: 0.99, alpha: 1)
-        if #available(OSX 10.10, *) {
-            self.window?.titlebarAppearsTransparent = true
-        }
+        self.window?.titlebarAppearsTransparent = true
         toolBarItemTapped(generalButton)
         generalButton.sendAction(on: .leftMouseDown)
         menuButton.sendAction(on: .leftMouseDown)

--- a/Clipy/Sources/Preferences/Panels/CPYTypePreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYTypePreferenceViewController.swift
@@ -12,8 +12,7 @@
 
 import Cocoa
 
-class CPYTypePreferenceViewController: NSViewController {
-
+final class CPYTypePreferenceViewController: NSViewController {
     // MARK: - Properties
     @objc var storeTypes: NSMutableDictionary!
 
@@ -25,6 +24,20 @@ class CPYTypePreferenceViewController: NSViewController {
             storeTypes = NSMutableDictionary()
         }
         super.loadView()
+        PasteboardAvailableType.allCases.forEach { availableType in
+            storeTypes.addObserver(self, forKeyPath: availableType.rawValue, options: .new, context: nil)
+        }
     }
 
+    deinit {
+        PasteboardAvailableType.allCases.forEach { availableType in
+            storeTypes.removeObserver(self, forKeyPath: availableType.rawValue)
+        }
+    }
+
+    // swiftlint:disable:next block_based_kvo
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        guard let dictionary = object as? NSMutableDictionary, dictionary == storeTypes else { return }
+        AppEnvironment.current.defaults.set(storeTypes, forKey: Constants.UserDefaults.storeTypes)
+    }
 }

--- a/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
+++ b/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
@@ -55,11 +55,8 @@ final class CPYSnippetsEditorWindowController: NSWindowController {
     // MARK: - Window Life Cycle
     override func windowDidLoad() {
         super.windowDidLoad()
-        self.window?.collectionBehavior = NSWindow.CollectionBehavior.canJoinAllSpaces
         self.window?.backgroundColor = NSColor(white: 0.99, alpha: 1)
-        if #available(OSX 10.10, *) {
-            self.window?.titlebarAppearsTransparent = true
-        }
+        self.window?.titlebarAppearsTransparent = true
         folders = snippetRepository.fetchFolderDetails().map(EditorSnippetFolder.init)
         outlineView.reloadData()
         // Select first folder


### PR DESCRIPTION
## Summary

This improves the preference and snippet utility windows by keeping them scoped to the active desktop instead of joining all Spaces.

It also changes store type preferences to persist as soon as the bound dictionary entries change. This removes the delayed save that previously happened only when the preferences window closed, so changes made through the type preference panel are written immediately.

The branch contains two focused commits:

- `Persist store type changes immediately`
- `Keep utility windows on the active desktop`

Built locally with `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug build`. The build succeeded; SwiftLint reported an existing warning in `Constants.swift`.