### PR TITLE
Adjust pasteboard monitoring interval

### DIFF
--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -33,7 +33,7 @@ final class ClipService {
     func startMonitoring() {
         disposeBag = DisposeBag()
         // Pasteboard observe timer
-        Observable<Int>.interval(.microseconds(750), scheduler: scheduler)
+        Observable<Int>.interval(.milliseconds(500), scheduler: scheduler)
             .map { _ in NSPasteboard.general.changeCount }
             .withLatestFrom(cachedChangeCount.asObservable()) { ($0, $1) }
             .filter { $0 != $1 }


### PR DESCRIPTION
## Summary

- Change pasteboard monitoring from 750 microseconds to 500 milliseconds.
- Keep the implementation limited to the polling interval change, without adding retry logic.

## Why

`NSPasteboard.changeCount` can increment before the copied data is fully available. With the current very short polling interval, Clipy can observe the change too early and miss the pasteboard contents. Slowing the interval to 500ms gives the pasteboard more time to expose the data before Clipy reads it.