### PR TITLE
Fix window display and temporary dark mode handling

### DIFF
--- a/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
+++ b/Clipy/Sources/Preferences/CPYPreferencesWindowController.swift
@@ -53,6 +53,8 @@ final class CPYPreferencesWindowController: NSWindowController {
     // MARK: - Window Life Cycle
     override func windowDidLoad() {
         super.windowDidLoad()
+        // Temporarily disable Dark Mode until this window is migrated to SwiftUI.
+        self.window?.appearance = NSAppearance(named: .aqua)
         self.window?.backgroundColor = NSColor(white: 0.99, alpha: 1)
         self.window?.titlebarAppearsTransparent = true
         toolBarItemTapped(generalButton)
@@ -67,7 +69,7 @@ final class CPYPreferencesWindowController: NSWindowController {
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        window?.makeKeyAndOrderFront(self)
+        window?.orderFrontRegardless()
     }
 }
 

--- a/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
+++ b/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
@@ -55,6 +55,8 @@ final class CPYSnippetsEditorWindowController: NSWindowController {
     // MARK: - Window Life Cycle
     override func windowDidLoad() {
         super.windowDidLoad()
+        // Temporarily disable Dark Mode until this window is migrated to SwiftUI.
+        self.window?.appearance = NSAppearance(named: .aqua)
         self.window?.backgroundColor = NSColor(white: 0.99, alpha: 1)
         self.window?.titlebarAppearsTransparent = true
         folders = snippetRepository.fetchFolderDetails().map(EditorSnippetFolder.init)
@@ -68,7 +70,7 @@ final class CPYSnippetsEditorWindowController: NSWindowController {
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        window?.makeKeyAndOrderFront(self)
+        window?.orderFrontRegardless()
     }
 }
 


### PR DESCRIPTION
## Summary

- Use `orderFrontRegardless()` when showing the preferences and snippets editor windows so they reliably come to the front from menu-bar initiated actions.
- Temporarily force the preferences and snippets editor windows to use the Aqua appearance while the current AppKit screens remain in place.

## Dark Mode

Dark Mode support for these screens is intentionally deferred for now. After the next stable release, these screens should support Dark Mode as part of the planned SwiftUI migration.
