### PR TITLE
Support NSPasteboard marker types

### DIFF
--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -67,6 +67,7 @@ struct Constants {
         static let excludeApplications = "kCPYExcludeApplications"
         static let collectCrashReport = "kCPYCollectCrashReport"
         static let showColorPreviewInTheMenu = "kCPYPrefShowColorPreviewInTheMenu"
+        static let ignoreConcealedPasteboardType = "kCPYPrefIgnoreConcealedPasteboardType"
     }
 
     struct Beta {

--- a/Clipy/Sources/Models/PasteboardAvailableType.swift
+++ b/Clipy/Sources/Models/PasteboardAvailableType.swift
@@ -28,6 +28,7 @@ enum PasteboardAvailableType: String, Equatable, CaseIterable {
         storeAvailableTypes: [PasteboardAvailableType]
     ) -> [NSPasteboard.PasteboardType] {
         let uniquePasteboardTypes = OrderedSet(pasteboardTypes)
+        guard uniquePasteboardTypes.allSatisfy({ !$0.isTransient }) else { return [] }
         return uniquePasteboardTypes.compactMap { pasteboardType -> NSPasteboard.PasteboardType? in
             guard let availableType = pasteboardType.availableType,
                 storeAvailableTypes.contains(availableType) else { return nil }
@@ -44,6 +45,16 @@ enum PasteboardAvailableType: String, Equatable, CaseIterable {
 }
 
 private extension NSPasteboard.PasteboardType {
+    // ref: https://nspasteboard.org/
+    var isTransient: Bool {
+        switch rawValue {
+        case "org.nspasteboard.TransientType":
+            return true
+        default:
+            return false
+        }
+    }
+
     var availableType: PasteboardAvailableType? {
         switch self {
         case .string, .deprecatedString:

--- a/Clipy/Sources/Models/PasteboardAvailableType.swift
+++ b/Clipy/Sources/Models/PasteboardAvailableType.swift
@@ -25,11 +25,13 @@ enum PasteboardAvailableType: String, Equatable, CaseIterable {
 
     static func availableTypes(
         from pasteboardTypes: [NSPasteboard.PasteboardType],
-        storeAvailableTypes: [PasteboardAvailableType]
+        storeAvailableTypes: [PasteboardAvailableType],
+        ignoresConcealedType: Bool
     ) -> [NSPasteboard.PasteboardType] {
         let uniquePasteboardTypes = OrderedSet(pasteboardTypes)
-        guard uniquePasteboardTypes.allSatisfy({ !$0.isTransient }) else { return [] }
-        return uniquePasteboardTypes.compactMap { pasteboardType -> NSPasteboard.PasteboardType? in
+        guard uniquePasteboardTypes.allSatisfy({ $0 != .transient }) else { return [] }
+        guard !ignoresConcealedType || uniquePasteboardTypes.allSatisfy({ $0 != .concealed }) else { return [] }
+        let availableTypes = uniquePasteboardTypes.compactMap { pasteboardType -> NSPasteboard.PasteboardType? in
             guard let availableType = pasteboardType.availableType,
                 storeAvailableTypes.contains(availableType) else { return nil }
             if pasteboardType.isCovered(by: uniquePasteboardTypes) {
@@ -41,20 +43,15 @@ enum PasteboardAvailableType: String, Equatable, CaseIterable {
             }
             return pasteboardType
         }
+        guard !availableTypes.isEmpty else { return [] }
+        if uniquePasteboardTypes.contains(.concealed) {
+            return availableTypes + [.concealed]
+        }
+        return availableTypes
     }
 }
 
 private extension NSPasteboard.PasteboardType {
-    // ref: https://nspasteboard.org/
-    var isTransient: Bool {
-        switch rawValue {
-        case "org.nspasteboard.TransientType":
-            return true
-        default:
-            return false
-        }
-    }
-
     var availableType: PasteboardAvailableType? {
         switch self {
         case .string, .deprecatedString:
@@ -107,4 +104,10 @@ private extension NSPasteboard.PasteboardType {
             return false
         }
     }
+}
+
+// ref: https://nspasteboard.org/
+extension NSPasteboard.PasteboardType {
+    static let transient = NSPasteboard.PasteboardType(rawValue: "org.nspasteboard.TransientType")
+    static let concealed = NSPasteboard.PasteboardType(rawValue: "org.nspasteboard.ConcealedType")
 }

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYTypePreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYTypePreferenceViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,18 +14,18 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="195"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="245"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box fixedFrame="YES" title="Select clipboard types to store:" translatesAutoresizingMaskIntoConstraints="NO" id="lSu-gq-grM">
-                    <rect key="frame" x="76" y="8" width="329" height="175"/>
+                    <rect key="frame" x="55" y="58" width="370" height="175"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <view key="contentView" id="kTH-wN-yAh">
-                        <rect key="frame" x="2" y="2" width="325" height="158"/>
+                        <rect key="frame" x="0.0" y="0.0" width="370" height="163"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hjR-M0-hZo" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="132" width="238" height="18"/>
+                                <rect key="frame" x="14" y="133" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Plain Text" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="9wr-mR-kmC">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -36,7 +36,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xza-Mm-bci" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="112" width="238" height="18"/>
+                                <rect key="frame" x="14" y="113" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Rich Text Format (RTF)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="xyj-FL-88b">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -47,7 +47,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oMv-K0-koZ" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="92" width="238" height="18"/>
+                                <rect key="frame" x="14" y="93" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Rich Text Format Directory (RTFD)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Nvy-pc-6hl">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -58,7 +58,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oOc-3g-cCd" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="72" width="238" height="18"/>
+                                <rect key="frame" x="14" y="73" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="PDF" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="27s-8p-tdh">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -69,7 +69,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ItL-b5-KT6" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="52" width="238" height="18"/>
+                                <rect key="frame" x="14" y="53" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Filenames" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="iO6-7x-OcH">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -80,7 +80,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AzQ-w6-3Sl" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
-                                <rect key="frame" x="14" y="32" width="238" height="18"/>
+                                <rect key="frame" x="14" y="33" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="URL" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="oXv-rM-kj5">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -91,7 +91,7 @@
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rf8-b9-Ehw">
-                                <rect key="frame" x="15" y="11" width="238" height="18"/>
+                                <rect key="frame" x="15" y="12" width="238" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="TIFF Image" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="lZ0-qQ-qWk">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -104,8 +104,28 @@
                         </subviews>
                     </view>
                 </box>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pY7-uO-7yK" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
+                    <rect key="frame" x="70" y="30" width="340" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Ignore clipboard data marked as Concealed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="wVB-cH-qgn">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="titleBar" size="12"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="B2y-4u-3Av" name="value" keyPath="values.kCPYPrefIgnoreConcealedPasteboardType" id="Io0-jT-y9h"/>
+                    </connections>
+                </button>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ecW-2l-hjR">
+                    <rect key="frame" x="68" y="15" width="344" height="14"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="For confidential data, such as from password managers." id="gXw-o2-02L">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
-            <point key="canvasLocation" x="623" y="576.5"/>
+            <point key="canvasLocation" x="623" y="591.5"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="B2y-4u-3Av"/>
     </objects>

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYTypePreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYTypePreferenceViewController.xib
@@ -29,7 +29,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Plain Text" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="9wr-mR-kmC">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.String" id="f5i-QI-5o3"/>
@@ -40,7 +40,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Rich Text Format (RTF)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="xyj-FL-88b">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.RTF" id="WhO-jO-eDv"/>
@@ -51,7 +51,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Rich Text Format Directory (RTFD)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Nvy-pc-6hl">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.RTFD" id="u86-Vg-Rmf"/>
@@ -62,7 +62,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="PDF" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="27s-8p-tdh">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.PDF" id="8uM-EG-QXe"/>
@@ -73,7 +73,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Filenames" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="iO6-7x-OcH">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.Filenames" id="J1C-Pq-hAJ"/>
@@ -84,7 +84,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="URL" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="oXv-rM-kj5">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.URL" id="z8D-08-Vwx"/>
@@ -95,7 +95,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="TIFF Image" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="lZ0-qQ-qWk">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="storeTypes.TIFF" id="qV0-bb-2SN"/>
@@ -109,7 +109,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore clipboard data marked as Concealed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="wVB-cH-qgn">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="titleBar" size="12"/>
+                        <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
                         <binding destination="B2y-4u-3Av" name="value" keyPath="values.kCPYPrefIgnoreConcealedPasteboardType" id="Io0-jT-y9h"/>

--- a/Clipy/Sources/Preferences/Panels/de.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/de.lproj/CPYTypePreferenceViewController.strings
@@ -20,5 +20,11 @@
 /* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
 "oXv-rM-kj5.title" = "URL";
 
+/* Class = "NSButtonCell"; title = "Ignore clipboard data marked as Concealed"; ObjectID = "wVB-cH-qgn"; */
+"wVB-cH-qgn.title" = "Ignore clipboard data marked as Concealed";
+
+/* Class = "NSTextFieldCell"; title = "For confidential data, such as from password managers."; ObjectID = "gXw-o2-02L"; */
+"gXw-o2-02L.title" = "For confidential data, such as from password managers.";
+
 /* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
 "xyj-FL-88b.title" = "Rich Text Format (RTF)";

--- a/Clipy/Sources/Preferences/Panels/it.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/it.lproj/CPYTypePreferenceViewController.strings
@@ -20,5 +20,11 @@
 /* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
 "oXv-rM-kj5.title" = "URL";
 
+/* Class = "NSButtonCell"; title = "Ignore clipboard data marked as Concealed"; ObjectID = "wVB-cH-qgn"; */
+"wVB-cH-qgn.title" = "Ignore clipboard data marked as Concealed";
+
+/* Class = "NSTextFieldCell"; title = "For confidential data, such as from password managers."; ObjectID = "gXw-o2-02L"; */
+"gXw-o2-02L.title" = "For confidential data, such as from password managers.";
+
 /* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
 "xyj-FL-88b.title" = "RTF";

--- a/Clipy/Sources/Preferences/Panels/ja.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/ja.lproj/CPYTypePreferenceViewController.strings
@@ -20,5 +20,11 @@
 /* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
 "oXv-rM-kj5.title" = "URL";
 
+/* Class = "NSButtonCell"; title = "Ignore clipboard data marked as Concealed"; ObjectID = "wVB-cH-qgn"; */
+"wVB-cH-qgn.title" = "機密とマークされたクリップボードデータを無視";
+
+/* Class = "NSTextFieldCell"; title = "For confidential data, such as from password managers."; ObjectID = "gXw-o2-02L"; */
+"gXw-o2-02L.title" = "パスワードマネージャーなどの機密データ向けです。";
+
 /* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
 "xyj-FL-88b.title" = "リッチテキストフォーマット";

--- a/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYTypePreferenceViewController.strings
@@ -20,5 +20,11 @@
 /* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
 "oXv-rM-kj5.title" = "URL";
 
+/* Class = "NSButtonCell"; title = "Ignore clipboard data marked as Concealed"; ObjectID = "wVB-cH-qgn"; */
+"wVB-cH-qgn.title" = "Ignore clipboard data marked as Concealed";
+
+/* Class = "NSTextFieldCell"; title = "For confidential data, such as from password managers."; ObjectID = "gXw-o2-02L"; */
+"gXw-o2-02L.title" = "For confidential data, such as from password managers.";
+
 /* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
 "xyj-FL-88b.title" = "Formato Rich Text (RTF)";

--- a/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYTypePreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYTypePreferenceViewController.strings
@@ -20,5 +20,11 @@
 /* Class = "NSButtonCell"; title = "URL"; ObjectID = "oXv-rM-kj5"; */
 "oXv-rM-kj5.title" = "URL";
 
+/* Class = "NSButtonCell"; title = "Ignore clipboard data marked as Concealed"; ObjectID = "wVB-cH-qgn"; */
+"wVB-cH-qgn.title" = "Ignore clipboard data marked as Concealed";
+
+/* Class = "NSTextFieldCell"; title = "For confidential data, such as from password managers."; ObjectID = "gXw-o2-02L"; */
+"gXw-o2-02L.title" = "For confidential data, such as from password managers.";
+
 /* Class = "NSButtonCell"; title = "Rich Text Format (RTF)"; ObjectID = "xyj-FL-88b"; */
 "xyj-FL-88b.title" = "多信息文本格式（RTF）";

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -82,7 +82,8 @@ extension ClipService {
         // then let PasteboardAvailableType filter the storeable types.
         let types = PasteboardAvailableType.availableTypes(
             from: pasteboard.types ?? pasteboard.pasteboardItems?.flatMap(\.types) ?? [],
-            storeAvailableTypes: storeTypes.filter { $0.value.boolValue }.compactMap { PasteboardAvailableType(rawValue: $0.key) }
+            storeAvailableTypes: storeTypes.filter { $0.value.boolValue }.compactMap { PasteboardAvailableType(rawValue: $0.key) },
+            ignoresConcealedType: AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.ignoreConcealedPasteboardType)
         )
         guard !types.isEmpty else { return }
 

--- a/Clipy/Sources/Services/ExcludeAppService.swift
+++ b/Clipy/Sources/Services/ExcludeAppService.swift
@@ -36,6 +36,7 @@ extension ExcludeAppService {
         // Monitoring top active application
         NSWorkspace.shared.notificationCenter.rx.notification(NSWorkspace.didActivateApplicationNotification)
             .map { $0.userInfo?["NSWorkspaceApplicationKey"] as? NSRunningApplication }
+            .startWith(NSWorkspace.shared.frontmostApplication)
             .bind(to: frontApplication)
             .disposed(by: disposeBag)
     }
@@ -80,27 +81,14 @@ extension ExcludeAppService {
 
 // MARK: - Special Applications
 extension ExcludeAppService {
-    /**
-     *  Responding to applications that have special handling for protection of passwords etc.
-     *  e.g 1Password on GoogleChrome browser extension
-     *
-     *  ref: http://nspasteboard.org/
-     */
+    /// Applications that mark pasteboard data when the frontmost application cannot identify the copy source,
+    /// such as menu bar applications that do not take focus.
     private enum Application: String {
         case onePassword = "com.agilebits.onepassword"
 
-        // MARK: - Properties
-        private var macApplicationIdentifiers: [String] {
-            switch self {
-            case .onePassword:
-                return ["com.agilebits.onepassword-osx", // for 1Password 6
-                        "com.agilebits.onepassword7"] // for 1Password 7
-            }
-        }
-
         // MARK: - Excluded
         func isExcluded(applications: [CPYAppInfo]) -> Bool {
-            return !applications.filter { macApplicationIdentifiers.contains($0.identifier) }.isEmpty
+            return applications.contains { $0.identifier.hasPrefix(rawValue) }
         }
 
     }

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -78,6 +78,7 @@ final class CPYUtilities {
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.UserDefaults.overwriteSameHistory)
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.UserDefaults.copySameHistory)
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+        defaultValues.updateValue(NSNumber(value: false), forKey: Constants.UserDefaults.ignoreConcealedPasteboardType)
 
         /* Updates */
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.Update.enableAutomaticCheck)

--- a/ClipyTests/Models/PasteboardAvailableTypeTests.swift
+++ b/ClipyTests/Models/PasteboardAvailableTypeTests.swift
@@ -95,4 +95,13 @@ struct PasteboardAvailableTypeTests {
         )
         #expect(availableTypes == [.deprecatedURL, .deprecatedFilenames, .deprecatedString, .deprecatedPDF, .deprecatedTIFF])
     }
+
+    @Test
+    func availableTypesIgnoresTransientPasteboards() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.string, NSPasteboard.PasteboardType(rawValue: "org.nspasteboard.TransientType")],
+            storeAvailableTypes: [.string]
+        )
+        #expect(availableTypes.isEmpty)
+    }
 }

--- a/ClipyTests/Models/PasteboardAvailableTypeTests.swift
+++ b/ClipyTests/Models/PasteboardAvailableTypeTests.swift
@@ -21,7 +21,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesPreservesPasteboardTypeOrder() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.pdf, .string, .fileURL, .rtf],
-            storeAvailableTypes: [.string, .rtf, .pdf, .filenames]
+            storeAvailableTypes: [.string, .rtf, .pdf, .filenames],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.pdf, .string, .fileURL, .rtf])
     }
@@ -30,7 +31,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesFiltersDisabledStoreTypes() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.pdf, .string, .tiff, .rtf],
-            storeAvailableTypes: [.string, .tiff]
+            storeAvailableTypes: [.string, .tiff],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.string, .tiff])
     }
@@ -39,7 +41,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesFiltersDeprecatedTypesForDisabledStoreTypes() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.deprecatedString, .deprecatedPDF, .deprecatedURL],
-            storeAvailableTypes: [.url]
+            storeAvailableTypes: [.url],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.deprecatedURL])
     }
@@ -48,7 +51,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesPrefersModernStringWhenBothStringTypesAreAvailable() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.deprecatedString, .string],
-            storeAvailableTypes: [.string]
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.string])
     }
@@ -57,7 +61,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesSkipsTIFFWhenPNGIsAvailable() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.tiff, .deprecatedTIFF, .png],
-            storeAvailableTypes: [.tiff]
+            storeAvailableTypes: [.tiff],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.png])
     }
@@ -66,7 +71,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesUsesTIFFWhenOnlyTIFFTypesAreAvailable() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.tiff, .deprecatedTIFF],
-            storeAvailableTypes: [.tiff]
+            storeAvailableTypes: [.tiff],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.tiff])
     }
@@ -82,7 +88,8 @@ struct PasteboardAvailableTypeTests {
                 .deprecatedPDF,
                 .pdf
             ],
-            storeAvailableTypes: [.filenames, .string, .pdf]
+            storeAvailableTypes: [.filenames, .string, .pdf],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.fileURL, .string, .pdf])
     }
@@ -91,7 +98,8 @@ struct PasteboardAvailableTypeTests {
     func availableTypesUsesDeprecatedTypesWhenModernTypesAreUnavailable() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.deprecatedURL, .deprecatedFilenames, .deprecatedString, .deprecatedPDF, .deprecatedTIFF],
-            storeAvailableTypes: [.filenames, .string, .pdf, .url, .tiff]
+            storeAvailableTypes: [.filenames, .string, .pdf, .url, .tiff],
+            ignoresConcealedType: false
         )
         #expect(availableTypes == [.deprecatedURL, .deprecatedFilenames, .deprecatedString, .deprecatedPDF, .deprecatedTIFF])
     }
@@ -99,8 +107,49 @@ struct PasteboardAvailableTypeTests {
     @Test
     func availableTypesIgnoresTransientPasteboards() {
         let availableTypes = PasteboardAvailableType.availableTypes(
-            from: [.string, NSPasteboard.PasteboardType(rawValue: "org.nspasteboard.TransientType")],
-            storeAvailableTypes: [.string]
+            from: [.string, .transient],
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes.isEmpty)
+    }
+
+    @Test
+    func availableTypesKeepsConcealedPasteboardByDefault() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.string, .concealed],
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes == [.string, .concealed])
+    }
+
+    @Test
+    func availableTypesPlacesConcealedPasteboardAfterStoredTypes() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.concealed, .string],
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes == [.string, .concealed])
+    }
+
+    @Test
+    func availableTypesIgnoresConcealedPasteboardWhenEnabled() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.string, .concealed],
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: true
+        )
+        #expect(availableTypes.isEmpty)
+    }
+
+    @Test
+    func availableTypesDoesNotStoreOnlyConcealedPasteboards() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.concealed],
+            storeAvailableTypes: [.string],
+            ignoresConcealedType: false
         )
         #expect(availableTypes.isEmpty)
     }

--- a/ClipyTests/Models/PasteboardContentTests.swift
+++ b/ClipyTests/Models/PasteboardContentTests.swift
@@ -137,6 +137,32 @@ struct PasteboardContentTests {
     }
 
     @Test
+    func writeObjectsPreservesConcealedMarker() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.clearContents() }
+
+        let stringAsset = PasteboardContent.Asset(type: .string, data: Data("Secret".utf8))
+        let concealedAsset = PasteboardContent.Asset(type: .concealed, data: Data("concealed".utf8))
+        let content = try #require(
+            PasteboardContent(
+                assets: [
+                    stringAsset,
+                    concealedAsset
+                ]
+            )
+        )
+
+        content.writeObjects(to: pasteboard)
+
+        #expect(pasteboard.types?.contains(.concealed) == true)
+        let restoredContent = try #require(PasteboardContent(
+            pasteboard: pasteboard,
+            types: [.string, .concealed]
+        ))
+        #expect(restoredContent.assets == [stringAsset, concealedAsset])
+    }
+
+    @Test
     func imageInitializerStoresTiffAsset() throws {
         let image = NSImage.create(with: .red, size: NSSize(width: 10, height: 10))
         let content = try #require(PasteboardContent(image: image))


### PR DESCRIPTION
## Summary
- Ignore pasteboard data marked with NSPasteboard TransientType.
- Add an opt-in setting to ignore clipboard data marked as Concealed.
- Preserve Concealed marker data when storing and restoring clipboard history.
- Keep 1Password-specific special application marker handling and update its exclusion check to match #426.
- Add coverage for marker filtering, ordering, and preservation behavior.

Closes #426

Tests run: `xcodebuild test -project Clipy.xcodeproj -scheme Clipy -configuration Debug -derivedDataPath /private/tmp/ClipyDerivedDataTransient -destination 'platform=macOS'`.