### PR TITLE
Handle Universal Clipboard file references

### DIFF
--- a/Clipy/Sources/Models/PasteboardAvailableType.swift
+++ b/Clipy/Sources/Models/PasteboardAvailableType.swift
@@ -29,9 +29,24 @@ enum PasteboardAvailableType: String, Equatable, CaseIterable {
         ignoresConcealedType: Bool
     ) -> [NSPasteboard.PasteboardType] {
         let uniquePasteboardTypes = OrderedSet(pasteboardTypes)
+        // Do not save pasteboards marked as temporary.
         guard uniquePasteboardTypes.allSatisfy({ $0 != .transient }) else { return [] }
+        // When concealed pasteboards are ignored, do not save items containing sensitive data.
         guard !ignoresConcealedType || uniquePasteboardTypes.allSatisfy({ $0 != .concealed }) else { return [] }
+        // Universal Clipboard file URLs can point to Apple-managed temporary storage,
+        // such as `Group Containers/group.com.apple.coreservices.useractivityd`.
+        // When a non-Apple app stores and reuses that file URL, macOS may fail to
+        // provide the required sandbox extension, so the paste target cannot open the
+        // file. If the file URL is the primary data, do not save the history item.
+        // Otherwise, drop only the file URL and keep other image or text representations.
+        let isUniversalClipboard = uniquePasteboardTypes.contains(.universalClipboard)
+        if isUniversalClipboard && uniquePasteboardTypes.first?.isFileReference == true {
+            return []
+        }
         let availableTypes = uniquePasteboardTypes.compactMap { pasteboardType -> NSPasteboard.PasteboardType? in
+            if isUniversalClipboard && pasteboardType.isFileReference {
+                return nil
+            }
             guard let availableType = pasteboardType.availableType,
                 storeAvailableTypes.contains(availableType) else { return nil }
             if pasteboardType.isCovered(by: uniquePasteboardTypes) {
@@ -104,6 +119,14 @@ private extension NSPasteboard.PasteboardType {
             return false
         }
     }
+
+    var isFileReference: Bool {
+        self == .fileURL || self == .deprecatedFilenames
+    }
+}
+
+extension NSPasteboard.PasteboardType {
+    static let universalClipboard = NSPasteboard.PasteboardType(rawValue: "com.apple.is-remote-clipboard")
 }
 
 // ref: https://nspasteboard.org/

--- a/ClipyTests/Models/PasteboardAvailableTypeTests.swift
+++ b/ClipyTests/Models/PasteboardAvailableTypeTests.swift
@@ -105,6 +105,46 @@ struct PasteboardAvailableTypeTests {
     }
 
     @Test
+    func availableTypesIgnoresUniversalClipboardWhenFileURLIsPrimary() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.fileURL, .string, .universalClipboard],
+            storeAvailableTypes: [.filenames, .string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes.isEmpty)
+    }
+
+    @Test
+    func availableTypesIgnoresUniversalClipboardWhenDeprecatedFilenamesIsPrimary() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.deprecatedFilenames, .string, .universalClipboard],
+            storeAvailableTypes: [.filenames, .string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes.isEmpty)
+    }
+
+    @Test
+    func availableTypesIgnoresFileURLForUniversalClipboardWhenItIsNotPrimary() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.string, .fileURL, .universalClipboard],
+            storeAvailableTypes: [.filenames, .string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes == [.string])
+    }
+
+    @Test
+    func availableTypesIgnoresDeprecatedFilenamesForUniversalClipboardWhenItIsNotPrimary() {
+        let availableTypes = PasteboardAvailableType.availableTypes(
+            from: [.string, .deprecatedFilenames, .universalClipboard],
+            storeAvailableTypes: [.filenames, .string],
+            ignoresConcealedType: false
+        )
+        #expect(availableTypes == [.string])
+    }
+
+    @Test
     func availableTypesIgnoresTransientPasteboards() {
         let availableTypes = PasteboardAvailableType.availableTypes(
             from: [.string, .transient],


### PR DESCRIPTION
## Summary

- Skip Universal Clipboard history items when a file URL or deprecated filenames flavor is the primary representation.
- Drop only file reference flavors for Universal Clipboard items when another primary representation, such as text or image data, remains useful.
- Document why Universal Clipboard file URLs cannot be safely stored and reused by non-Apple apps, and add focused coverage for both modern and deprecated file flavors.

## Notes

Tested with:

`xcodebuild test -project Clipy.xcodeproj -scheme Clipy -destination 'platform=macOS' -only-testing:ClipyTests/PasteboardAvailableTypeTests`