### PR TITLE
Prepare search index tables

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C50767032FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */; };
 		C522FB952FCBD6AA00E61800 /* PasteboardAvailableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB942FCBD69A00E61800 /* PasteboardAvailableType.swift */; };
 		C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB982FCC019100E61800 /* PasteboardAvailableTypeTests.swift */; };
 		C53FC6C02FCCA1C400219A25 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = C53FC6BF2FCCA1C400219A25 /* Collections */; };
@@ -157,6 +158,7 @@
 		A07D83942FC384F100390DB2 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/CPYTypePreferenceViewController.strings"; sourceTree = "<group>"; };
 		A07D83952FC384F100390DB2 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/CPYUpdatesPreferenceViewController.strings"; sourceTree = "<group>"; };
 		A07D83962FC384F100390DB2 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/CPYSnippetsEditorWindowController.strings"; sourceTree = "<group>"; };
+		C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataDatabase+TriggerTests.swift"; sourceTree = "<group>"; };
 		C5208B882FC6E7FF00BC4568 /* Clipy.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Clipy.xcconfig; sourceTree = "<group>"; };
 		C5208B8D2FC6E88E00BC4568 /* CodeSigning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CodeSigning.xcconfig; sourceTree = "<group>"; };
 		C5208B8E2FC6E8B000BC4568 /* CodeSigning-AdHoc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CodeSigning-AdHoc.xcconfig"; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 		C5700B472FC5C0DB00C8F965 /* Database */ = {
 			isa = PBXGroup;
 			children = (
+				C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */,
 				C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */,
 				C5700B4F2FD106000C8F965 /* DatabaseMigrationTests.swift */,
 			);
@@ -904,6 +907,7 @@
 				C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */,
 				C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */,
 				C57100052FCEB01000C8F965 /* PasteboardHistoryRepositoryTests.swift in Sources */,
+				C50767032FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift in Sources */,
 				C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */,
 				C57100012FCAE00000C8F965 /* SnippetRepositoryTests.swift in Sources */,
 			);

--- a/Clipy/Sources/Database/SQLiteDataMigrator.swift
+++ b/Clipy/Sources/Database/SQLiteDataMigrator.swift
@@ -10,14 +10,16 @@
 //  Copyright © 2015-2026 Clipy Project.
 //
 
+// swiftlint:disable function_body_length
+
 import SQLiteData
 
 extension DatabaseMigrator {
     mutating func registerMigration() {
         registerMigrationV1()
+        registerMigrationV2()
     }
 
-    // swiftlint:disable:next function_body_length
     mutating func registerMigrationV1() {
         registerMigration("Create initial tables") { database in
             try #sql(
@@ -141,4 +143,119 @@ extension DatabaseMigrator {
             .execute(database)
         }
     }
+
+    mutating func registerMigrationV2() {
+        registerMigration("Create search indexes") { database in
+            try #sql(
+                """
+                CREATE VIRTUAL TABLE "pasteboardHistorySearches"
+                USING fts5(
+                  "id" UNINDEXED,
+                  "title",
+                  tokenize = 'trigram'
+                )
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "insert_pasteboardHistories_into_pasteboardHistorySearches"
+                AFTER INSERT ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = new."id";
+
+                  INSERT INTO "pasteboardHistorySearches" ("id", "title")
+                  VALUES (new."id", new."title");
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "update_pasteboardHistories_in_pasteboardHistorySearches"
+                AFTER UPDATE OF "id", "title" ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = old."id";
+
+                  INSERT INTO "pasteboardHistorySearches" ("id", "title")
+                  VALUES (new."id", new."title");
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "delete_pasteboardHistories_from_pasteboardHistorySearches"
+                AFTER DELETE ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = old."id";
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE VIRTUAL TABLE "snippetSearches"
+                USING fts5(
+                  "id" UNINDEXED,
+                  "title",
+                  "content",
+                  tokenize = 'trigram'
+                )
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "insert_snippets_into_snippetSearches"
+                AFTER INSERT ON "snippets"
+                BEGIN
+                  DELETE FROM "snippetSearches"
+                  WHERE "id" = new."id";
+
+                  INSERT INTO "snippetSearches" ("id", "title", "content")
+                  VALUES (new."id", new."title", new."content");
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "update_snippets_in_snippetSearches"
+                AFTER UPDATE OF "id", "title", "content" ON "snippets"
+                BEGIN
+                  DELETE FROM "snippetSearches"
+                  WHERE "id" = old."id";
+
+                  INSERT INTO "snippetSearches" ("id", "title", "content")
+                  VALUES (new."id", new."title", new."content");
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "delete_snippets_from_snippetSearches"
+                AFTER DELETE ON "snippets"
+                BEGIN
+                  DELETE FROM "snippetSearches"
+                  WHERE "id" = old."id";
+                END
+                """
+            )
+            .execute(database)
+        }
+    }
 }
+
+// swiftlint:enable function_body_length

--- a/Clipy/Sources/Database/SQLiteDataSchema.swift
+++ b/Clipy/Sources/Database/SQLiteDataSchema.swift
@@ -64,6 +64,18 @@ struct PasteboardHistoryDetail: Equatable {
 }
 
 @Table
+struct PasteboardHistorySearch: FTS5, Equatable {
+    let id: PasteboardHistory.ID
+    let title: String
+}
+
+@Selection
+struct PasteboardHistorySearchResult: Equatable {
+    let history: PasteboardHistory?
+    let thumbnailAsset: PasteboardHistoryThumbnailAsset?
+}
+
+@Table
 struct SnippetFolder: Identifiable, Equatable {
     typealias ID = Tagged<Self, UUID>
 
@@ -85,6 +97,18 @@ struct Snippet: Identifiable, Equatable {
     let content: String
     let index: Int
     let isEnabled: Bool
+}
+
+@Table
+struct SnippetSearch: FTS5, Equatable {
+    let id: Snippet.ID
+    let title: String
+    let content: String
+}
+
+@Selection
+struct SnippetSearchResult: Equatable {
+    let snippet: Snippet?
 }
 
 extension NSPasteboard.PasteboardType: @retroactive SQLiteType {}

--- a/ClipyTests/Database/SQLiteDataDatabase+TriggerTests.swift
+++ b/ClipyTests/Database/SQLiteDataDatabase+TriggerTests.swift
@@ -1,0 +1,235 @@
+//
+//  SQLiteData+TriggerTests.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/06/11.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import DependenciesTestSupport
+import SQLiteData
+import Testing
+@testable import Clipy
+
+@MainActor
+@Suite(
+    .dependencies {
+        try $0.bootstrapDatabase()
+    }
+)
+struct SQLiteDataDatabaseTriggerTests {
+    @Dependency(\.defaultDatabase)
+    var database
+
+    @Test
+    func pasteboardHistorySearchesIndexIsUpdatedByTriggers() throws {
+        let historyID = PasteboardHistory.ID(rawValue: "history-1")
+
+        try database.write { database in
+            try PasteboardHistory.insert {
+                PasteboardHistory(
+                    id: historyID,
+                    title: "Xqa History Start",
+                    pasteboardTypes: [.string],
+                    updateAt: 1,
+                    deviceID: nil
+                )
+            }
+            .execute(database)
+        }
+
+        try database.read { database in
+            let historyIDs = try pasteboardHistories(matching: "xqa", database: database)
+                .map(\.history?.id)
+            #expect(historyIDs == [historyID])
+        }
+
+        try database.write { database in
+            try PasteboardHistory.where { $0.id.eq(historyID) }
+                .update { $0.title = "Gamma Delta" }
+                .execute(database)
+        }
+
+        try database.read { database in
+            let oldHistoryIDs = try pasteboardHistories(matching: "xqa", database: database)
+                .map(\.history?.id)
+            #expect(oldHistoryIDs == [])
+
+            let updatedHistoryIDs = try pasteboardHistories(matching: "mma", database: database)
+                .map(\.history?.id)
+            #expect(updatedHistoryIDs == [historyID])
+        }
+
+        try database.write { database in
+            try PasteboardHistory.upsert {
+                PasteboardHistory(
+                    id: historyID,
+                    title: "Rpb History Finish",
+                    pasteboardTypes: [.string],
+                    updateAt: 2,
+                    deviceID: nil
+                )
+            }
+            .execute(database)
+        }
+
+        try database.read { database in
+            let oldHistoryIDs = try pasteboardHistories(matching: "mma", database: database)
+                .map(\.history?.id)
+            #expect(oldHistoryIDs == [])
+
+            let upsertedHistoryIDs = try pasteboardHistories(matching: "rpb", database: database)
+                .map(\.history?.id)
+            #expect(upsertedHistoryIDs == [historyID])
+        }
+
+        try database.write { database in
+            try PasteboardHistory.delete()
+                .where { $0.id.eq(historyID) }
+                .execute(database)
+        }
+
+        try database.read { database in
+            let historyCount = try #sql(
+                """
+                SELECT count(*)
+                FROM "pasteboardHistorySearches"
+                """,
+                as: Int.self
+            )
+            .fetchOne(database)
+            #expect(historyCount == 0)
+        }
+    }
+
+    @Test
+    func snippetSearchesIndexIsUpdatedByTriggers() throws {
+        let folderID = SnippetFolder.ID(rawValue: UUID())
+        let snippetID = Snippet.ID(rawValue: UUID())
+
+        try database.write { database in
+            try SnippetFolder.insert {
+                SnippetFolder(
+                    id: folderID,
+                    title: "Folder",
+                    index: 0,
+                    isEnabled: true
+                )
+            }
+            .execute(database)
+
+            try Snippet.insert {
+                Snippet(
+                    id: snippetID,
+                    folderID: folderID,
+                    title: "Xqa Snippet Start",
+                    content: "nuv package",
+                    index: 0,
+                    isEnabled: true
+                )
+            }
+            .execute(database)
+        }
+
+        try database.read { database in
+            let titleIDs = try snippets(matching: "xqa", database: database)
+                .map(\.snippet?.id)
+            #expect(titleIDs == [snippetID])
+
+            let contentIDs = try snippets(matching: "nuv", database: database)
+                .map(\.snippet?.id)
+            #expect(contentIDs == [snippetID])
+        }
+
+        try database.write { database in
+            try Snippet.where { $0.id.eq(snippetID) }
+                .update {
+                    $0.title = "Archive Note"
+                    $0.content = "rotating token"
+                }
+                .execute(database)
+        }
+
+        try database.read { database in
+            let oldIDs = try snippets(matching: "nuv", database: database)
+                .map(\.snippet?.id)
+            #expect(oldIDs == [])
+
+            let updatedIDs = try snippets(matching: "tat", database: database)
+                .map(\.snippet?.id)
+            #expect(updatedIDs == [snippetID])
+        }
+
+        try database.write { database in
+            try Snippet.upsert {
+                Snippet(
+                    id: snippetID,
+                    folderID: folderID,
+                    title: "Rpb Snippet Finish",
+                    content: "rst token",
+                    index: 0,
+                    isEnabled: true
+                )
+            }
+            .execute(database)
+        }
+
+        try database.read { database in
+            let oldIDs = try snippets(matching: "tat", database: database)
+                .map(\.snippet?.id)
+            #expect(oldIDs == [])
+
+            let upsertedIDs = try snippets(matching: "rpb", database: database)
+                .map(\.snippet?.id)
+            #expect(upsertedIDs == [snippetID])
+        }
+
+        try database.write { database in
+            try Snippet.delete()
+                .where { $0.id.eq(snippetID) }
+                .execute(database)
+        }
+
+        try database.read { database in
+            let snippetCount = try #sql(
+                """
+                SELECT count(*)
+                FROM "snippetSearches"
+                """,
+                as: Int.self
+            )
+                .fetchOne(database)
+            #expect(snippetCount == 0)
+        }
+    }
+}
+
+private extension SQLiteDataDatabaseTriggerTests {
+    private func pasteboardHistories(
+        matching query: String,
+        database: Database
+    ) throws -> [PasteboardHistorySearchResult] {
+        try PasteboardHistorySearch
+            .where { $0.match(query) }
+            .leftJoin(PasteboardHistory.all) { $0.id.eq($1.id) }
+            .leftJoin(PasteboardHistoryThumbnailAsset.all) { $0.id.eq($2.pasteboardHistoryID) }
+            .select { PasteboardHistorySearchResult.Columns(history: $1, thumbnailAsset: $2) }
+            .fetchAll(database)
+    }
+
+    private func snippets(
+        matching query: String,
+        database: Database
+    ) throws -> [SnippetSearchResult] {
+        try SnippetSearch
+            .where { $0.match(query) }
+            .leftJoin(Snippet.all) { $0.id.eq($1.id) }
+            .select { SnippetSearchResult.Columns(snippet: $1) }
+            .fetchAll(database)
+    }
+}

--- a/ClipyTests/Database/SQLiteDataMigratorTests.swift
+++ b/ClipyTests/Database/SQLiteDataMigratorTests.swift
@@ -18,23 +18,14 @@ import Testing
 @Suite
 struct SQLiteDataMigratorTests {
     @Test
-    func migrationV1() throws { // swiftlint:disable:this function_body_length
+    func migrationV1() throws {
         let database = try DatabaseQueue()
         var migrator = DatabaseMigrator()
         migrator.registerMigrationV1()
         try migrator.migrate(database)
 
         try database.read { database in
-            let tables = try #sql(
-                """
-                SELECT "name"
-                FROM "sqlite_master"
-                WHERE "type" = 'table'
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let tables = try tableNames(database)
             #expect(
                 tables == [
                     "grdb_migrations",
@@ -47,18 +38,55 @@ struct SQLiteDataMigratorTests {
             )
         }
 
+        try expectV1Indexes(database)
+        try expectV1Tables(database)
+    }
+
+    @Test
+    func migrationV2() throws {
+        let database = try DatabaseQueue()
+        var migrator = DatabaseMigrator()
+        migrator.registerMigrationV1()
+        migrator.registerMigrationV2()
+        try migrator.migrate(database)
+
         try database.read { database in
-            let indexes = try #sql(
-                """
-                SELECT "name"
-                FROM "sqlite_master"
-                WHERE "type" = 'index'
-                AND "name" GLOB 'index_*'
-                ORDER BY "name"
-                """,
-                as: String.self
+            let tables = try tableNames(database)
+            #expect(
+                tables == [
+                    "grdb_migrations",
+                    "pasteboardHistories",
+                    "pasteboardHistoryAssets",
+                    "pasteboardHistorySearches",
+                    "pasteboardHistorySearches_config",
+                    "pasteboardHistorySearches_content",
+                    "pasteboardHistorySearches_data",
+                    "pasteboardHistorySearches_docsize",
+                    "pasteboardHistorySearches_idx",
+                    "pasteboardHistoryThumbnailAssets",
+                    "snippetFolders",
+                    "snippetSearches",
+                    "snippetSearches_config",
+                    "snippetSearches_content",
+                    "snippetSearches_data",
+                    "snippetSearches_docsize",
+                    "snippetSearches_idx",
+                    "snippets"
+                ]
             )
-            .fetchAll(database)
+        }
+
+        try expectV1Indexes(database)
+        try expectV1Tables(database)
+        try expectV2Triggers(database)
+        try expectV2Tables(database)
+    }
+}
+
+private extension SQLiteDataMigratorTests {
+    func expectV1Indexes(_ database: DatabaseQueue) throws {
+        try database.read { database in
+            let indexes = try indexes(database)
             #expect(
                 indexes == [
                     "index_pasteboardHistories_on_updateAt",
@@ -70,17 +98,11 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
+    }
 
+    func expectV1Tables(_ database: DatabaseQueue) throws {
         try database.read { database in
-            let columnNames = try #sql(
-                """
-                SELECT "name"
-                FROM pragma_table_info('pasteboardHistories')
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let columnNames = try columnNames(of: "pasteboardHistories", database: database)
             #expect(
                 columnNames == [
                     "deviceID",
@@ -91,17 +113,8 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
-
         try database.read { database in
-            let columnNames = try #sql(
-                """
-                SELECT "name"
-                FROM pragma_table_info('pasteboardHistoryAssets')
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let columnNames = try columnNames(of: "pasteboardHistoryAssets", database: database)
             #expect(
                 columnNames == [
                     "data",
@@ -112,17 +125,8 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
-
         try database.read { database in
-            let columnNames = try #sql(
-                """
-                SELECT "name"
-                FROM pragma_table_info('pasteboardHistoryThumbnailAssets')
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let columnNames = try columnNames(of: "pasteboardHistoryThumbnailAssets", database: database)
             #expect(
                 columnNames == [
                     "data",
@@ -131,17 +135,8 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
-
         try database.read { database in
-            let columnNames = try #sql(
-                """
-                SELECT "name"
-                FROM pragma_table_info('snippetFolders')
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let columnNames = try columnNames(of: "snippetFolders", database: database)
             #expect(
                 columnNames == [
                     "id",
@@ -151,17 +146,8 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
-
         try database.read { database in
-            let columnNames = try #sql(
-                """
-                SELECT "name"
-                FROM pragma_table_info('snippets')
-                ORDER BY "name"
-                """,
-                as: String.self
-            )
-            .fetchAll(database)
+            let columnNames = try columnNames(of: "snippets", database: database)
             #expect(
                 columnNames == [
                     "content",
@@ -173,5 +159,97 @@ struct SQLiteDataMigratorTests {
                 ]
             )
         }
+    }
+
+    func expectV2Triggers(_ database: DatabaseQueue) throws {
+        try database.read { database in
+            let triggers = try triggers(database)
+            #expect(
+                triggers == [
+                    "delete_pasteboardHistories_from_pasteboardHistorySearches",
+                    "delete_snippets_from_snippetSearches",
+                    "insert_pasteboardHistories_into_pasteboardHistorySearches",
+                    "insert_snippets_into_snippetSearches",
+                    "update_pasteboardHistories_in_pasteboardHistorySearches",
+                    "update_snippets_in_snippetSearches"
+                ]
+            )
+        }
+    }
+
+    func expectV2Tables(_ database: DatabaseQueue) throws {
+        try database.read { database in
+            let columnNames = try columnNames(of: "pasteboardHistorySearches", database: database)
+            #expect(
+                columnNames == [
+                    "id",
+                    "title"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "snippetSearches", database: database)
+            #expect(
+                columnNames == [
+                    "content",
+                    "id",
+                    "title"
+                ]
+            )
+        }
+    }
+}
+
+private extension SQLiteDataMigratorTests {
+    func tableNames(_ database: Database) throws -> [String] {
+        try #sql(
+            """
+            SELECT "name"
+            FROM "sqlite_master"
+            WHERE "type" = 'table'
+            ORDER BY "name"
+            """,
+            as: String.self
+        )
+        .fetchAll(database)
+    }
+
+    func indexes(_ database: Database) throws -> [String] {
+        try #sql(
+            """
+            SELECT "name"
+            FROM "sqlite_master"
+            WHERE "type" = 'index'
+            AND "name" GLOB 'index_*'
+            ORDER BY "name"
+            """,
+            as: String.self
+        )
+        .fetchAll(database)
+    }
+
+    func triggers(_ database: Database) throws -> [String] {
+        try #sql(
+            """
+            SELECT "name"
+            FROM "sqlite_master"
+            WHERE "type" = 'trigger'
+            ORDER BY "name"
+            """,
+            as: String.self
+        )
+        .fetchAll(database)
+    }
+
+    func columnNames(of tableName: String, database: Database) throws -> [String] {
+        try #sql(
+            """
+            SELECT "name"
+            FROM pragma_table_info('\(raw: tableName)')
+            ORDER BY "name"
+            """,
+            as: String.self
+        )
+        .fetchAll(database)
     }
 }


### PR DESCRIPTION
## Summary

This prepares SQLite search index tables ahead of the future search feature.

The user-facing search UI is not part of this change, and the timing for that feature is still undecided. The goal of this PR is only to ship the database structures and triggers early so newly created data can start maintaining search-ready content on users' machines.

## Changes

- Add a v2 SQLiteData migration that creates FTS5 trigram tables for pasteboard history titles and snippet title/content search data.
- Add persistent triggers that keep the FTS tables in sync on insert, update, upsert, and delete paths.
- Add schema models and selection result types for the future search queries.
- Expand migration tests to assert the v2 table and trigger definitions.
- Add trigger tests that verify model-driven writes update the FTS tables through left-joined search results.