### PR TITLE
Fix beta history action wording

### DIFF
--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYBetaPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYBetaPreferenceViewController.xib
@@ -88,7 +88,7 @@
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uSX-Yy-86r" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
                     <rect key="frame" x="59" y="107" width="237" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Delete history" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sYs-Da-TSj">
+                    <buttonCell key="cell" type="check" title="Delete from history" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sYs-Da-TSj">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -119,7 +119,7 @@
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="195-Rx-goW" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
                     <rect key="frame" x="59" y="76" width="237" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Paste and delete history" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="M5n-Mr-02l">
+                    <buttonCell key="cell" type="check" title="Paste and delete from history" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="M5n-Mr-02l">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/Clipy/Sources/Preferences/Panels/de.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/de.lproj/CPYBetaPreferenceViewController.strings
@@ -8,7 +8,7 @@
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
 "HZd-yn-p4o.title" = "Command";
 
-/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
+/* Class = "NSButtonCell"; title = "Paste and delete from history"; ObjectID = "M5n-Mr-02l"; */
 "M5n-Mr-02l.title" = "Einfügen und Verlauf löschen";
 
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
@@ -44,7 +44,7 @@
 /* Class = "NSMenuItem"; title = "Shift"; ObjectID = "riQ-CH-Kcr"; */
 "riQ-CH-Kcr.title" = "Shift";
 
-/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
+/* Class = "NSButtonCell"; title = "Delete from history"; ObjectID = "sYs-Da-TSj"; */
 "sYs-Da-TSj.title" = "Verlauf löschen";
 
 /* Class = "NSMenuItem"; title = "Control"; ObjectID = "vtQ-7v-nLJ"; */

--- a/Clipy/Sources/Preferences/Panels/it.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/it.lproj/CPYBetaPreferenceViewController.strings
@@ -29,8 +29,8 @@
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
 "HZd-yn-p4o.title" = "Command";
 
-/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
-"M5n-Mr-02l.title" = "Paste and delete history";
+/* Class = "NSButtonCell"; title = "Paste and delete from history"; ObjectID = "M5n-Mr-02l"; */
+"M5n-Mr-02l.title" = "Paste and delete from history";
 
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
 "M9s-9f-OKA.title" = "Alt";
@@ -47,8 +47,8 @@
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "orJ-AB-Oxl"; */
 "orJ-AB-Oxl.title" = "Alt";
 
-/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
-"sYs-Da-TSj.title" = "Delete history";
+/* Class = "NSButtonCell"; title = "Delete from history"; ObjectID = "sYs-Da-TSj"; */
+"sYs-Da-TSj.title" = "Delete from history";
 
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "yZK-TZ-SNb"; */
 "yZK-TZ-SNb.title" = "Command";

--- a/Clipy/Sources/Preferences/Panels/ja.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/ja.lproj/CPYBetaPreferenceViewController.strings
@@ -29,7 +29,7 @@
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
 "HZd-yn-p4o.title" = "Command";
 
-/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
+/* Class = "NSButtonCell"; title = "Paste and delete from history"; ObjectID = "M5n-Mr-02l"; */
 "M5n-Mr-02l.title" = "ペーストした後に履歴を削除する";
 
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
@@ -47,7 +47,7 @@
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "orJ-AB-Oxl"; */
 "orJ-AB-Oxl.title" = "Alt";
 
-/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
+/* Class = "NSButtonCell"; title = "Delete from history"; ObjectID = "sYs-Da-TSj"; */
 "sYs-Da-TSj.title" = "履歴を削除する";
 
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "yZK-TZ-SNb"; */

--- a/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYBetaPreferenceViewController.strings
@@ -8,7 +8,7 @@
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
 "HZd-yn-p4o.title" = "Command";
 
-/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
+/* Class = "NSButtonCell"; title = "Paste and delete from history"; ObjectID = "M5n-Mr-02l"; */
 "M5n-Mr-02l.title" = "Colar e apagar histórico";
 
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
@@ -44,7 +44,7 @@
 /* Class = "NSMenuItem"; title = "Shift"; ObjectID = "riQ-CH-Kcr"; */
 "riQ-CH-Kcr.title" = "Shift";
 
-/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
+/* Class = "NSButtonCell"; title = "Delete from history"; ObjectID = "sYs-Da-TSj"; */
 "sYs-Da-TSj.title" = "Apagar histórico";
 
 /* Class = "NSMenuItem"; title = "Control"; ObjectID = "vtQ-7v-nLJ"; */

--- a/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYBetaPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYBetaPreferenceViewController.strings
@@ -8,7 +8,7 @@
 /* Class = "NSMenuItem"; title = "Command"; ObjectID = "HZd-yn-p4o"; */
 "HZd-yn-p4o.title" = "Command";
 
-/* Class = "NSButtonCell"; title = "Paste and delete history"; ObjectID = "M5n-Mr-02l"; */
+/* Class = "NSButtonCell"; title = "Paste and delete from history"; ObjectID = "M5n-Mr-02l"; */
 "M5n-Mr-02l.title" = "粘贴并删除历史";
 
 /* Class = "NSMenuItem"; title = "Alt"; ObjectID = "M9s-9f-OKA"; */
@@ -44,7 +44,7 @@
 /* Class = "NSMenuItem"; title = "Shift"; ObjectID = "riQ-CH-Kcr"; */
 "riQ-CH-Kcr.title" = "Shift";
 
-/* Class = "NSButtonCell"; title = "Delete history"; ObjectID = "sYs-Da-TSj"; */
+/* Class = "NSButtonCell"; title = "Delete from history"; ObjectID = "sYs-Da-TSj"; */
 "sYs-Da-TSj.title" = "删除历史";
 
 /* Class = "NSMenuItem"; title = "Control"; ObjectID = "vtQ-7v-nLJ"; */


### PR DESCRIPTION
## Summary

This updates the beta preference labels from `Delete history` / `Paste and delete history` to `Delete from history` / `Paste and delete from history`, matching the actual behavior of removing the selected item from history rather than clearing all history.

Closes #334.

The change is based on commit 7bd5b7830d0e2d8beeef09d9839865f2745d95cf by @tessus. The local commit keeps Helmut K. C. Tessarek as the author so the original contribution is preserved.

Checked the updated `.strings` files with `plutil -lint`, the xib with `xmllint --noout`, and the diff with `git diff --check`.