### PR TITLE
Add Firebase dependency client

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C58E0A822FDAB5B100B3A901 /* ClipyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58E0A812FDAB5B100B3A901 /* ClipyApp.swift */; };
 		C5A67BC42FECF03C0015A0DE /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A67BC32FECF0380015A0DE /* Accessibility.swift */; };
+		C5A67BCA2FECF8670015A0DE /* Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A67BC92FECF8640015A0DE /* Firebase.swift */; };
+		C5A67BCC2FED00E10015A0DE /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = C5A67BCB2FED00E10015A0DE /* DependenciesMacros */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
 		C5D220A82FBD2655005CD45E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D220A72FBD2655005CD45E /* RealmSwift */; };
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
@@ -187,6 +189,7 @@
 		C576AD7B2FBD345000B71213 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		C58E0A812FDAB5B100B3A901 /* ClipyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipyApp.swift; sourceTree = "<group>"; };
 		C5A67BC32FECF0380015A0DE /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		C5A67BC92FECF8640015A0DE /* Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Firebase.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
 		FA0D5CE71DDCC61600AC9052 /* ClipService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipService.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 		FAC43DC31B35D8B100C06102 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
+				C5A67BCC2FED00E10015A0DE /* DependenciesMacros in Frameworks */,
 				C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */,
 				C5E3D0512FB43570005D632A /* Screeen in Frameworks */,
 				C53FC6C02FCCA1C400219A25 /* Collections in Frameworks */,
@@ -402,6 +406,7 @@
 			isa = PBXGroup;
 			children = (
 				C57447252FD09FD9000D64D3 /* RealmConfiguration.swift */,
+				C5A67BC92FECF8640015A0DE /* Firebase.swift */,
 			);
 			path = Dependencies;
 			sourceTree = "<group>";
@@ -690,6 +695,7 @@
 				C53FC6BF2FCCA1C400219A25 /* Collections */,
 				C574472B2FD13ADF000D64D3 /* FirebaseCrashlytics */,
 				C574472E2FD13FD9000D64D3 /* FirebaseAnalyticsCore */,
+				C5A67BCB2FED00E10015A0DE /* DependenciesMacros */,
 			);
 			productName = Clipy;
 			productReference = FAC43DC61B35D8B100C06102 /* Clipy.app */;
@@ -886,6 +892,7 @@
 				FA1DB4EA1DDCB49C007F95C8 /* CPYSnippetsEditorCell.swift in Sources */,
 				FA1DB5161DDCB4C0007F95C8 /* CPYShortcutsPreferenceViewController.swift in Sources */,
 				FA431F021E6718CE00ACFF56 /* Collection+Safe.swift in Sources */,
+				C5A67BCA2FECF8670015A0DE /* Firebase.swift in Sources */,
 				FA1DB4E71DDCB49C007F95C8 /* CPYDesignableButton.swift in Sources */,
 				FA1DB4D21DDCB479007F95C8 /* CPYAppInfo.swift in Sources */,
 				FAE911B91DE045E2008A4BEC /* HotKeyService.swift in Sources */,
@@ -1462,6 +1469,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+		C5A67BCB2FED00E10015A0DE /* DependenciesMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5700B4A2FC5C3D500C8F965 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = DependenciesMacros;
 		};
 		C5A6BA732FBC5A6E00C8B9EB /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -33,6 +33,8 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     private var pasteboardHistoryRepository
     @Dependency(\.snippetRepository)
     private var snippetRepository
+    @Dependency(\.firebase)
+    private var firebase
 
     // MARK: - NSMenuItem Validation
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
@@ -152,7 +154,7 @@ extension AppDelegate: NSApplicationDelegate {
         guard context != .test else { return }
 
         // SDKs
-        CPYUtilities.initSDKs()
+        firebase.configure()
         // Check Accessibility Permission
         Accessibility.isAccessibilityEnabled(isPrompt: true)
 

--- a/Clipy/Sources/Dependencies/Firebase.swift
+++ b/Clipy/Sources/Dependencies/Firebase.swift
@@ -1,0 +1,84 @@
+//
+//  Firebase.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/06/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Dependencies
+import DependenciesMacros
+import Firebase
+
+@DependencyClient
+struct Firebase {
+    var configure: () -> Void
+    var logEvent: (_ event: Event) -> Void
+
+    enum Event {
+        case popUpMenu(MenuType)
+        case popUpSnippetFolderMenu
+
+        var name: String {
+            switch self {
+            case .popUpMenu:
+                return "pop_up_menu"
+            case .popUpSnippetFolderMenu:
+                return "pop_up_snippet_folder_menu"
+            }
+        }
+        var parameters: [String: Any]? {
+            switch self {
+            case .popUpMenu(let type):
+                return ["type": type.rawValue]
+            case .popUpSnippetFolderMenu:
+                return nil
+            }
+        }
+    }
+}
+
+extension DependencyValues {
+    var firebase: Firebase {
+        get { self[Firebase.self] }
+        set { self[Firebase.self] = newValue }
+    }
+}
+
+extension Firebase: DependencyKey {
+    static let liveValue: Firebase = .init(
+        configure: {
+            @Dependency(\.defaultAppStorage) var appStorage
+
+            appStorage.register(defaults: ["NSApplicationCrashOnExceptions": true])
+            guard
+                appStorage.bool(forKey: Constants.UserDefaults.collectCrashReport),
+                let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+                let options = FirebaseOptions(contentsOfFile: path),
+                FirebaseApp.app() == nil
+            else { return }
+
+            FirebaseApp.configure(options: options)
+        },
+        logEvent: { event in
+            @Dependency(\.defaultAppStorage) var appStorage
+
+            guard appStorage.bool(forKey: Constants.UserDefaults.collectCrashReport) else { return }
+
+            Analytics.logEvent(event.name, parameters: event.parameters)
+        }
+    )
+
+    static var previewValue: Firebase = Firebase(
+        configure: {},
+        logEvent: { _ in }
+    )
+    static var testValue: Firebase = Firebase(
+        configure: {},
+        logEvent: { _ in }
+    )
+}

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYGeneralPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYGeneralPreferenceViewController.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,7 +42,7 @@
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VCz-7v-qzU" customClass="CPYDesignableButton" customModule="Clipy" customModuleProvider="target">
                     <rect key="frame" x="59" y="160" width="403" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Send crash report and error log (reflected at the next launch)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="LsC-YB-qAw">
+                    <buttonCell key="cell" type="check" title="Send crash reports and usage logs (applies next launch)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="LsC-YB-qAw">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -49,7 +50,7 @@
                         <binding destination="Rq0-bo-cst" name="value" keyPath="values.kCPYCollectCrashReport" id="fJL-An-xXy"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="Aum-MH-ep1">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="Aum-MH-ep1">
                     <rect key="frame" x="59" y="230" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Behavior" id="nDk-8y-89n">
@@ -58,7 +59,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="bPn-Ta-y2W">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="bPn-Ta-y2W">
                     <rect key="frame" x="59" y="135" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Clipboard History" id="OOT-F5-Pal">
@@ -67,7 +68,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="35" translatesAutoresizingMaskIntoConstraints="NO" id="6VU-dp-Epr">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="35" translatesAutoresizingMaskIntoConstraints="NO" id="6VU-dp-Epr">
                     <rect key="frame" x="371" y="105" width="53" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="items" id="eeq-cw-v00">
@@ -76,7 +77,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xqV-G6-XbY">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xqV-G6-XbY">
                     <rect key="frame" x="322" y="105" width="44" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="Gdr-ac-Sdi">
@@ -91,7 +92,7 @@
                         <binding destination="Rq0-bo-cst" name="value" keyPath="values.kCPYPrefMaxHistorySizeKey" id="fNy-AG-mbR"/>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="249" translatesAutoresizingMaskIntoConstraints="NO" id="brY-3U-2fh">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="249" translatesAutoresizingMaskIntoConstraints="NO" id="brY-3U-2fh">
                     <rect key="frame" x="59" y="107" width="253" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Max clipboard history size:" id="Nab-CO-ytH">
@@ -100,7 +101,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="192" translatesAutoresizingMaskIntoConstraints="NO" id="O1y-G2-LAu">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="192" translatesAutoresizingMaskIntoConstraints="NO" id="O1y-G2-LAu">
                     <rect key="frame" x="60" y="81" width="196" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sort history order by:" id="Lps-06-dPB">
@@ -114,7 +115,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Last Used" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="ju3-6a-6xj" id="OT4-9P-YiO">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="8EE-RI-YH4">
                             <items>
                                 <menuItem title="Date Created" id="YmS-J6-ERc"/>
@@ -126,7 +127,7 @@
                         <binding destination="Rq0-bo-cst" name="selectedIndex" keyPath="values.kCPYPrefReorderClipsAfterPasting" id="mcg-ZF-p2J"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="CR1-tn-jHf">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="CR1-tn-jHf">
                     <rect key="frame" x="59" y="47" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Appearance" id="FM4-mw-DCx">
@@ -135,7 +136,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="193" translatesAutoresizingMaskIntoConstraints="NO" id="FPr-bp-NVR">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="193" translatesAutoresizingMaskIntoConstraints="NO" id="FPr-bp-NVR">
                     <rect key="frame" x="59" y="20" width="258" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Status Bar icon style:" id="Faj-kQ-G1v">
@@ -149,7 +150,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="1N9-cv-ChQ" id="Zdh-dV-1hf">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="rTG-88-oYs">
                             <items>
                                 <menuItem state="on" image="statusbar_menu_black" tag="1" id="1N9-cv-ChQ">

--- a/Clipy/Sources/Preferences/Panels/de.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/de.lproj/CPYGeneralPreferenceViewController.strings
@@ -11,8 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
 "Lps-06-dPB.title" = "Verlauf sortieren nach:";
 
-/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
-"LsC-YB-qAw.title" = "Absturzberichte und Fehlerprotokolle senden (Nach dem nächsten Anwendungsstart)";
+/* Class = "NSButtonCell"; title = "Send crash reports and usage logs (applies next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "Crashreports und Nutzungslogs senden (ab nächstem Start)";
 
 /* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
 "Nab-CO-ytH.title" = "Maximale Anzahl im Zwischenablagenverlauf:";

--- a/Clipy/Sources/Preferences/Panels/it.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/it.lproj/CPYGeneralPreferenceViewController.strings
@@ -11,8 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
 "Lps-06-dPB.title" = "Ordina la Cronologia in base a:";
 
-/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
-"LsC-YB-qAw.title" = "Invia rapporti sugli arresti anomali";
+/* Class = "NSButtonCell"; title = "Send crash reports and usage logs (applies next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "Invia crash report e log d'uso (dal prossimo avvio)";
 
 /* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
 "Nab-CO-ytH.title" = "Dimensione massima della Cronologia:";

--- a/Clipy/Sources/Preferences/Panels/ja.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/ja.lproj/CPYGeneralPreferenceViewController.strings
@@ -11,8 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
 "Lps-06-dPB.title" = "履歴のソート順:";
 
-/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
-"LsC-YB-qAw.title" = "クラッシュレポートやエラーログを送信する(次回起動時に反映)";
+/* Class = "NSButtonCell"; title = "Send crash reports and usage logs (applies next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "クラッシュレポートと利用ログを送信する(次回起動時に適用)";
 
 /* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
 "Nab-CO-ytH.title" = "記憶する履歴の数:";

--- a/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYGeneralPreferenceViewController.strings
@@ -11,8 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
 "Lps-06-dPB.title" = "Ordenar o histórico por:";
 
-/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
-"LsC-YB-qAw.title" = "Enviar relatório de erro e log (refletido na próxima inicialização)";
+/* Class = "NSButtonCell"; title = "Send crash reports and usage logs (applies next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "Enviar crash reports e logs de uso (próx. inicialização)";
 
 /* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
 "Nab-CO-ytH.title" = "Tamanho máximo do histórico:";

--- a/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYGeneralPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYGeneralPreferenceViewController.strings
@@ -11,8 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Sort history order by:"; ObjectID = "Lps-06-dPB"; */
 "Lps-06-dPB.title" = "历史排序按照：";
 
-/* Class = "NSButtonCell"; title = "Send crash report and error log (reflected at the next launch)"; ObjectID = "LsC-YB-qAw"; */
-"LsC-YB-qAw.title" = "发送崩溃报告和错误日志（下次启动时生效）";
+/* Class = "NSButtonCell"; title = "Send crash reports and usage logs (applies next launch)"; ObjectID = "LsC-YB-qAw"; */
+"LsC-YB-qAw.title" = "发送崩溃报告和使用日志（下次启动时生效）";
 
 /* Class = "NSTextFieldCell"; title = "Max clipboard history size:"; ObjectID = "Nab-CO-ytH"; */
 "Nab-CO-ytH.title" = "最大剪贴板历史：";

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -33,20 +33,25 @@ final class HotKeyService: NSObject {
 
     @Dependency(\.snippetRepository)
     private var snippetRepository
+    @Dependency(\.firebase)
+    private var firebase
 }
 
 // MARK: - Actions
 extension HotKeyService {
     @objc func popupMainMenu() {
         AppEnvironment.current.menuManager.popUpMenu(.main)
+        firebase.logEvent(event: .popUpMenu(.main))
     }
 
     @objc func popupHistoryMenu() {
         AppEnvironment.current.menuManager.popUpMenu(.history)
+        firebase.logEvent(event: .popUpMenu(.history))
     }
 
     @objc func popUpSnippetMenu() {
         AppEnvironment.current.menuManager.popUpMenu(.snippet)
+        firebase.logEvent(event: .popUpMenu(.snippet))
     }
 
     @objc func popUpClearHistoryAlert() {
@@ -214,6 +219,7 @@ extension HotKeyService {
         }
         guard folderDetail.folder.isEnabled else { return }
         AppEnvironment.current.menuManager.popUpSnippetFolder(folderDetail)
+        firebase.logEvent(event: .popUpSnippetFolderMenu)
     }
 
     fileprivate func setupSnippetHotKeys() {

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -11,7 +11,6 @@
 //
 
 import Cocoa
-import Firebase
 import IOKit
 
 final class CPYUtilities {
@@ -34,15 +33,6 @@ final class CPYUtilities {
         }
         return property.takeRetainedValue() as? String
     }()
-
-    static func initSDKs() {
-        AppEnvironment.current.defaults.register(defaults: ["NSApplicationCrashOnExceptions": true])
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.collectCrashReport) else { return }
-        guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") else { return }
-        guard let options = FirebaseOptions(contentsOfFile: path) else { return }
-        guard FirebaseApp.app() == nil else { return }
-        FirebaseApp.configure(options: options)
-    }
 
     static func registerUserDefaultKeys() {
         var defaultValues = [String: Any]()


### PR DESCRIPTION
## Summary

- Add a Firebase dependency client using swift-dependencies macros.
- Route Firebase configuration and menu analytics logging through the dependency client.
- Update preferences copy and localizations to describe crash reports and usage logs.

## Notes

- Confirmed the Debug build succeeds with Xcode.
- Checked the updated XIB and localized strings for valid syntax.