### PR TITLE
Highlight first menu item on popup

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C57100072FCEB02000C8F965 /* PasteboardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100062FCEB02000C8F965 /* PasteboardContent.swift */; };
 		C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */; };
 		C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */; };
+		C57235112FF24ADE002158F7 /* NSMenu+Highlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57235102FF24AD8002158F7 /* NSMenu+Highlight.swift */; };
 		C57447202FD09FC6000D64D3 /* CPYClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471B2FD09FC6000D64D3 /* CPYClip.swift */; };
 		C57447212FD09FC6000D64D3 /* CPYSnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471E2FD09FC6000D64D3 /* CPYSnippet.swift */; };
 		C57447222FD09FC6000D64D3 /* CPYClipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471C2FD09FC6000D64D3 /* CPYClipData.swift */; };
@@ -178,6 +179,7 @@
 		C57100062FCEB02000C8F965 /* PasteboardContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardContent.swift; sourceTree = "<group>"; };
 		C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardContentTests.swift; sourceTree = "<group>"; };
 		C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+ResizeTests.swift"; sourceTree = "<group>"; };
+		C57235102FF24AD8002158F7 /* NSMenu+Highlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+Highlight.swift"; sourceTree = "<group>"; };
 		C574471A2FD09FC6000D64D3 /* DatabaseMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigration.swift; sourceTree = "<group>"; };
 		C574471B2FD09FC6000D64D3 /* CPYClip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPYClip.swift; sourceTree = "<group>"; };
 		C574471C2FD09FC6000D64D3 /* CPYClipData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPYClipData.swift; sourceTree = "<group>"; };
@@ -488,6 +490,7 @@
 				FA1DB4B21DDCB452007F95C8 /* String+Substring.swift */,
 				FA431F011E6718CE00ACFF56 /* Collection+Safe.swift */,
 				C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */,
+				C57235102FF24AD8002158F7 /* NSMenu+Highlight.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -853,6 +856,7 @@
 				FAC0DCF11DE576F300309C49 /* PasteService.swift in Sources */,
 				FA1DB4E51DDCB49C007F95C8 /* CPYUtilities.swift in Sources */,
 				FA1DB4B81DDCB452007F95C8 /* NSLock+Clipy.swift in Sources */,
+				C57235112FF24ADE002158F7 /* NSMenu+Highlight.swift in Sources */,
 				FA1DB4BA1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift in Sources */,
 				C5700B412FC40ABF00C8F965 /* SnippetFolderDetail.swift in Sources */,
 				C5700B422FC40ABF00C8F965 /* DraggedData.swift in Sources */,

--- a/Clipy/Sources/Extensions/NSMenu+Highlight.swift
+++ b/Clipy/Sources/Extensions/NSMenu+Highlight.swift
@@ -1,0 +1,28 @@
+// 
+//  NSMenu+Highlight.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+// 
+//  Created by Shunsuke Furubayashi on 2026/06/29.
+// 
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+
+/// Uses a private NSMenu API to highlight the first selectable item by default.
+/// ref: https://kazakov.life/2017/05/18/hacking-nsmenu-keyboard-navigation/
+extension NSMenu {
+    func highlightingfirstItemIfPossible() {
+        guard let firstItem = items.first(where: { !$0.isSeparatorItem && !$0.isHidden && $0.isEnabled }) else { return }
+
+        let selector = Selector(("highlightItem:"))
+        guard responds(to: selector) else { return }
+
+        RunLoop.current.perform(inModes: [.eventTracking]) { [weak self, weak firstItem] in
+            self?.perform(selector, with: firstItem)
+        }
+    }
+}

--- a/Clipy/Sources/Extensions/NSMenu+Highlight.swift
+++ b/Clipy/Sources/Extensions/NSMenu+Highlight.swift
@@ -1,12 +1,12 @@
-// 
+//
 //  NSMenu+Highlight.swift
 //
 //  Clipy
 //  GitHub: https://github.com/clipy
 //  HP: https://clipy-app.com
-// 
+//
 //  Created by Shunsuke Furubayashi on 2026/06/29.
-// 
+//
 //  Copyright © 2015-2026 Clipy Project.
 //
 
@@ -15,7 +15,7 @@ import AppKit
 /// Uses a private NSMenu API to highlight the first selectable item by default.
 /// ref: https://kazakov.life/2017/05/18/hacking-nsmenu-keyboard-navigation/
 extension NSMenu {
-    func highlightingfirstItemIfPossible() {
+    func highlightingFirstItemIfPossible() {
         guard let firstItem = items.first(where: { !$0.isSeparatorItem && !$0.isHidden && $0.isEnabled }) else { return }
 
         let selector = Selector(("highlightItem:"))

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -80,6 +80,7 @@ extension MenuManager {
         case .snippet:
             menu = snippetMenu
         }
+        menu?.highlightingfirstItemIfPossible()
         menu?.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
 
@@ -98,6 +99,7 @@ extension MenuManager {
                 folderMenu.addItem(subMenuItem)
                 index += 1
             }
+        folderMenu.highlightingfirstItemIfPossible()
         folderMenu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
 }

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -80,7 +80,7 @@ extension MenuManager {
         case .snippet:
             menu = snippetMenu
         }
-        menu?.highlightingfirstItemIfPossible()
+        menu?.highlightingFirstItemIfPossible()
         menu?.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
 
@@ -99,7 +99,7 @@ extension MenuManager {
                 folderMenu.addItem(subMenuItem)
                 index += 1
             }
-        folderMenu.highlightingfirstItemIfPossible()
+        folderMenu.highlightingFirstItemIfPossible()
         folderMenu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
 }


### PR DESCRIPTION
## Summary
- Add an `NSMenu` extension that highlights the first selectable item when a menu opens.
- Use the private `highlightItem:` API during the event tracking run loop, based on the referenced NSMenu keyboard navigation approach.
- Apply the behavior to the main, history, snippet, and snippet folder popup flows.

## Notes
- This intentionally relies on a private AppKit API, so behavior may change across macOS releases.
- Tests were not run; runtime behavior will be checked manually.

Closed https://github.com/Clipy/Clipy/issues/279