### PR TITLE
Use SMAppService for login items

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
 		C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75E2FB86A0200C9DCB6 /* Magnet */; };
 		C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A7612FB86A1C00C9DCB6 /* KeyHolder */; };
-		C5D3A7652FB86A2C00C9DCB6 /* LoginServiceKit in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A7642FB86A2C00C9DCB6 /* LoginServiceKit */; };
 		C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9D2FBA939E0083839F /* RxCocoa */; };
 		C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9F2FBA939E0083839F /* RxSwift */; };
 		C5D76DA52FBA98A90083839F /* AEXML in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DA42FBA98A90083839F /* AEXML */; };
@@ -284,7 +283,6 @@
 				FAC43E291B35DFDA00C06102 /* Cocoa.framework in Frameworks */,
 				FAC43E271B35DFD300C06102 /* Carbon.framework in Frameworks */,
 				C5D76DA52FBA98A90083839F /* AEXML in Frameworks */,
-				C5D3A7652FB86A2C00C9DCB6 /* LoginServiceKit in Frameworks */,
 				C5D76DA82FBA9C150083839F /* PINCache in Frameworks */,
 				FAC43E251B35DFD000C06102 /* AppKit.framework in Frameworks */,
 				C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */,
@@ -761,7 +759,6 @@
 				C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */,
 				C5D3A75D2FB86A0200C9DCB6 /* XCRemoteSwiftPackageReference "Magnet" */,
 				C5D3A7602FB86A1C00C9DCB6 /* XCRemoteSwiftPackageReference "KeyHolder" */,
-				C5D3A7632FB86A2C00C9DCB6 /* XCRemoteSwiftPackageReference "LoginServiceKit" */,
 				C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				C5D76D9C2FBA939E0083839F /* XCRemoteSwiftPackageReference "RxSwift" */,
 				C5D76DA32FBA98A90083839F /* XCRemoteSwiftPackageReference "AEXML" */,
@@ -1377,14 +1374,6 @@
 				minimumVersion = 4.3.0;
 			};
 		};
-		C5D3A7632FB86A2C00C9DCB6 /* XCRemoteSwiftPackageReference "LoginServiceKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Clipy/LoginServiceKit";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.5.0;
-			};
-		};
 		C5D76D9C2FBA939E0083839F /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -1487,11 +1476,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5D3A7602FB86A1C00C9DCB6 /* XCRemoteSwiftPackageReference "KeyHolder" */;
 			productName = KeyHolder;
-		};
-		C5D3A7642FB86A2C00C9DCB6 /* LoginServiceKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5D3A7632FB86A2C00C9DCB6 /* XCRemoteSwiftPackageReference "LoginServiceKit" */;
-			productName = LoginServiceKit;
 		};
 		C5D76D9D2FBA939E0083839F /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a3351c55f7a919ac2fc96e9a127386c7a2e3a53e8d17d5281513c83271fe8de0",
+  "originHash" : "8406461c0ee4c6ded60f8b736d69f44c3c5f470b86a4f7442150adfc20105792",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -134,15 +134,6 @@
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "loginservicekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Clipy/LoginServiceKit",
-      "state" : {
-        "revision" : "56dce9dbf4367c1445ef2343a2a912bbe5019a6c",
-        "version" : "2.5.0"
       }
     },
     {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -12,11 +12,11 @@
 
 import Cocoa
 import Dependencies
-import LoginServiceKit
 import Magnet
 import RxCocoa
 import RxSwift
 import Screeen
+import ServiceManagement
 import Sparkle
 
 class AppDelegate: NSObject, NSMenuItemValidation {
@@ -117,26 +117,12 @@ class AppDelegate: NSObject, NSMenuItemValidation {
         if alert.runModal() == NSApplication.ModalResponse.alertFirstButtonReturn {
             AppEnvironment.current.defaults.set(true, forKey: Constants.UserDefaults.loginItem)
             AppEnvironment.current.defaults.synchronize()
-            reflectLoginItemState()
         }
         // Do not show this message again
         if alert.suppressionButton?.state == NSControl.StateValue.on {
             AppEnvironment.current.defaults.set(true, forKey: Constants.UserDefaults.suppressAlertForLoginItem)
             AppEnvironment.current.defaults.synchronize()
         }
-    }
-
-    private func toggleAddingToLoginItems(_ isEnable: Bool) {
-        if isEnable {
-            LoginServiceKit.addLoginItems()
-        } else {
-            LoginServiceKit.removeLoginItems()
-        }
-    }
-
-    private func reflectLoginItemState() {
-        let isInLoginItems = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.loginItem)
-        toggleAddingToLoginItems(isInLoginItems)
     }
 }
 
@@ -200,8 +186,14 @@ private extension AppDelegate {
         // Login Item
         AppEnvironment.current.defaults.rx.observe(Bool.self, Constants.UserDefaults.loginItem, retainSelf: false)
             .compactMap { $0 }
-            .subscribe(onNext: { [weak self] _ in
-                self?.reflectLoginItemState()
+            .subscribe(onNext: { isEnabled in
+                if isEnabled {
+                    guard SMAppService.mainApp.status != .enabled else { return }
+                    try? SMAppService.mainApp.register()
+                } else {
+                    guard SMAppService.mainApp.status != .notRegistered else { return }
+                    try? SMAppService.mainApp.unregister()
+                }
             })
             .disposed(by: disposeBag)
         // Observe Screenshot


### PR DESCRIPTION
## Summary

Replace LoginServiceKit usage with macOS ServiceManagement's SMAppService for managing launch-at-login behavior.

This removes the LoginServiceKit Swift package from the Xcode project and Package.resolved, and updates the existing login item defaults observer to register or unregister the main app through SMAppService.

Debug build completed successfully with `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug build`. The build still reports existing warnings from SwiftLint and Crashlytics setup, but it completed successfully.