### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds Dependabot configuration for Swift Package Manager dependencies and GitHub Actions.

The Swift ecosystem entry watches the repository root so Dependabot can discover the Xcode SwiftPM `Package.resolved` file. The GitHub Actions entry watches workflow action references. Both ecosystems use weekly checks and a seven-day cooldown before version update PRs are opened.

## Checks

- Parsed `.github/dependabot.yml` successfully with Ruby YAML.