### PR TITLE
Limit Dependabot to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "swift"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Removes the Swift Package Manager ecosystem from Dependabot configuration and keeps GitHub Actions updates enabled.

The Swift entry is being deferred because Dependabot does not update Xcode SwiftPM `originHash` values in the generated package resolution data, which can leave Xcode-managed package state inconsistent.

## Checks

- Parsed `.github/dependabot.yml` successfully with Ruby YAML.