### PR TITLE
Group CodeQL Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Summary

Group `github/codeql-action/*` updates in Dependabot so `init` and `analyze` are updated together.

## Impact

This avoids CI failures caused by Dependabot opening separate CodeQL action update PRs with mismatched versions.