### PR TITLE
Respect custom paste shortcut

### DIFF
--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clipy/sauce",
       "state" : {
-        "revision" : "c9ebdcfddb4b94da5b9a6ebd113ab385edda88c1",
-        "version" : "2.5.0"
+        "revision" : "84d03fcddebf78e08f3105b1159300bfdae3b217",
+        "version" : "2.5.1"
       }
     },
     {

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -17,6 +17,11 @@ import Sauce
 final class PasteService {
 
     // MARK: - Properties
+    private var pasteMenu: NSMenuItem? = {
+        NSApp.mainMenu?.items
+            .flatMap { $0.submenu?.items ?? [] }
+            .first { $0.action == #selector(NSText.paste(_:)) }
+    }()
     fileprivate let lock = NSRecursiveLock(name: "com.clipy-app.Clipy.Pastable")
     fileprivate var isPastePlainText: Bool {
         guard AppEnvironment.current.defaults.bool(forKey: Constants.Beta.pastePlainText) else { return false }
@@ -114,21 +119,22 @@ extension PasteService {
             Accessibility.showAccessibilityAuthenticationAlert()
             return
         }
-
-        let vKeyCode = Sauce.shared.keyCode(for: .v, cocoaModifiers: .command)
+        let modifier = pasteMenu?.keyEquivalentModifierMask ?? .command
+        let keyCode = Sauce.shared.keyCode(for: pasteMenu?.key ?? .v, cocoaModifiers: modifier)
+        let modifierFlags = CGEventFlags(rawValue: UInt64(modifier.rawValue))
         DispatchQueue.main.async {
             let source = CGEventSource(stateID: .combinedSessionState)
             // Disable local keyboard events while pasting
             source?.setLocalEventsFilterDuringSuppressionState([.permitLocalMouseEvents, .permitSystemDefinedEvents], state: .eventSuppressionStateSuppressionInterval)
-            // Press Command + V
-            let keyVDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
-            keyVDown?.flags = .maskCommand
-            // Release Command + V
-            let keyVUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
-            keyVUp?.flags = .maskCommand
+            // Press paste keyboard shortcut
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
+            keyDown?.flags = modifierFlags
+            // Release paste keyboard shortcut
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+            keyUp?.flags = modifierFlags
             // Post Paste Command
-            keyVDown?.post(tap: .cgAnnotatedSessionEventTap)
-            keyVUp?.post(tap: .cgAnnotatedSessionEventTap)
+            keyDown?.post(tap: .cgAnnotatedSessionEventTap)
+            keyUp?.post(tap: .cgAnnotatedSessionEventTap)
         }
     }
 }

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -120,7 +120,7 @@ extension PasteService {
             return
         }
         let modifier = pasteMenu?.keyEquivalentModifierMask ?? .command
-        let keyCode = Sauce.shared.keyCode(for: pasteMenu?.key ?? .v, cocoaModifiers: modifier)
+        let keyCode = Sauce.shared.keyCode(for: pasteMenu?.key ?? .v, modifiers: .cocoa(modifier))
         let modifierFlags = CGEventFlags(rawValue: UInt64(modifier.rawValue))
         DispatchQueue.main.async {
             let source = CGEventSource(stateID: .combinedSessionState)


### PR DESCRIPTION
## Summary
- Read Clipy's Paste menu item shortcut instead of always posting Command+V.
- Use the resolved key equivalent and modifier mask when synthesizing the paste event.
- Update Sauce to 2.5.1 so AppKit special key equivalents, including function-key menu shortcuts, can be resolved.
- Keep Command+V as the fallback when the menu item shortcut cannot be resolved.

## Details
Clipy previously posted Command+V after a menu item was selected. Users who changed the system Paste shortcut, for example to Control+V, could copy the selected history item but the follow-up paste event still used the old default shortcut. This change makes the generated paste event follow the app's Paste menu item shortcut so macOS keyboard shortcut overrides are respected.

Sauce 2.5.1 adds handling for AppKit's special key-equivalent characters, which lets Clipy resolve menu shortcuts backed by keys such as F1/F2 rather than treating those private-use characters as unknown input.

## Checks
- `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug -derivedDataPath /private/tmp/ClipyDerivedDataSauce -quiet build`

Closes #464