### PR TITLE
Isolate hot key storage in tests

### DIFF
--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -135,7 +135,7 @@ extension AppDelegate: NSApplicationDelegate {
         // Environments
         AppEnvironment.replaceCurrent(environment: AppEnvironment.fromStorage())
         // UserDefaults
-        CPYUtilities.registerUserDefaultKeys()
+        CPYUtilities.registerUserDefaultKeys(AppEnvironment.current.defaults)
 
         guard context != .test else { return }
 

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -14,6 +14,7 @@ import Cocoa
 import Dependencies
 import Foundation
 import Magnet
+import Sharing
 
 final class HotKeyService: NSObject {
     // MARK: - Properties
@@ -35,6 +36,8 @@ final class HotKeyService: NSObject {
     private var snippetRepository
     @Dependency(\.firebase)
     private var firebase
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
 }
 
 // MARK: - Actions
@@ -64,10 +67,10 @@ extension HotKeyService {
 extension HotKeyService {
     func setupDefaultHotKeys() {
         // Migration new framework
-        if !AppEnvironment.current.defaults.bool(forKey: Constants.HotKey.migrateNewKeyCombo) {
+        if !appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) {
             migrationKeyCombos()
-            AppEnvironment.current.defaults.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
-            AppEnvironment.current.defaults.synchronize()
+            appStorage.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
+            appStorage.synchronize()
         }
         // Snippet hotkey
         setupSnippetHotKeys()
@@ -96,8 +99,8 @@ extension HotKeyService {
 
     func changeClearHistoryKeyCombo(_ keyCombo: KeyCombo?) {
         clearHistoryKeyCombo = keyCombo
-        AppEnvironment.current.defaults.set(keyCombo?.archive(), forKey: Constants.HotKey.clearHistoryKeyCombo)
-        AppEnvironment.current.defaults.synchronize()
+        appStorage.set(keyCombo?.archive(), forKey: Constants.HotKey.clearHistoryKeyCombo)
+        appStorage.synchronize()
         // Reset hotkey
         HotKeyCenter.shared.unregisterHotKey(with: "ClearHistory")
         // Register new hotkey
@@ -107,7 +110,7 @@ extension HotKeyService {
     }
 
     private func savedKeyCombo(forKey key: String) -> KeyCombo? {
-        guard let data = AppEnvironment.current.defaults.object(forKey: key) as? Data else { return nil }
+        guard let data = appStorage.object(forKey: key) as? Data else { return nil }
         guard let keyCombo = NSKeyedUnarchiver.unarchiveObject(with: data) as? KeyCombo else { return nil }
         return keyCombo
     }
@@ -126,8 +129,8 @@ private extension HotKeyService {
     }
 
     func save(with type: MenuType, keyCombo: KeyCombo?) {
-        AppEnvironment.current.defaults.set(keyCombo?.archive(), forKey: type.userDefaultsKey)
-        AppEnvironment.current.defaults.synchronize()
+        appStorage.set(keyCombo?.archive(), forKey: type.userDefaultsKey)
+        appStorage.synchronize()
     }
 }
 
@@ -138,24 +141,24 @@ private extension HotKeyService {
      *  Changed framework, PTHotKey to Magnet
      */
     func migrationKeyCombos() {
-        guard let keyCombos = AppEnvironment.current.defaults.object(forKey: Constants.UserDefaults.hotKeys) as? [String: Any] else { return }
+        guard let keyCombos = appStorage.object(forKey: Constants.UserDefaults.hotKeys) as? [String: Any] else { return }
 
         // Main menu
         if let (keyCode, modifiers) = parse(with: keyCombos, forKey: Constants.Menu.clip) {
             if let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers) {
-                AppEnvironment.current.defaults.set(keyCombo.archive(), forKey: Constants.HotKey.mainKeyCombo)
+                appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.mainKeyCombo)
             }
         }
         // History menu
         if let (keyCode, modifiers) = parse(with: keyCombos, forKey: Constants.Menu.history) {
             if let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers) {
-                AppEnvironment.current.defaults.set(keyCombo.archive(), forKey: Constants.HotKey.historyKeyCombo)
+                appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.historyKeyCombo)
             }
         }
         // Snippet menu
         if let (keyCode, modifiers) = parse(with: keyCombos, forKey: Constants.Menu.snippet) {
             if let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers) {
-                AppEnvironment.current.defaults.set(keyCombo.archive(), forKey: Constants.HotKey.snippetKeyCombo)
+                appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.snippetKeyCombo)
             }
         }
     }
@@ -171,16 +174,16 @@ private extension HotKeyService {
 extension HotKeyService {
     private var folderKeyCombos: [String: KeyCombo]? {
         get {
-            guard let data = AppEnvironment.current.defaults.object(forKey: Constants.HotKey.folderKeyCombos) as? Data else { return nil }
+            guard let data = appStorage.object(forKey: Constants.HotKey.folderKeyCombos) as? Data else { return nil }
             return NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: KeyCombo]
         }
         set {
             if let value = newValue {
-                AppEnvironment.current.defaults.set(NSKeyedArchiver.archivedData(withRootObject: value), forKey: Constants.HotKey.folderKeyCombos)
+                appStorage.set(NSKeyedArchiver.archivedData(withRootObject: value), forKey: Constants.HotKey.folderKeyCombos)
             } else {
-                AppEnvironment.current.defaults.removeObject(forKey: Constants.HotKey.folderKeyCombos)
+                appStorage.removeObject(forKey: Constants.HotKey.folderKeyCombos)
             }
-            AppEnvironment.current.defaults.synchronize()
+            appStorage.synchronize()
         }
     }
 

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -34,7 +34,7 @@ final class CPYUtilities {
         return property.takeRetainedValue() as? String
     }()
 
-    static func registerUserDefaultKeys() {
+    static func registerUserDefaultKeys(_ defaults: UserDefaults) {
         var defaultValues = [String: Any]()
 
         defaultValues.updateValue(HotKeyService.defaultKeyCombos, forKey: Constants.UserDefaults.hotKeys)
@@ -83,8 +83,8 @@ final class CPYUtilities {
         defaultValues.updateValue(NSNumber(value: 0), forKey: Constants.Beta.pasteAndDeleteHistoryModifier)
         defaultValues.updateValue(NSNumber(value: false), forKey: Constants.Beta.observerScreenshot)
 
-        AppEnvironment.current.defaults.register(defaults: defaultValues)
-        AppEnvironment.current.defaults.synchronize()
+        defaults.register(defaults: defaultValues)
+        defaults.synchronize()
     }
 
     static func applicationSupportFolder() -> String {

--- a/ClipyTests/HotKeyServiceTests.swift
+++ b/ClipyTests/HotKeyServiceTests.swift
@@ -1,31 +1,19 @@
 import Carbon
+import Dependencies
+import DependenciesTestSupport
 import Foundation
 import Magnet
+import Sharing
 import Testing
 @testable import Clipy
 
-@Suite(.serialized)
+@Suite(.serialized, .dependencies)
 final class HotKeyServiceTests {
-    init() {
-        let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: Constants.UserDefaults.hotKeys)
-        defaults.removeObject(forKey: Constants.HotKey.migrateNewKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.mainKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.historyKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.snippetKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.clearHistoryKeyCombo)
-        defaults.synchronize()
-    }
+    @Dependency(\.defaultAppStorage)
+    var appStorage
 
-    deinit {
-        let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: Constants.UserDefaults.hotKeys)
-        defaults.removeObject(forKey: Constants.HotKey.migrateNewKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.mainKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.historyKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.snippetKeyCombo)
-        defaults.removeObject(forKey: Constants.HotKey.clearHistoryKeyCombo)
-        defaults.synchronize()
+    init() {
+        CPYUtilities.registerUserDefaultKeys(appStorage)
     }
 
     @Test
@@ -35,10 +23,9 @@ final class HotKeyServiceTests {
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
 
-        let defaults = UserDefaults.standard
-        #expect(defaults.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
+        #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
         service.setupDefaultHotKeys()
-        #expect(defaults.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == true)
+        #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == true)
 
         let mainKeyCombo = try #require(service.mainKeyCombo)
         #expect(mainKeyCombo.QWERTYKeyCode == 9)
@@ -66,16 +53,14 @@ final class HotKeyServiceTests {
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
 
-        let defaults = UserDefaults.standard
         let defaultKeyCombos: [String: Any] = [Constants.Menu.clip: ["keyCode": 0, "modifiers": 4352],
                                                Constants.Menu.history: ["keyCode": 9, "modifiers": 768],
                                                Constants.Menu.snippet: ["keyCode": 11, "modifiers": 4352]]
-        defaults.register(defaults: [Constants.UserDefaults.hotKeys: defaultKeyCombos])
-        defaults.synchronize()
+        appStorage.register(defaults: [Constants.UserDefaults.hotKeys: defaultKeyCombos])
 
-        #expect(defaults.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
+        #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
         service.setupDefaultHotKeys()
-        #expect(defaults.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == true)
+        #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == true)
 
         let mainKeyCombo = try #require(service.mainKeyCombo)
         #expect(mainKeyCombo.QWERTYKeyCode == 0)
@@ -98,17 +83,16 @@ final class HotKeyServiceTests {
 
     @Test
     func saveKeyCombos() throws {
-        let defaults = UserDefaults.standard
-        defaults.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
+        appStorage.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
 
         let service = HotKeyService()
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
 
-        #expect(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
-        #expect(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo) == nil)
-        #expect(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo) == nil)
+        #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
+        #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo) == nil)
+        #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo) == nil)
 
         service.setupDefaultHotKeys()
         #expect(service.mainKeyCombo == nil)
@@ -123,9 +107,9 @@ final class HotKeyServiceTests {
         service.change(with: .history, keyCombo: historyKeyCombo)
         service.change(with: .snippet, keyCombo: snippetKeyCombo)
 
-        let savedMainKeyCombo = try #require(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo))
-        let savedHistoryKeyCombo = try #require(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo))
-        let savedSnippetKeyCombo = try #require(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo))
+        let savedMainKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo))
+        let savedHistoryKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo))
+        let savedSnippetKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo))
 
         #expect(savedMainKeyCombo.QWERTYKeyCode == 9)
         #expect(savedMainKeyCombo.modifiers == 768)
@@ -144,21 +128,20 @@ final class HotKeyServiceTests {
 
         service.change(with: .main, keyCombo: nil)
         #expect(service.mainKeyCombo == nil)
-        #expect(defaults.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
+        #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
     }
 
     @Test
     func unarchiveSavedKeyCombos() throws {
-        let defaults = UserDefaults.standard
-        defaults.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
+        appStorage.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
 
         let mainKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 9, carbonModifiers: 768))
         let historyKeyCombo = try #require(KeyCombo(doubledCocoaModifiers: .command))
         let snippetKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 0, cocoaModifiers: .shift))
 
-        defaults.setArchiveData(mainKeyCombo, forKey: Constants.HotKey.mainKeyCombo)
-        defaults.setArchiveData(historyKeyCombo, forKey: Constants.HotKey.historyKeyCombo)
-        defaults.setArchiveData(snippetKeyCombo, forKey: Constants.HotKey.snippetKeyCombo)
+        appStorage.setArchiveData(mainKeyCombo, forKey: Constants.HotKey.mainKeyCombo)
+        appStorage.setArchiveData(historyKeyCombo, forKey: Constants.HotKey.historyKeyCombo)
+        appStorage.setArchiveData(snippetKeyCombo, forKey: Constants.HotKey.snippetKeyCombo)
 
         let service = HotKeyService()
         #expect(service.mainKeyCombo == nil)
@@ -215,8 +198,7 @@ final class HotKeyServiceTests {
         #expect(service.clearHistoryKeyCombo != nil)
         #expect(service.clearHistoryKeyCombo == keyCombo)
 
-        let defaults = UserDefaults.standard
-        let savedData = try #require(defaults.object(forKey: Constants.HotKey.clearHistoryKeyCombo) as? Data)
+        let savedData = try #require(appStorage.object(forKey: Constants.HotKey.clearHistoryKeyCombo) as? Data)
         let savedKeyCombo = try #require(NSKeyedUnarchiver.unarchiveObject(with: savedData) as? KeyCombo)
         #expect(savedKeyCombo == keyCombo)
 


### PR DESCRIPTION
## Summary

This changes hot key storage access to go through the `defaultAppStorage` dependency so tests use Sharing's isolated in-memory `UserDefaults` instead of the local standard defaults.

The default registration helper now accepts an explicit `UserDefaults` instance, and `HotKeyServiceTests` registers defaults against the injected test storage. This keeps local shortcut settings from being reset when the test suite runs.

Checked with:

`xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug -derivedDataPath /private/tmp/ClipyDerivedDataReview test`

Result: `TEST SUCCEEDED`, 75 tests passed.