### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,14 +2,26 @@ name: CI
 
 on: [push, pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
 
 jobs:
   test:
+    # branch protection requires the "test" status check; keep this name in sync
+    name: test
     runs-on: macos-26
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Cache Swift packages
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,12 +7,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
+    name: Lint workflows
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
+      checks: write # required for reviewdog to report actionlint results via the Checks API
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 9 * * 0'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -15,9 +21,7 @@ jobs:
     runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-latest' }}
     
     permissions:
-      security-events: write
-      packages: read
-      actions: read
+      security-events: write # required to upload CodeQL analysis results
       contents: read
 
     strategy:
@@ -31,6 +35,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Cache Swift packages
       if: matrix.language == 'swift'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,12 +9,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
+    name: Security audit
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
+      security-events: write # required to upload zizmor's SARIF results to code scanning
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:


### PR DESCRIPTION
## Summary

Resolves all four open code scanning alerts (11–14) and hardens every workflow until `zizmor --persona=auditor` (its strictest level) reports zero findings.

### Code scanning alert fixes
- **CI.yml**: top-level `permissions: {}` + job-level `contents: read` (alerts 11, 13), `persist-credentials: false` on checkout (alert 12)
- **codeql.yml**: `persist-credentials: false` on checkout (alert 14)

### Additional hardening (pedantic/auditor findings)
- Add `concurrency` groups to all workflows so superseded runs are cancelled — saves macOS runner time on force-pushes
- Add explicit `name:` to all jobs; document each non-default permission with an inline comment
- Add top-level `permissions: {}` to codeql.yml for defense in depth
- Drop CodeQL permissions that a public repository does not need (`packages: read` for private query packs, `actions: read` per the official starter workflow)

> [!NOTE]
> The CI job keeps its exact `test` display name — the develop branch protection requires that status check context, so renaming it would block PR merges.

## Verification

- `actionlint`: pass
- `zizmor` v1.26.1 `--persona=regular` / `pedantic` / `auditor`: **No findings to report** on all four workflows
- The open alerts will auto-close once the scanners re-run on develop after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)