### PR TITLE
Add on-device text recognition for image histories

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -13,9 +13,6 @@
 		C53FC6C02FCCA1C400219A25 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = C53FC6BF2FCCA1C400219A25 /* Collections */; };
 		C54C29D52FC3E20000EF30FB /* SQLiteDataDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */; };
 		C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */; };
-		C5D41A052FDB4A0500EF30FB /* SQLiteDataMigrator+V1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */; };
-		C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */; };
-		C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */; };
 		C54C29D92FC3E22000EF30FB /* SQLiteDataSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D82FC3E21A00EF30FB /* SQLiteDataSchema.swift */; };
 		C5700B412FC40ABF00C8F965 /* SnippetFolderDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */; };
 		C5700B422FC40ABF00C8F965 /* DraggedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */; };
@@ -56,6 +53,9 @@
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
 		C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75E2FB86A0200C9DCB6 /* Magnet */; };
 		C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A7612FB86A1C00C9DCB6 /* KeyHolder */; };
+		C5D41A052FDB4A0500EF30FB /* SQLiteDataMigrator+V1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */; };
+		C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */; };
+		C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */; };
 		C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9D2FBA939E0083839F /* RxCocoa */; };
 		C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9F2FBA939E0083839F /* RxSwift */; };
 		C5D76DA52FBA98A90083839F /* AEXML in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DA42FBA98A90083839F /* AEXML */; };
@@ -65,6 +65,8 @@
 		C5E8EE642FFA260700270F1F /* PasteboardHistoryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */; };
 		C5E8EE682FFA28DD00270F1F /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE672FFA28D900270F1F /* StringExtensions.swift */; };
 		C5E8EE6A2FFA2A5600270F1F /* SnippetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE692FFA2A5000270F1F /* SnippetExtensions.swift */; };
+		C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */; };
+		C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0230190005AA110002 /* TextRecognizer.swift */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
 		FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */; };
 		FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0D5CE71DDCC61600AC9052 /* ClipService.swift */; };
@@ -179,9 +181,6 @@
 		C522FB982FCC019100E61800 /* PasteboardAvailableTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardAvailableTypeTests.swift; sourceTree = "<group>"; };
 		C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataDatabase.swift; sourceTree = "<group>"; };
 		C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataMigrator.swift; sourceTree = "<group>"; };
-		C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V1.swift"; sourceTree = "<group>"; };
-		C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V2.swift"; sourceTree = "<group>"; };
-		C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V3.swift"; sourceTree = "<group>"; };
 		C54C29D82FC3E21A00EF30FB /* SQLiteDataSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataSchema.swift; sourceTree = "<group>"; };
 		C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggedData.swift; sourceTree = "<group>"; };
 		C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetFolderDetail.swift; sourceTree = "<group>"; };
@@ -208,12 +207,17 @@
 		C58E0A812FDAB5B100B3A901 /* ClipyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipyApp.swift; sourceTree = "<group>"; };
 		C5A67BC32FECF0380015A0DE /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		C5A67BC92FECF8640015A0DE /* Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Firebase.swift; sourceTree = "<group>"; };
+		C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V1.swift"; sourceTree = "<group>"; };
+		C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V2.swift"; sourceTree = "<group>"; };
+		C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V3.swift"; sourceTree = "<group>"; };
 		C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardHistoryExtensions.swift; sourceTree = "<group>"; };
 		C5E8EE672FFA28D900270F1F /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		C5E8EE692FFA2A5000270F1F /* SnippetExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExtensions.swift; sourceTree = "<group>"; };
 		C5E8EE6D2FFA46F400270F1F /* PasteboardHistoryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardHistoryExtensionsTests.swift; sourceTree = "<group>"; };
 		C5E8EE6F2FFA46F400270F1F /* SnippetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExtensionsTests.swift; sourceTree = "<group>"; };
 		C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
+		C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V4.swift"; sourceTree = "<group>"; };
+		C5F1AD0230190005AA110002 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
 		FA0D5CE71DDCC61600AC9052 /* ClipService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipService.swift; sourceTree = "<group>"; };
@@ -368,17 +372,6 @@
 			path = Database;
 			sourceTree = "<group>";
 		};
-		C5D41A012FDB4A0100EF30FB /* Migrations */ = {
-			isa = PBXGroup;
-			children = (
-				C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */,
-				C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */,
-				C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */,
-				C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */,
-			);
-			path = Migrations;
-			sourceTree = "<group>";
-		};
 		C5700B452FC40BBF00C8F965 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
@@ -466,6 +459,26 @@
 			path = Accessibility;
 			sourceTree = "<group>";
 		};
+		C5D41A012FDB4A0100EF30FB /* Migrations */ = {
+			isa = PBXGroup;
+			children = (
+				C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */,
+				C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */,
+				C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */,
+				C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */,
+				C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */,
+			);
+			path = Migrations;
+			sourceTree = "<group>";
+		};
+		C5F1AD0330190005AA110003 /* OCR */ = {
+			isa = PBXGroup;
+			children = (
+				C5F1AD0230190005AA110002 /* TextRecognizer.swift */,
+			);
+			path = OCR;
+			sourceTree = "<group>";
+		};
 		FA06D2D21DD882BD002FB7C2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -501,6 +514,7 @@
 				C57447262FD09FD9000D64D3 /* Dependencies */,
 				C54C29D32FC3E1F500EF30FB /* Database */,
 				C5700B452FC40BBF00C8F965 /* Repositories */,
+				C5F1AD0330190005AA110003 /* OCR */,
 				C5A67BC22FECF0010015A0DE /* Accessibility */,
 				FA3778911F3B690D003B5BAB /* Environments */,
 				FA0D5CE61DDCC5D000AC9052 /* Services */,
@@ -926,6 +940,7 @@
 				C5E8EE6A2FFA2A5600270F1F /* SnippetExtensions.swift in Sources */,
 				FA1DB4B91DDCB452007F95C8 /* NSMenuItem+Initialize.swift in Sources */,
 				FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */,
+				C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */,
 				FA1DB4C91DDCB460007F95C8 /* MenuManager.swift in Sources */,
 				FA1189331E4CD58C00244F12 /* ExcludeAppService.swift in Sources */,
 				FA1DB4E91DDCB49C007F95C8 /* CPYSplitView.swift in Sources */,
@@ -956,6 +971,7 @@
 				C5D41A052FDB4A0500EF30FB /* SQLiteDataMigrator+V1.swift in Sources */,
 				C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */,
 				C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */,
+				C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */,
 				FA3778951F3B6920003B5BAB /* Environment.swift in Sources */,
 			);
 		};

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		C50767032FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */; };
 		C522FB952FCBD6AA00E61800 /* PasteboardAvailableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB942FCBD69A00E61800 /* PasteboardAvailableType.swift */; };
 		C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB982FCC019100E61800 /* PasteboardAvailableTypeTests.swift */; };
+		C5348FB130008FE4008DFEB3 /* WaitUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5348FB030008FE1008DFEB3 /* WaitUntil.swift */; };
 		C53FC6C02FCCA1C400219A25 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = C53FC6BF2FCCA1C400219A25 /* Collections */; };
 		C54C29D52FC3E20000EF30FB /* SQLiteDataDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */; };
 		C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */; };
@@ -18,9 +19,6 @@
 		C5700B422FC40ABF00C8F965 /* DraggedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */; };
 		C5700B462FC40BBF00C8F965 /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B442FC40BBF00C8F965 /* SnippetRepository.swift */; };
 		C5700B492FC5C0E500C8F965 /* SQLiteDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */; };
-		C5D41A0C2FDB4A0C00EF30FB /* SQLiteDataMigratorTests+V1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */; };
-		C5D41A0D2FDB4A0D00EF30FB /* SQLiteDataMigratorTests+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */; };
-		C5D41A0E2FDB4A0E00EF30FB /* SQLiteDataMigratorTests+V3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */; };
 		C5700B4C2FC5C3D500C8F965 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = C5700B4B2FC5C3D500C8F965 /* Dependencies */; };
 		C5700B4E2FC5C3D500C8F965 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = C5700B4D2FC5C3D500C8F965 /* DependenciesTestSupport */; };
 		C5700B502FD106000C8F965 /* DatabaseMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B4F2FD106000C8F965 /* DatabaseMigrationTests.swift */; };
@@ -30,9 +28,6 @@
 		C57100072FCEB02000C8F965 /* PasteboardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100062FCEB02000C8F965 /* PasteboardContent.swift */; };
 		C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C571000B2FCEB03000C8F965 /* PasteboardContentTests.swift */; };
 		C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57100102FCEB45000C8F965 /* NSImage+ResizeTests.swift */; };
-		C5E8EE6E2FFA46F400270F1F /* PasteboardHistoryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE6D2FFA46F400270F1F /* PasteboardHistoryExtensionsTests.swift */; };
-		C5E8EE702FFA46F400270F1F /* SnippetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE6F2FFA46F400270F1F /* SnippetExtensionsTests.swift */; };
-		C5E8EE722FFA46F400270F1F /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */; };
 		C57235112FF24ADE002158F7 /* NSMenu+Highlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57235102FF24AD8002158F7 /* NSMenu+Highlight.swift */; };
 		C57447202FD09FC6000D64D3 /* CPYClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471B2FD09FC6000D64D3 /* CPYClip.swift */; };
 		C57447212FD09FC6000D64D3 /* CPYSnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C574471E2FD09FC6000D64D3 /* CPYSnippet.swift */; };
@@ -56,6 +51,9 @@
 		C5D41A052FDB4A0500EF30FB /* SQLiteDataMigrator+V1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */; };
 		C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */; };
 		C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */; };
+		C5D41A0C2FDB4A0C00EF30FB /* SQLiteDataMigratorTests+V1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */; };
+		C5D41A0D2FDB4A0D00EF30FB /* SQLiteDataMigratorTests+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */; };
+		C5D41A0E2FDB4A0E00EF30FB /* SQLiteDataMigratorTests+V3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */; };
 		C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9D2FBA939E0083839F /* RxCocoa */; };
 		C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9F2FBA939E0083839F /* RxSwift */; };
 		C5D76DA52FBA98A90083839F /* AEXML in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DA42FBA98A90083839F /* AEXML */; };
@@ -65,8 +63,13 @@
 		C5E8EE642FFA260700270F1F /* PasteboardHistoryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */; };
 		C5E8EE682FFA28DD00270F1F /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE672FFA28D900270F1F /* StringExtensions.swift */; };
 		C5E8EE6A2FFA2A5600270F1F /* SnippetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE692FFA2A5000270F1F /* SnippetExtensions.swift */; };
+		C5E8EE6E2FFA46F400270F1F /* PasteboardHistoryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE6D2FFA46F400270F1F /* PasteboardHistoryExtensionsTests.swift */; };
+		C5E8EE702FFA46F400270F1F /* SnippetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE6F2FFA46F400270F1F /* SnippetExtensionsTests.swift */; };
+		C5E8EE722FFA46F400270F1F /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */; };
 		C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */; };
+		C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */; };
 		C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0230190005AA110002 /* TextRecognizer.swift */; };
+		C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
 		FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */; };
 		FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0D5CE71DDCC61600AC9052 /* ClipService.swift */; };
@@ -179,6 +182,7 @@
 		C5208B8E2FC6E8B000BC4568 /* CodeSigning-AdHoc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CodeSigning-AdHoc.xcconfig"; sourceTree = "<group>"; };
 		C522FB942FCBD69A00E61800 /* PasteboardAvailableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardAvailableType.swift; sourceTree = "<group>"; };
 		C522FB982FCC019100E61800 /* PasteboardAvailableTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardAvailableTypeTests.swift; sourceTree = "<group>"; };
+		C5348FB030008FE1008DFEB3 /* WaitUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitUntil.swift; sourceTree = "<group>"; };
 		C54C29D42FC3E1FD00EF30FB /* SQLiteDataDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataDatabase.swift; sourceTree = "<group>"; };
 		C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataMigrator.swift; sourceTree = "<group>"; };
 		C54C29D82FC3E21A00EF30FB /* SQLiteDataSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataSchema.swift; sourceTree = "<group>"; };
@@ -186,9 +190,6 @@
 		C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetFolderDetail.swift; sourceTree = "<group>"; };
 		C5700B442FC40BBF00C8F965 /* SnippetRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetRepository.swift; sourceTree = "<group>"; };
 		C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataMigratorTests.swift; sourceTree = "<group>"; };
-		C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V1.swift"; sourceTree = "<group>"; };
-		C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V2.swift"; sourceTree = "<group>"; };
-		C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V3.swift"; sourceTree = "<group>"; };
 		C5700B4F2FD106000C8F965 /* DatabaseMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigrationTests.swift; sourceTree = "<group>"; };
 		C57100002FCAE00000C8F965 /* SnippetRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetRepositoryTests.swift; sourceTree = "<group>"; };
 		C57100022FCEB00000C8F965 /* PasteboardHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardHistoryRepository.swift; sourceTree = "<group>"; };
@@ -210,6 +211,9 @@
 		C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V1.swift"; sourceTree = "<group>"; };
 		C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V2.swift"; sourceTree = "<group>"; };
 		C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V3.swift"; sourceTree = "<group>"; };
+		C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V1.swift"; sourceTree = "<group>"; };
+		C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V2.swift"; sourceTree = "<group>"; };
+		C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V3.swift"; sourceTree = "<group>"; };
 		C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardHistoryExtensions.swift; sourceTree = "<group>"; };
 		C5E8EE672FFA28D900270F1F /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		C5E8EE692FFA2A5000270F1F /* SnippetExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExtensions.swift; sourceTree = "<group>"; };
@@ -217,7 +221,9 @@
 		C5E8EE6F2FFA46F400270F1F /* SnippetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExtensionsTests.swift; sourceTree = "<group>"; };
 		C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V4.swift"; sourceTree = "<group>"; };
+		C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V4.swift"; sourceTree = "<group>"; };
 		C5F1AD0230190005AA110002 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
+		C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizerTests.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
 		FA0D5CE71DDCC61600AC9052 /* ClipService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipService.swift; sourceTree = "<group>"; };
@@ -360,6 +366,14 @@
 			path = Configurations;
 			sourceTree = "<group>";
 		};
+		C5348FAF30008FDF008DFEB3 /* TestSupport */ = {
+			isa = PBXGroup;
+			children = (
+				C5348FB030008FE1008DFEB3 /* WaitUntil.swift */,
+			);
+			path = TestSupport;
+			sourceTree = "<group>";
+		};
 		C54C29D32FC3E1F500EF30FB /* Database */ = {
 			isa = PBXGroup;
 			children = (
@@ -389,17 +403,6 @@
 				C5700B4F2FD106000C8F965 /* DatabaseMigrationTests.swift */,
 			);
 			path = Database;
-			sourceTree = "<group>";
-		};
-		C5D41A082FDB4A0800EF30FB /* Migrations */ = {
-			isa = PBXGroup;
-			children = (
-				C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */,
-				C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */,
-				C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */,
-				C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */,
-			);
-			path = Migrations;
 			sourceTree = "<group>";
 		};
 		C5700B4F2FC5C8C800C8F965 /* Repositories */ = {
@@ -471,10 +474,30 @@
 			path = Migrations;
 			sourceTree = "<group>";
 		};
+		C5D41A082FDB4A0800EF30FB /* Migrations */ = {
+			isa = PBXGroup;
+			children = (
+				C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */,
+				C5D41A092FDB4A0900EF30FB /* SQLiteDataMigratorTests+V1.swift */,
+				C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */,
+				C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */,
+				C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */,
+			);
+			path = Migrations;
+			sourceTree = "<group>";
+		};
 		C5F1AD0330190005AA110003 /* OCR */ = {
 			isa = PBXGroup;
 			children = (
 				C5F1AD0230190005AA110002 /* TextRecognizer.swift */,
+			);
+			path = OCR;
+			sourceTree = "<group>";
+		};
+		C5F1AD0630190005AA110006 /* OCR */ = {
+			isa = PBXGroup;
+			children = (
+				C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */,
 			);
 			path = OCR;
 			sourceTree = "<group>";
@@ -714,7 +737,9 @@
 		FAC43DDB1B35D8B100C06102 /* ClipyTests */ = {
 			isa = PBXGroup;
 			children = (
+				C5348FAF30008FDF008DFEB3 /* TestSupport */,
 				C5700B472FC5C0DB00C8F965 /* Database */,
+				C5F1AD0630190005AA110006 /* OCR */,
 				C571000D2FCEB44000C8F965 /* Extensions */,
 				C571000C2FCEB03000C8F965 /* Models */,
 				C5700B4F2FC5C8C800C8F965 /* Repositories */,
@@ -983,7 +1008,10 @@
 				C5D41A0C2FDB4A0C00EF30FB /* SQLiteDataMigratorTests+V1.swift in Sources */,
 				C5D41A0D2FDB4A0D00EF30FB /* SQLiteDataMigratorTests+V2.swift in Sources */,
 				C5D41A0E2FDB4A0E00EF30FB /* SQLiteDataMigratorTests+V3.swift in Sources */,
+				C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */,
+				C5348FB130008FE4008DFEB3 /* WaitUntil.swift in Sources */,
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */,
+				C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */,
 				FA6167941D3ACCB90049FA14 /* DraggedDataTests.swift in Sources */,
 				C571000A2FCEB03000C8F965 /* PasteboardContentTests.swift in Sources */,
 				C57100112FCEB45000C8F965 /* NSImage+ResizeTests.swift in Sources */,

--- a/Clipy/Sources/Database/DatabaseMigration.swift
+++ b/Clipy/Sources/Database/DatabaseMigration.swift
@@ -56,6 +56,7 @@ struct DatabaseMigration {
                     historiesByID[id] = PasteboardHistory(
                         id: id,
                         title: clip.title,
+                        ocrText: nil,
                         pasteboardTypes: content.types,
                         createdAt: clip.updateTime,
                         updateAt: clip.updateTime,

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V4.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V4.swift
@@ -1,0 +1,119 @@
+//
+//  SQLiteDataMigrator+V4.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/07/09.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+
+extension DatabaseMigrator {
+    mutating func registerMigrationV4() {
+        registerMigration("Add OCR text to history search") { database in
+            try #sql(
+                """
+                ALTER TABLE "pasteboardHistories"
+                ADD COLUMN "ocrText" TEXT
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                DROP TRIGGER "insert_pasteboardHistories_into_pasteboardHistorySearches"
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                DROP TRIGGER "update_pasteboardHistories_in_pasteboardHistorySearches"
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                DROP TRIGGER "delete_pasteboardHistories_from_pasteboardHistorySearches"
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                DROP TABLE "pasteboardHistorySearches"
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE VIRTUAL TABLE "pasteboardHistorySearches"
+                USING fts5(
+                  "id" UNINDEXED,
+                  "title",
+                  "ocrText",
+                  tokenize = 'trigram'
+                )
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "insert_pasteboardHistories_into_pasteboardHistorySearches"
+                AFTER INSERT ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = new."id";
+
+                  INSERT INTO "pasteboardHistorySearches" ("id", "title", "ocrText")
+                  VALUES (new."id", new."title", coalesce(new."ocrText", ''));
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "update_pasteboardHistories_in_pasteboardHistorySearches"
+                AFTER UPDATE OF "id", "title", "ocrText" ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = old."id";
+
+                  INSERT INTO "pasteboardHistorySearches" ("id", "title", "ocrText")
+                  VALUES (new."id", new."title", coalesce(new."ocrText", ''));
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                CREATE TRIGGER "delete_pasteboardHistories_from_pasteboardHistorySearches"
+                AFTER DELETE ON "pasteboardHistories"
+                BEGIN
+                  DELETE FROM "pasteboardHistorySearches"
+                  WHERE "id" = old."id";
+                END
+                """
+            )
+            .execute(database)
+
+            try #sql(
+                """
+                INSERT INTO "pasteboardHistorySearches" ("id", "title", "ocrText")
+                SELECT "id", "title", coalesce("ocrText", '')
+                FROM "pasteboardHistories"
+                """
+            )
+            .execute(database)
+        }
+    }
+}

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
@@ -17,5 +17,6 @@ extension DatabaseMigrator {
         registerMigrationV1()
         registerMigrationV2()
         registerMigrationV3()
+        registerMigrationV4()
     }
 }

--- a/Clipy/Sources/Database/SQLiteDataSchema.swift
+++ b/Clipy/Sources/Database/SQLiteDataSchema.swift
@@ -21,6 +21,7 @@ struct PasteboardHistory: Identifiable, Equatable {
     @Column(primaryKey: true)
     let id: ID
     let title: String
+    let ocrText: String?
     @Column(as: [NSPasteboard.PasteboardType].JSONRepresentation.self)
     let pasteboardTypes: [NSPasteboard.PasteboardType]
     let createdAt: Int
@@ -64,6 +65,7 @@ struct PasteboardHistoryDetail: Equatable {
 struct PasteboardHistorySearch: FTS5, Equatable {
     let id: PasteboardHistory.ID
     let title: String
+    let ocrText: String
 }
 
 @Selection

--- a/Clipy/Sources/Models/PasteboardContent.swift
+++ b/Clipy/Sources/Models/PasteboardContent.swift
@@ -40,16 +40,14 @@ struct PasteboardContent: Equatable {
         let defaults = UserDefaults.standard
         let width = defaults.integer(forKey: Constants.UserDefaults.thumbnailWidth)
         let height = defaults.integer(forKey: Constants.UserDefaults.thumbnailHeight)
-
-        let imageURL = assets.filter { $0.type == .fileURL }
-            .compactMap { URL(dataRepresentation: $0.data, relativeTo: nil) }
-            .first(where: { ["jpg", "jpeg", "png", "bmp", "tiff"].contains($0.pathExtension.lowercased()) })
-        if let imageURL {
-            return NSImage(contentsOf: imageURL)?.resizeImage(CGFloat(width), CGFloat(height))
-        } else if let data = data(for: .png) ?? data(for: .tiff) ?? data(for: .deprecatedTIFF) {
-            return NSImage(data: data)?.resizeImage(CGFloat(width), CGFloat(height))
+        guard let imageData else { return nil }
+        return NSImage(data: imageData)?.resizeImage(CGFloat(width), CGFloat(height))
+    }
+    var imageData: Data? {
+        if let imageFileURL {
+            return try? Data(contentsOf: imageFileURL)
         }
-        return nil
+        return storedImageData
     }
     var pasteboardItems: [NSPasteboardItem] {
         var countsByType: [NSPasteboard.PasteboardType: Int] = [:]
@@ -129,6 +127,16 @@ extension PasteboardContent {
 }
 
 private extension PasteboardContent {
+    var storedImageData: Data? {
+        data(for: .png) ?? data(for: .tiff) ?? data(for: .deprecatedTIFF)
+    }
+
+    var imageFileURL: URL? {
+        assets.filter { $0.type == .fileURL }
+            .compactMap { URL(dataRepresentation: $0.data, relativeTo: nil) }
+            .first { ["jpg", "jpeg", "png", "bmp", "tiff"].contains($0.pathExtension.lowercased()) }
+    }
+
     func data(for type: NSPasteboard.PasteboardType) -> Data? {
         assets.first(where: { $0.type == type })?.data
     }

--- a/Clipy/Sources/OCR/TextRecognizer.swift
+++ b/Clipy/Sources/OCR/TextRecognizer.swift
@@ -1,0 +1,61 @@
+//
+//  TextRecognizer.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/07/10.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Dependencies
+import Foundation
+import Vision
+
+protocol TextRecognizerProtocol {
+    func recognizeTextIfNeeded(id: PasteboardHistory.ID)
+}
+
+final class TextRecognizer: TextRecognizerProtocol {
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
+
+    private let queue = DispatchQueue(label: "com.clipy-app.Clipy.TextRecognizer", qos: .utility)
+
+    func recognizeTextIfNeeded(id: PasteboardHistory.ID) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard let history = self.pasteboardHistoryRepository.fetchHistory(id: id), history.ocrText == nil else { return }
+            guard let imageData = self.pasteboardHistoryRepository.fetchContent(id: id)?.imageData else { return }
+            let text = recognizedText(in: imageData) ?? ""
+            pasteboardHistoryRepository.updateOCRText(id: id, ocrText: String(text.prefix(10000)))
+        }
+    }
+}
+
+private extension TextRecognizer {
+    func recognizedText(in imageData: Data) -> String? {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        request.automaticallyDetectsLanguage = true
+        let handler = VNImageRequestHandler(data: imageData)
+        try? handler.perform([request])
+        return request.results?
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n")
+    }
+}
+
+private enum TextRecognizerKey: DependencyKey {
+    static let liveValue: any TextRecognizerProtocol = TextRecognizer()
+}
+
+extension DependencyValues {
+    var textRecognizer: any TextRecognizerProtocol {
+        get { self[TextRecognizerKey.self] }
+        set { self[TextRecognizerKey.self] = newValue }
+    }
+}

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -27,6 +27,7 @@ protocol PasteboardHistoryRepositoryProtocol {
     func fetchContent(id: PasteboardHistory.ID) -> PasteboardContent?
 
     func save(id: PasteboardHistory.ID, content: PasteboardContent, updateAt: Int)
+    func updateOCRText(id: PasteboardHistory.ID, ocrText: String)
     func deleteHistory(id: PasteboardHistory.ID)
     func deleteAll()
     func deleteOverflowingHistories(maxHistorySize: Int)
@@ -119,6 +120,7 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                 let history = PasteboardHistory(
                     id: id,
                     title: String(content.stringValue.prefix(10000)),
+                    ocrText: existingHistory?.ocrText,
                     pasteboardTypes: content.types,
                     createdAt: existingHistory?.createdAt ?? updateAt,
                     updateAt: updateAt,
@@ -143,6 +145,17 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                         try PasteboardHistoryThumbnailAsset.insert { thumbnailAsset }.execute(database)
                     }
                 }
+            }
+        }
+    }
+
+    func updateOCRText(id: PasteboardHistory.ID, ocrText: String) {
+        withErrorReporting {
+            try database.write { database in
+                try PasteboardHistory
+                    .find(id)
+                    .update { $0.ocrText = #bind(ocrText) }
+                    .execute(database)
             }
         }
     }

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -28,6 +28,8 @@ final class ClipService {
 
     @Dependency(\.pasteboardHistoryRepository)
     private var pasteboardHistoryRepository
+    @Dependency(\.textRecognizer)
+    private var textRecognizer
 
     // MARK: - Clips
     func startMonitoring() {
@@ -117,6 +119,8 @@ extension ClipService {
         let savedHash = (isOverwriteHistory) ? content.hash : UUID().uuidString
 
         let unixTime = Int(Date().timeIntervalSince1970)
-        pasteboardHistoryRepository.save(id: .init(rawValue: savedHash), content: content, updateAt: unixTime)
+        let id = PasteboardHistory.ID(rawValue: savedHash)
+        pasteboardHistoryRepository.save(id: id, content: content, updateAt: unixTime)
+        textRecognizer.recognizeTextIfNeeded(id: id)
     }
 }

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V4.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V4.swift
@@ -1,0 +1,116 @@
+//
+//  SQLiteDataMigratorTests+V4.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/07/09.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+import Testing
+@testable import Clipy
+
+extension SQLiteDataMigratorTests {
+    @Test
+    func migrationV4() throws {
+        let database = try DatabaseQueue()
+        var migrator = DatabaseMigrator()
+        migrator.registerMigrationV1()
+        migrator.registerMigrationV2()
+        migrator.registerMigrationV3()
+        migrator.registerMigrationV4()
+        try migrator.migrate(database)
+
+        try expectV2TableNames(database)
+        try expectV2Triggers(database)
+        try expectV3Indexes(database)
+        try expectV4Tables(database)
+    }
+
+    func expectV4Tables(_ database: DatabaseQueue) throws {
+        try database.read { database in
+            let columnNames = try columnNames(of: "pasteboardHistories", database: database)
+            #expect(
+                columnNames == [
+                    "createdAt",
+                    "deviceID",
+                    "id",
+                    "ocrText",
+                    "pasteboardTypes",
+                    "title",
+                    "updateAt"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "pasteboardHistoryAssets", database: database)
+            #expect(
+                columnNames == [
+                    "data",
+                    "id",
+                    "index",
+                    "pasteboardHistoryID",
+                    "pasteboardType"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "pasteboardHistoryThumbnailAssets", database: database)
+            #expect(
+                columnNames == [
+                    "data",
+                    "kind",
+                    "pasteboardHistoryID"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "snippetFolders", database: database)
+            #expect(
+                columnNames == [
+                    "id",
+                    "index",
+                    "isEnabled",
+                    "title"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "snippets", database: database)
+            #expect(
+                columnNames == [
+                    "content",
+                    "folderID",
+                    "id",
+                    "index",
+                    "isEnabled",
+                    "title"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "pasteboardHistorySearches", database: database)
+            #expect(
+                columnNames == [
+                    "id",
+                    "ocrText",
+                    "title"
+                ]
+            )
+        }
+        try database.read { database in
+            let columnNames = try columnNames(of: "snippetSearches", database: database)
+            #expect(
+                columnNames == [
+                    "content",
+                    "id",
+                    "title"
+                ]
+            )
+        }
+    }
+}

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
@@ -30,7 +30,8 @@ struct SQLiteDataMigratorTests {
                 identifiers == [
                     "Create initial tables",
                     "Create search indexes",
-                    "Add createdAt to pasteboardHistories"
+                    "Add createdAt to pasteboardHistories",
+                    "Add OCR text to history search"
                 ]
             )
         }

--- a/ClipyTests/Database/SQLiteDataDatabase+TriggerTests.swift
+++ b/ClipyTests/Database/SQLiteDataDatabase+TriggerTests.swift
@@ -35,6 +35,7 @@ struct SQLiteDataDatabaseTriggerTests {
                 PasteboardHistory(
                     id: historyID,
                     title: "Xqa History Start",
+                    ocrText: nil,
                     pasteboardTypes: [.string],
                     createdAt: 1,
                     updateAt: 1,
@@ -67,17 +68,12 @@ struct SQLiteDataDatabaseTriggerTests {
         }
 
         try database.write { database in
-            try PasteboardHistory.upsert {
-                PasteboardHistory(
-                    id: historyID,
-                    title: "Rpb History Finish",
-                    pasteboardTypes: [.string],
-                    createdAt: 1,
-                    updateAt: 2,
-                    deviceID: nil
-                )
-            }
-            .execute(database)
+            try PasteboardHistory.where { $0.id.eq(historyID) }
+                .update {
+                    $0.title = #bind("Rpb History Finish")
+                    $0.updateAt = 2
+                }
+                .execute(database)
         }
 
         try database.read { database in
@@ -88,6 +84,22 @@ struct SQLiteDataDatabaseTriggerTests {
             let upsertedHistoryIDs = try pasteboardHistories(matching: "rpb", database: database)
                 .map(\.history?.id)
             #expect(upsertedHistoryIDs == [historyID])
+        }
+
+        try database.write { database in
+            try PasteboardHistory.where { $0.id.eq(historyID) }
+                .update { $0.ocrText = #bind("Zvw Screenshot Text") }
+                .execute(database)
+        }
+
+        try database.read { database in
+            let ocrHistoryIDs = try pasteboardHistories(matching: "zvw", database: database)
+                .map(\.history?.id)
+            #expect(ocrHistoryIDs == [historyID])
+
+            let titleHistoryIDs = try pasteboardHistories(matching: "rpb", database: database)
+                .map(\.history?.id)
+            #expect(titleHistoryIDs == [historyID])
         }
 
         try database.write { database in
@@ -168,17 +180,12 @@ struct SQLiteDataDatabaseTriggerTests {
         }
 
         try database.write { database in
-            try Snippet.upsert {
-                Snippet(
-                    id: snippetID,
-                    folderID: folderID,
-                    title: "Rpb Snippet Finish",
-                    content: "rst token",
-                    index: 0,
-                    isEnabled: true
-                )
-            }
-            .execute(database)
+            try Snippet.where { $0.id.eq(snippetID) }
+                .update {
+                    $0.title = "Rpb Snippet Finish"
+                    $0.content = "rst token"
+                }
+                .execute(database)
         }
 
         try database.read { database in

--- a/ClipyTests/Extensions/PasteboardHistoryExtensionsTests.swift
+++ b/ClipyTests/Extensions/PasteboardHistoryExtensionsTests.swift
@@ -151,6 +151,7 @@ private extension PasteboardHistoryExtensionsTests {
         PasteboardHistory(
             id: PasteboardHistory.ID(rawValue: UUID().uuidString),
             title: title,
+            ocrText: nil,
             pasteboardTypes: pasteboardTypes,
             createdAt: 1,
             updateAt: 1,

--- a/ClipyTests/OCR/TextRecognizerTests.swift
+++ b/ClipyTests/OCR/TextRecognizerTests.swift
@@ -1,0 +1,122 @@
+//
+//  TextRecognizerTests.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/07/10.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Dependencies
+import DependenciesTestSupport
+import SQLiteData
+import Testing
+@testable import Clipy
+
+@MainActor
+@Suite(
+    .dependencies {
+        try $0.bootstrapDatabase()
+    }
+)
+struct TextRecognizerTests {
+    let repository: PasteboardHistoryRepository
+    let textRecognizer: TextRecognizer
+
+    init() {
+        let repository = PasteboardHistoryRepository()
+        self.repository = repository
+        self.textRecognizer = withDependencies {
+            $0.pasteboardHistoryRepository = repository
+        } operation: {
+            TextRecognizer()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recognizeTextIfNeededStoresRecognizedText() async throws {
+        let content = try #require(PasteboardContent(image: renderedTextImage(text: "CLIPY 12345")))
+        let id = PasteboardHistory.ID(rawValue: content.hash)
+        repository.save(id: id, content: content, updateAt: 1)
+
+        textRecognizer.recognizeTextIfNeeded(id: id)
+
+        try await waitUntil { self.repository.fetchHistory(id: id)?.ocrText != nil }
+        #expect(repository.fetchHistory(id: id)?.ocrText?.contains("12345") == true)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recognizeTextIfNeededStoresEmptyTextForImagesWithoutText() async throws {
+        let content = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 64, height: 64)))
+        )
+        let id = PasteboardHistory.ID(rawValue: content.hash)
+        repository.save(id: id, content: content, updateAt: 1)
+
+        textRecognizer.recognizeTextIfNeeded(id: id)
+
+        try await waitUntil { self.repository.fetchHistory(id: id)?.ocrText != nil }
+        #expect(repository.fetchHistory(id: id)?.ocrText == "")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recognizeTextIfNeededSkipsAlreadyRecognizedHistories() async throws {
+        let recognizedContent = try #require(PasteboardContent(image: renderedTextImage(text: "CLIPY 12345")))
+        let recognizedID = PasteboardHistory.ID(rawValue: recognizedContent.hash)
+        repository.save(id: recognizedID, content: recognizedContent, updateAt: 1)
+        repository.updateOCRText(id: recognizedID, ocrText: "Already Recognized")
+
+        let pendingContent = try #require(PasteboardContent(image: renderedTextImage(text: "PENDING 67890")))
+        let pendingID = PasteboardHistory.ID(rawValue: pendingContent.hash)
+        repository.save(id: pendingID, content: pendingContent, updateAt: 2)
+
+        textRecognizer.recognizeTextIfNeeded(id: recognizedID)
+        textRecognizer.recognizeTextIfNeeded(id: pendingID)
+
+        try await waitUntil { self.repository.fetchHistory(id: pendingID)?.ocrText != nil }
+        #expect(repository.fetchHistory(id: recognizedID)?.ocrText == "Already Recognized")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recognizeTextIfNeededLeavesHistoriesWithoutImagesUnrecognized() async throws {
+        let textContent = try #require(
+            PasteboardContent(assets: [PasteboardContent.Asset(type: .string, data: Data("Hello".utf8))])
+        )
+        let textID = PasteboardHistory.ID(rawValue: textContent.hash)
+        repository.save(id: textID, content: textContent, updateAt: 1)
+
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 64, height: 64)))
+        )
+        let imageID = PasteboardHistory.ID(rawValue: imageContent.hash)
+        repository.save(id: imageID, content: imageContent, updateAt: 2)
+
+        textRecognizer.recognizeTextIfNeeded(id: textID)
+        textRecognizer.recognizeTextIfNeeded(id: imageID)
+
+        try await waitUntil { self.repository.fetchHistory(id: imageID)?.ocrText != nil }
+        let textHistory = try #require(repository.fetchHistory(id: textID))
+        #expect(textHistory.ocrText == nil)
+    }
+}
+
+private extension TextRecognizerTests {
+    func renderedTextImage(text: String) -> NSImage {
+        let size = NSSize(width: 480, height: 120)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 48, weight: .bold),
+            .foregroundColor: NSColor.black
+        ]
+        (text as NSString).draw(at: NSPoint(x: 24, y: 32), withAttributes: attributes)
+        image.unlockFocus()
+        return image
+    }
+}

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -182,6 +182,36 @@ struct PasteboardHistoryRepositoryTests {
     }
 
     @Test
+    func updateOCRTextStoresRecognizedText() throws {
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))
+        )
+        let id = PasteboardHistory.ID(rawValue: imageContent.hash)
+        repository.save(id: id, content: imageContent, updateAt: 1)
+
+        repository.updateOCRText(id: id, ocrText: "recognized text")
+
+        let history = try #require(repository.fetchHistory(id: id))
+        #expect(history.ocrText == "recognized text")
+    }
+
+    @Test
+    func saveExistingHistoryPreservesOCRText() throws {
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))
+        )
+        let id = PasteboardHistory.ID(rawValue: imageContent.hash)
+        repository.save(id: id, content: imageContent, updateAt: 1)
+        repository.updateOCRText(id: id, ocrText: "recognized text")
+
+        repository.save(id: id, content: imageContent, updateAt: 2)
+
+        let history = try #require(repository.fetchHistory(id: id))
+        #expect(history.updateAt == 2)
+        #expect(history.ocrText == "recognized text")
+    }
+
+    @Test
     func saveExistingHistoryUpdatesStoredHistory() throws {
         let content = try #require(PasteboardContent("Same"))
         let id = PasteboardHistory.ID(rawValue: content.hash)
@@ -269,27 +299,15 @@ private extension PasteboardContent {
 }
 
 private extension PasteboardHistory {
-    init(id: PasteboardHistory.ID, title: String, createdAt: Int? = nil, updateAt: Int) {
+    init(id: PasteboardHistory.ID, title: String, createdAt: Int? = nil, updateAt: Int, ocrText: String? = nil) {
         self.init(
             id: id,
             title: title,
+            ocrText: ocrText,
             pasteboardTypes: [.string],
             createdAt: createdAt ?? updateAt,
             updateAt: updateAt,
             deviceID: CPYUtilities.deviceID
         )
-    }
-}
-
-private func waitUntil(condition: @escaping @MainActor () async -> Bool) async throws {
-    try await confirmation { confirmation in
-        while true {
-            if await condition() {
-                confirmation()
-                return
-            } else {
-                try await Task.sleep(for: .seconds(0.01))
-            }
-        }
     }
 }

--- a/ClipyTests/Repositories/SnippetRepositoryTests.swift
+++ b/ClipyTests/Repositories/SnippetRepositoryTests.swift
@@ -209,16 +209,3 @@ struct SnippetRepositoryTests {
         #expect(repository.fetchSnippet(id: snippet.id) == nil)
     }
 }
-
-private func waitUntil(condition: @escaping @MainActor () async -> Bool) async throws {
-    try await confirmation { confirmation in
-        while true {
-            if await condition() {
-                confirmation()
-                return
-            } else {
-                try await Task.sleep(for: .seconds(0.01))
-            }
-        }
-    }
-}

--- a/ClipyTests/TestSupport/WaitUntil.swift
+++ b/ClipyTests/TestSupport/WaitUntil.swift
@@ -1,0 +1,30 @@
+// 
+//  WaitUntil.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+// 
+//  Created by Shunsuke Furubayashi on 2026/07/10.
+// 
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Foundation
+import Testing
+
+func waitUntil(
+    interval: TimeInterval = 0.01,
+    condition: @escaping @MainActor () async -> Bool
+) async throws {
+    try await confirmation { confirmation in
+        while true {
+            if await condition() {
+                confirmation()
+                return
+            } else {
+                try await Task.sleep(for: .seconds(interval))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Groundwork for history search: this stores and indexes text recognized from image histories, but does **not** expose it in any UI yet — the search UI will consume the index in a separate change.

- Store recognized text in a new `ocrText` column (`NULL` = never recognized) and rebuild the `pasteboardHistorySearches` FTS5 index with it in migration V4 (FTS5 tables cannot `ALTER TABLE ADD COLUMN`, so the virtual table and its sync triggers are dropped, recreated with the new column, and repopulated from the base table).
- Add `OCR/TextRecognizer`, which recognizes image contents with Vision (`VNRecognizeTextRequest`, accurate level, automatic language detection) on a serial background queue. `ClipService` requests a recognition after each save. Recognition is best effort: a failure or an app quit simply leaves `ocrText` unset, and nothing is rescanned from the database later.
- Resolve image bytes through a single `PasteboardContent.imageData`, preferring an image file over raw image data because Finder copies of image files can put the file icon on the pasteboard as image data; `thumbnailImage` shares the same resolution.

## Test plan
- `xcodebuild -scheme Clipy -project Clipy.xcodeproj test` — 84 tests pass, including the new V4 migration tests and the `TextRecognizer` pipeline tests that run real Vision recognitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)