### PR TITLE
Fix legacy clipboard history database migrations

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */; };
 		C5F1AE0130190006AA110001 /* SQLiteDataMigrator+V5.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */; };
 		C5F1AE0330190006AA110003 /* SQLiteDataMigratorTests+V5.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */; };
+		C5F1AF0130190007AA110001 /* SQLiteDataMigrator+V6.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AF0230190007AA110002 /* SQLiteDataMigrator+V6.swift */; };
+		C5F1AF0330190007AA110003 /* SQLiteDataMigratorTests+V6.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AF0430190007AA110004 /* SQLiteDataMigratorTests+V6.swift */; };
 		C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0230190005AA110002 /* TextRecognizer.swift */; };
 		C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
@@ -226,6 +228,8 @@
 		C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V4.swift"; sourceTree = "<group>"; };
 		C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V5.swift"; sourceTree = "<group>"; };
 		C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V5.swift"; sourceTree = "<group>"; };
+		C5F1AF0230190007AA110002 /* SQLiteDataMigrator+V6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V6.swift"; sourceTree = "<group>"; };
+		C5F1AF0430190007AA110004 /* SQLiteDataMigratorTests+V6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V6.swift"; sourceTree = "<group>"; };
 		C5F1AD0230190005AA110002 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
 		C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizerTests.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
@@ -475,6 +479,7 @@
 				C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */,
 				C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */,
 				C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */,
+				C5F1AF0230190007AA110002 /* SQLiteDataMigrator+V6.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -488,6 +493,7 @@
 				C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */,
 				C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */,
 				C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */,
+				C5F1AF0430190007AA110004 /* SQLiteDataMigratorTests+V6.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -1004,6 +1010,7 @@
 				C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */,
 				C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */,
 				C5F1AE0130190006AA110001 /* SQLiteDataMigrator+V5.swift in Sources */,
+				C5F1AF0130190007AA110001 /* SQLiteDataMigrator+V6.swift in Sources */,
 				FA3778951F3B6920003B5BAB /* Environment.swift in Sources */,
 			);
 		};
@@ -1017,6 +1024,7 @@
 				C5D41A0E2FDB4A0E00EF30FB /* SQLiteDataMigratorTests+V3.swift in Sources */,
 				C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */,
 				C5F1AE0330190006AA110003 /* SQLiteDataMigratorTests+V5.swift in Sources */,
+				C5F1AF0330190007AA110003 /* SQLiteDataMigratorTests+V6.swift in Sources */,
 				C5348FB130008FE4008DFEB3 /* WaitUntil.swift in Sources */,
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */,
 				C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */,

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		C5E8EE722FFA46F400270F1F /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */; };
 		C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */; };
 		C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */; };
+		C5F1AE0130190006AA110001 /* SQLiteDataMigrator+V5.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */; };
+		C5F1AE0330190006AA110003 /* SQLiteDataMigratorTests+V5.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */; };
 		C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0230190005AA110002 /* TextRecognizer.swift */; };
 		C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
@@ -222,6 +224,8 @@
 		C5E8EE712FFA46F400270F1F /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V4.swift"; sourceTree = "<group>"; };
 		C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V4.swift"; sourceTree = "<group>"; };
+		C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V5.swift"; sourceTree = "<group>"; };
+		C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V5.swift"; sourceTree = "<group>"; };
 		C5F1AD0230190005AA110002 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
 		C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizerTests.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
@@ -470,6 +474,7 @@
 				C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */,
 				C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */,
 				C5F1AC0230190004AA110002 /* SQLiteDataMigrator+V4.swift */,
+				C5F1AE0230190006AA110002 /* SQLiteDataMigrator+V5.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -482,6 +487,7 @@
 				C5D41A0A2FDB4A0A00EF30FB /* SQLiteDataMigratorTests+V2.swift */,
 				C5D41A0B2FDB4A0B00EF30FB /* SQLiteDataMigratorTests+V3.swift */,
 				C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */,
+				C5F1AE0430190006AA110004 /* SQLiteDataMigratorTests+V5.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -997,6 +1003,7 @@
 				C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */,
 				C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */,
 				C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */,
+				C5F1AE0130190006AA110001 /* SQLiteDataMigrator+V5.swift in Sources */,
 				FA3778951F3B6920003B5BAB /* Environment.swift in Sources */,
 			);
 		};
@@ -1009,6 +1016,7 @@
 				C5D41A0D2FDB4A0D00EF30FB /* SQLiteDataMigratorTests+V2.swift in Sources */,
 				C5D41A0E2FDB4A0E00EF30FB /* SQLiteDataMigratorTests+V3.swift in Sources */,
 				C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */,
+				C5F1AE0330190006AA110003 /* SQLiteDataMigratorTests+V5.swift in Sources */,
 				C5348FB130008FE4008DFEB3 /* WaitUntil.swift in Sources */,
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */,
 				C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */,

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V5.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V5.swift
@@ -1,0 +1,26 @@
+//
+//  SQLiteDataMigrator+V5.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+
+extension DatabaseMigrator {
+    mutating func registerMigrationV5() {
+        // `deviceID` was added to the original schema after some users had already
+        // applied that migration. Add it explicitly for those existing databases.
+        registerMigration("Add deviceID to pasteboardHistories") { database in
+            try #sql(
+                """
+                ALTER TABLE "pasteboardHistories"
+                ADD COLUMN "deviceID" TEXT
+                """
+            )
+            .execute(database)
+        }
+    }
+}

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V6.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator+V6.swift
@@ -1,0 +1,61 @@
+//
+//  SQLiteDataMigrator+V6.swift
+//
+//  Clipy
+//  GitHub: https://github.com/Clipy/Clipy
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+
+extension DatabaseMigrator {
+    mutating func registerMigrationV6() {
+        registerMigration("Repair legacy pasteboard asset columns") { database in
+            let assetColumns = try #sql(
+                "SELECT \"name\" FROM pragma_table_info('pasteboardHistoryAssets')",
+                as: String.self
+            )
+            .fetchAll(database)
+            if !assetColumns.contains("index") {
+                try #sql(
+                    """
+                    ALTER TABLE "pasteboardHistoryAssets"
+                    ADD COLUMN "index" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0
+                    """
+                )
+                .execute(database)
+
+                // Preserve the original asset order for databases that predate
+                // the explicit index column.
+                try #sql(
+                    """
+                    UPDATE "pasteboardHistoryAssets" AS target
+                    SET "index" = (
+                      SELECT COUNT(*) - 1
+                      FROM "pasteboardHistoryAssets" AS previous
+                      WHERE previous."pasteboardHistoryID" = target."pasteboardHistoryID"
+                        AND previous.rowid <= target.rowid
+                    )
+                    """
+                )
+                .execute(database)
+            }
+
+            let thumbnailColumns = try #sql(
+                "SELECT \"name\" FROM pragma_table_info('pasteboardHistoryThumbnailAssets')",
+                as: String.self
+            )
+            .fetchAll(database)
+            if !thumbnailColumns.contains("kind") {
+                try #sql(
+                    """
+                    ALTER TABLE "pasteboardHistoryThumbnailAssets"
+                    ADD COLUMN "kind" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT 'image'
+                    """
+                )
+                .execute(database)
+            }
+        }
+    }
+}

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
@@ -18,5 +18,6 @@ extension DatabaseMigrator {
         registerMigrationV2()
         registerMigrationV3()
         registerMigrationV4()
+        registerMigrationV5()
     }
 }

--- a/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
+++ b/Clipy/Sources/Database/Migrations/SQLiteDataMigrator.swift
@@ -19,5 +19,6 @@ extension DatabaseMigrator {
         registerMigrationV3()
         registerMigrationV4()
         registerMigrationV5()
+        registerMigrationV6()
     }
 }

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V5.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V5.swift
@@ -1,0 +1,69 @@
+//
+//  SQLiteDataMigratorTests+V5.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+import Testing
+@testable import Clipy
+
+extension SQLiteDataMigratorTests {
+    @Test
+    func migrationV5AddsDeviceIDToExistingDatabase() throws {
+        let database = try DatabaseQueue()
+        try database.write { database in
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistories" (
+                  "id" TEXT PRIMARY KEY NOT NULL,
+                  "title" TEXT NOT NULL,
+                  "pasteboardTypes" TEXT NOT NULL,
+                  "updateAt" INTEGER NOT NULL,
+                  "createdAt" INTEGER NOT NULL,
+                  "ocrText" TEXT
+                ) STRICT
+                """
+            )
+            .execute(database)
+            try #sql(
+                """
+                INSERT INTO "pasteboardHistories"
+                  ("id", "title", "pasteboardTypes", "updateAt", "createdAt", "ocrText")
+                VALUES ('existing-history', 'Existing history', '[]', 1, 1, NULL)
+                """
+            )
+            .execute(database)
+        }
+
+        var migrator = DatabaseMigrator()
+        migrator.registerMigrationV5()
+        try migrator.migrate(database)
+
+        try database.read { database in
+            let columns = try columnNames(of: "pasteboardHistories", database: database)
+            #expect(columns == [
+                "createdAt",
+                "deviceID",
+                "id",
+                "ocrText",
+                "pasteboardTypes",
+                "title",
+                "updateAt"
+            ])
+            let title = try #sql(
+                """
+                SELECT "title"
+                FROM "pasteboardHistories"
+                WHERE "id" = 'existing-history'
+                """,
+                as: String.self
+            )
+            .fetchOne(database)
+            #expect(title == "Existing history")
+        }
+    }
+}

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V6.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests+V6.swift
@@ -1,0 +1,90 @@
+//
+//  SQLiteDataMigratorTests+V6.swift
+//
+//  Clipy
+//  GitHub: https://github.com/Clipy/Clipy
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import SQLiteData
+import Testing
+@testable import Clipy
+
+extension SQLiteDataMigratorTests {
+    @Test
+    func migrationV6RepairsLegacyAssetColumns() throws {
+        let database = try DatabaseQueue()
+        try database.write { database in
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistoryAssets" (
+                  "id" TEXT PRIMARY KEY NOT NULL,
+                  "pasteboardHistoryID" TEXT NOT NULL,
+                  "pasteboardType" TEXT NOT NULL,
+                  "data" BLOB NOT NULL
+                ) STRICT
+                """
+            )
+            .execute(database)
+            try #sql(
+                """
+                INSERT INTO "pasteboardHistoryAssets"
+                  ("id", "pasteboardHistoryID", "pasteboardType", "data")
+                VALUES
+                  ('asset-1', 'history-1', 'public.utf8-plain-text', X'01'),
+                  ('asset-2', 'history-1', 'public.utf8-plain-text', X'02')
+                """
+            )
+            .execute(database)
+            try #sql(
+                """
+                CREATE TABLE "pasteboardHistoryThumbnailAssets" (
+                  "pasteboardHistoryID" TEXT PRIMARY KEY NOT NULL,
+                  "data" BLOB NOT NULL
+                ) STRICT
+                """
+            )
+            .execute(database)
+            try #sql(
+                """
+                INSERT INTO "pasteboardHistoryThumbnailAssets"
+                  ("pasteboardHistoryID", "data")
+                VALUES ('history-1', X'01')
+                """
+            )
+            .execute(database)
+        }
+
+        var migrator = DatabaseMigrator()
+        migrator.registerMigrationV6()
+        try migrator.migrate(database)
+
+        try database.read { database in
+            let assetColumnNames = try columnNames(of: "pasteboardHistoryAssets", database: database)
+            #expect(assetColumnNames == [
+                "data", "id", "index", "pasteboardHistoryID", "pasteboardType"
+            ])
+            let thumbnailColumnNames = try columnNames(of: "pasteboardHistoryThumbnailAssets", database: database)
+            #expect(thumbnailColumnNames == [
+                "data", "kind", "pasteboardHistoryID"
+            ])
+            let indexes = try #sql(
+                """
+                SELECT "index"
+                FROM "pasteboardHistoryAssets"
+                ORDER BY rowid
+                """,
+                as: Int.self
+            )
+            .fetchAll(database)
+            #expect(indexes == [0, 1])
+            let kind = try #sql(
+                "SELECT \"kind\" FROM \"pasteboardHistoryThumbnailAssets\"",
+                as: String.self
+            )
+            .fetchOne(database)
+            #expect(kind == "image")
+        }
+    }
+}

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
@@ -31,7 +31,8 @@ struct SQLiteDataMigratorTests {
                     "Create initial tables",
                     "Create search indexes",
                     "Add createdAt to pasteboardHistories",
-                    "Add OCR text to history search"
+                    "Add OCR text to history search",
+                    "Add deviceID to pasteboardHistories"
                 ]
             )
         }

--- a/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
+++ b/ClipyTests/Database/Migrations/SQLiteDataMigratorTests.swift
@@ -32,7 +32,8 @@ struct SQLiteDataMigratorTests {
                     "Create search indexes",
                     "Add createdAt to pasteboardHistories",
                     "Add OCR text to history search",
-                    "Add deviceID to pasteboardHistories"
+                    "Add deviceID to pasteboardHistories",
+                    "Repair legacy pasteboard asset columns"
                 ]
             )
         }


### PR DESCRIPTION
## Summary

- Add migrations that repair legacy clipboard-history databases missing `deviceID` and pasteboard asset columns.
- Backfill legacy asset ordering and classify existing thumbnail rows as images.

## Root cause

The affected columns were added to the original schema migration after existing installations had already recorded it. On those databases, history writes failed with SQLite `no such column` errors.

## Impact

Existing users with the older database layout can resume saving clipboard history after upgrading, without deleting their data.

## Validation

- Built the Release app successfully with `xcodebuild`.
- Added migration coverage for the legacy schema repairs.
