### PR TITLE
Apply current sort preferences to history pruning

### DIFF
--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -11,12 +11,14 @@
 //
 
 import Cocoa
+import Clocks
 import Dependencies
 import Magnet
 import RxCocoa
 import RxSwift
 import Screeen
 import ServiceManagement
+import Sharing
 import Sparkle
 
 class AppDelegate: NSObject, NSMenuItemValidation {
@@ -25,10 +27,13 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     private(set) var updaterController: SPUStandardUpdaterController?
     private let screenshotObserver = ScreenShotObserver(searchDirectoryPaths: AppDelegate.screenshotSearchDirectoryPaths())
     private let disposeBag = DisposeBag()
-    private let historyPruningScheduler = SerialDispatchQueueScheduler(qos: .utility)
 
     @Dependency(\.context)
     var context
+    @Dependency(\.continuousClock)
+    private var continuousClock
+    @Dependency(\.defaultAppStorage)
+    var appStorage
     @Dependency(\.pasteboardHistoryRepository)
     private var pasteboardHistoryRepository
     @Dependency(\.snippetRepository)
@@ -171,13 +176,18 @@ extension AppDelegate: NSApplicationDelegate {
         // Screenshot
         screenshotObserver.delegate = self
 
-        // Clean histories every 30 minutes
-        Observable<Int>.interval(.seconds(60 * 30), scheduler: historyPruningScheduler)
-            .subscribe(onNext: { [weak self] _ in
-                let maxHistorySize = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.maxHistorySize)
-                self?.pasteboardHistoryRepository.deleteOverflowingHistories(maxHistorySize: maxHistorySize)
-            })
-            .disposed(by: disposeBag)
+        // Periodically trim excess history using the current size limit and sort preference.
+        Task(priority: .utility) { [weak self] in
+            guard let self else { return }
+            for await _ in continuousClock.timer(interval: .seconds(60)) {
+                let maxHistorySize = appStorage.integer(forKey: Constants.UserDefaults.maxHistorySize)
+                let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+                pasteboardHistoryRepository.deleteOverflowingHistories(
+                    sortsByCreatedAt: !reorderClipsAfterPasting,
+                    maxHistorySize: maxHistorySize
+                )
+            }
+        }
     }
 
 }

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -30,7 +30,7 @@ protocol PasteboardHistoryRepositoryProtocol {
     func updateOCRText(id: PasteboardHistory.ID, ocrText: String)
     func deleteHistory(id: PasteboardHistory.ID)
     func deleteAll()
-    func deleteOverflowingHistories(maxHistorySize: Int)
+    func deleteOverflowingHistories(sortsByCreatedAt: Bool, maxHistorySize: Int)
 }
 
 final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
@@ -179,7 +179,7 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
         }
     }
 
-    func deleteOverflowingHistories(maxHistorySize: Int) {
+    func deleteOverflowingHistories(sortsByCreatedAt: Bool, maxHistorySize: Int) {
         guard maxHistorySize > 0 else {
             deleteAll()
             return
@@ -187,7 +187,13 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
         withErrorReporting {
             try database.write { database in
                 let deletingIDs = try PasteboardHistory
-                    .order { $0.updateAt.desc() }
+                    .order { columns in
+                        if sortsByCreatedAt {
+                            columns.createdAt.desc()
+                        } else {
+                            columns.updateAt.desc()
+                        }
+                    }
                     .limit(-1, offset: maxHistorySize)
                     .select { $0.id }
                     .fetchAll(database)

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -261,7 +261,7 @@ struct PasteboardHistoryRepositoryTests {
     }
 
     @Test
-    func deleteOverflowingHistories() throws {
+    func deleteOverflowingHistoriesUsesSelectedSortOrder() throws {
         let content = try #require(PasteboardContent("First"))
         let content2 = try #require(PasteboardContent("Second"))
         let content3 = try #require(PasteboardContent("Third"))
@@ -272,16 +272,31 @@ struct PasteboardHistoryRepositoryTests {
         repository.save(id: id, content: content, updateAt: 1)
         repository.save(id: id2, content: content2, updateAt: 2)
         repository.save(id: id3, content: content3, updateAt: 3)
+        repository.save(id: id, content: content, updateAt: 4)
 
-        repository.deleteOverflowingHistories(maxHistorySize: 2)
+        repository.deleteOverflowingHistories(sortsByCreatedAt: false, maxHistorySize: 2)
         #expect(
             repository
                 .fetchHistoryDetails(sortsByCreatedAt: false, includesThumbnailAsset: false, limit: 10)
+                .map(\.history.id) == [id, id3]
+        )
+        #expect(repository.fetchHistory(id: id2) == nil)
+
+        repository.deleteAll()
+        repository.save(id: id, content: content, updateAt: 1)
+        repository.save(id: id2, content: content2, updateAt: 2)
+        repository.save(id: id3, content: content3, updateAt: 3)
+        repository.save(id: id, content: content, updateAt: 4)
+
+        repository.deleteOverflowingHistories(sortsByCreatedAt: true, maxHistorySize: 2)
+        #expect(
+            repository
+                .fetchHistoryDetails(sortsByCreatedAt: true, includesThumbnailAsset: false, limit: 10)
                 .map(\.history.id) == [id3, id2]
         )
         #expect(repository.fetchHistory(id: id) == nil)
 
-        repository.deleteOverflowingHistories(maxHistorySize: 0)
+        repository.deleteOverflowingHistories(sortsByCreatedAt: true, maxHistorySize: 0)
         #expect(!repository.hasHistories())
     }
 }


### PR DESCRIPTION
## Summary

- Respect the active created-at or updated-at sort order when pruning excess history.
- Read the current history limit and reorder preference from app storage on every cleanup.
- Replace the Rx interval with `swift-clocks` and prune every minute.
- Cover both sort modes in repository tests.

## Motivation

History pruning previously always retained records by update time and ran every 30 minutes. This could leave hidden overflow records searchable and make database cleanup inconsistent with the current display order.

All 84 tests pass, and the Debug macOS app builds successfully.