### PR TITLE
Update Swift package dependencies

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -1411,7 +1411,7 @@
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.5.1;
+				minimumVersion = 1.6.0;
 			};
 		};
 		C5700B4A2FC5C3D500C8F965 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
@@ -1419,15 +1419,19 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.12.0;
+				minimumVersion = 1.14.1;
 			};
+			traits = (
+				Clocks,
+				CombineSchedulers,
+			);
 		};
 		C57447282FD13ADF000D64D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 12.14.0;
+				minimumVersion = 12.16.0;
 			};
 		};
 		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
@@ -1435,10 +1439,10 @@
 			repositoryURL = "https://github.com/pointfreeco/sqlite-data";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.6.1;
+				minimumVersion = 1.7.0;
 			};
 			traits = (
-				SQLiteDataTagged,
+				Tagged,
 			);
 		};
 		C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
@@ -1446,7 +1450,7 @@
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.63.2;
+				minimumVersion = 0.65.0;
 			};
 		};
 		C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */ = {
@@ -1454,7 +1458,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.9.2;
+				minimumVersion = 2.9.4;
 			};
 		};
 		C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */ = {

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "8d5b4189f1f482df8d5c58c9985ea70491ef5382",
-        "version" : "12.14.0"
+        "revision" : "9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5",
+        "version" : "12.16.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "219e564a8510e983e675c94f77f7f7c50049f22d",
-        "version" : "12.14.0"
+        "revision" : "ce606e3768abddff0510783e1a6d2f270b943b35",
+        "version" : "12.16.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
-        "version" : "2.9.2"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "da3a94ed49c7a30d82853de551c07a93196e8cab",
-        "version" : "1.6.1"
+        "revision" : "93e0540441a6bfdba51df27ca6d01eb6508c82a5",
+        "version" : "1.7.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
-        "version" : "1.3.2"
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
-        "version" : "1.12.0"
+        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version" : "1.14.1"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
-        "version" : "0.31.1"
+        "revision" : "9c2935e47b0ed9627e4278c566e0ac386be5472e",
+        "version" : "0.33.3"
       }
     },
     {
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
-        "version" : "0.63.2"
+        "revision" : "3292bab28e6e92000161348003fdef8edc4e582d",
+        "version" : "0.65.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- update six direct Swift package dependencies and refresh their resolved transitive versions
- adopt the updated package trait names required by SQLiteData and swift-dependencies
- keep application source and behavior unchanged while picking up upstream fixes and compatibility updates

## Direct dependency changelog

| Package | From | To | Highlights |
| --- | ---: | ---: | --- |
| [swift-collections](https://github.com/apple/swift-collections/releases/tag/1.6.0) | 1.5.1 | 1.6.0 | Adds move operations for ordered collections and includes bug fixes. |
| [swift-dependencies](https://github.com/pointfreeco/swift-dependencies/compare/1.12.0...1.14.1) | 1.12.0 | 1.14.1 | Updates package traits and includes the FoundationNetworking trait fix. The Clocks and CombineSchedulers traits are enabled explicitly. |
| [Firebase Apple SDK](https://firebase.google.com/support/release-notes/ios) | 12.14.0 | 12.16.0 | Includes Analytics maintenance and a Crashlytics reentrant logging deadlock fix. Version 12.15.0 raises the Swift package requirement to Swift tools 6.1 / Xcode 16.3+. |
| [SQLiteData](https://github.com/pointfreeco/sqlite-data/compare/1.6.1...1.7.0) | 1.6.1 | 1.7.0 | Adds the standard CasePaths and Tagged traits and enables NonisolatedNonsendingByDefault. The project switches from SQLiteDataTagged to Tagged. |
| [SwiftLintPlugins](https://github.com/SimplyDanny/SwiftLintPlugins/releases/tag/0.65.0) | 0.63.2 | 0.65.0 | Updates the build tool plugin to the SwiftLint 0.65.0 release. |
| [Sparkle](https://github.com/sparkle-project/Sparkle/compare/2.9.2...2.9.4) | 2.9.2 | 2.9.4 | Fixes user-initiated update UI failing to activate windows for backgrounded or dockless apps. |

## Resolved transitive updates

| Package | From | To |
| --- | ---: | ---: |
| AppCheck | 11.2.0 | 11.3.1 |
| GoogleAppMeasurement | 12.14.0 | 12.16.0 |
| swift-concurrency-extras | 1.3.2 | 1.4.0 |
| swift-structured-queries | 0.31.1 | 0.33.3 |

## Impact

The Firebase update now requires Xcode 16.3 or newer for Swift Package Manager resolution. The repository CI uses Xcode 26.5, so the updated requirement is satisfied. No application source migration was required.

## Checks

- Resolved and checked out the complete updated package graph with Xcode 26.5.
- Ran `xcodebuild clean test` with code signing and package/macro validation disabled, matching CI.
- All 84 tests in 14 suites passed.
