### PR TITLE
Add clipboard history search

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		C5F1AC0330190004AA110003 /* SQLiteDataMigratorTests+V4.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */; };
 		C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0230190005AA110002 /* TextRecognizer.swift */; };
 		C5F1AD0430190005AA110004 /* TextRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */; };
+		C5F1AE0130190006AA110001 /* HistorySearchWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1AE0230190006AA110002 /* HistorySearchWindowController.swift */; };
 		C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */; };
 		FA08EDF81D1FED7D000D1D13 /* HotKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */; };
 		FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0D5CE71DDCC61600AC9052 /* ClipService.swift */; };
@@ -224,6 +225,7 @@
 		C5F1AC0430190004AA110004 /* SQLiteDataMigratorTests+V4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigratorTests+V4.swift"; sourceTree = "<group>"; };
 		C5F1AD0230190005AA110002 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
 		C5F1AD0530190005AA110005 /* TextRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizerTests.swift; sourceTree = "<group>"; };
+		C5F1AE0230190006AA110002 /* HistorySearchWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistorySearchWindowController.swift; sourceTree = "<group>"; };
 		C5F1B7321FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Deprecated.swift"; sourceTree = "<group>"; };
 		FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyServiceTests.swift; sourceTree = "<group>"; };
 		FA0D5CE71DDCC61600AC9052 /* ClipService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipService.swift; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 		FA1DB4BE1DDCB460007F95C8 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				C5F1AE0230190006AA110002 /* HistorySearchWindowController.swift */,
 				FA1DB4C31DDCB460007F95C8 /* MenuManager.swift */,
 			);
 			path = Managers;
@@ -966,6 +969,7 @@
 				FA1DB4B91DDCB452007F95C8 /* NSMenuItem+Initialize.swift in Sources */,
 				FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */,
 				C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */,
+				C5F1AE0130190006AA110001 /* HistorySearchWindowController.swift in Sources */,
 				FA1DB4C91DDCB460007F95C8 /* MenuManager.swift in Sources */,
 				FA1189331E4CD58C00244F12 /* ExcludeAppService.swift in Sources */,
 				FA1DB4E91DDCB49C007F95C8 /* CPYSplitView.swift in Sources */,

--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -801,6 +801,176 @@
         }
       }
     },
+    "Enter a continuous text fragment to search your clipboard history" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite um trecho contínuo de texto para pesquisar no histórico da área de transferência"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geben Sie einen zusammenhängenden Textausschnitt ein, um den Zwischenablageverlauf zu durchsuchen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci un frammento di testo continuo per cercare nella cronologia degli appunti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続するテキストの一部を入力してクリップボード履歴を検索"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入一段连续文本以搜索剪贴板历史"
+          }
+        }
+      }
+    },
+    "No matching history" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum histórico correspondente"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein passender Verlauf"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun elemento corrispondente nella cronologia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一致する履歴はありません"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的历史记录"
+          }
+        }
+      }
+    },
+    "Paste" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colar"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einfügen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incolla"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼り付け"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴"
+          }
+        }
+      }
+    },
+    "Search clipboard history" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar no histórico da área de transferência"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischenablageverlauf durchsuchen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca nella cronologia degli appunti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボード履歴を検索"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索剪贴板历史"
+          }
+        }
+      }
+    },
+    "Search History" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar histórico"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlauf durchsuchen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca nella cronologia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴を検索"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索历史"
+          }
+        }
+      }
+    },
     "You can change this setting in the Preferences if you want" : {
       "localizations" : {
         "pt-BR" : {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -60,6 +60,10 @@ class AppDelegate: NSObject, NSMenuItemValidation {
         CPYSnippetsEditorWindowController.sharedController.showWindow(self)
     }
 
+    @objc func showHistorySearchWindow() {
+        HistorySearchWindowController.shared.showSearchWindow()
+    }
+
     @objc func terminate() {
         terminateApplication()
     }

--- a/Clipy/Sources/Managers/HistorySearchWindowController.swift
+++ b/Clipy/Sources/Managers/HistorySearchWindowController.swift
@@ -1,0 +1,306 @@
+//
+//  HistorySearchWindowController.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Combine
+import Dependencies
+import SwiftUI
+
+final class HistorySearchWindowController: NSWindowController {
+    static let shared = HistorySearchWindowController()
+
+    private let viewModel = HistorySearchViewModel()
+    private var previousApplication: NSRunningApplication?
+
+    private lazy var hostingController = NSHostingController(
+        rootView: HistorySearchView(viewModel: viewModel)
+    )
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 480),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "Search History")
+        window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 480, height: 320)
+        window.collectionBehavior = [.moveToActiveSpace]
+        window.setFrameAutosaveName("HistorySearchWindow")
+
+        super.init(window: window)
+
+        window.contentViewController = hostingController
+        window.delegate = self
+        viewModel.onPaste = { [weak self] id in
+            self?.pasteHistory(id: id)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func showSearchWindow() {
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        if frontmostApplication?.processIdentifier != ProcessInfo.processInfo.processIdentifier {
+            previousApplication = frontmostApplication
+        }
+
+        viewModel.reset()
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+private extension HistorySearchWindowController {
+    func pasteHistory(id: PasteboardHistory.ID) {
+        @Dependency(\.pasteboardHistoryRepository) var pasteboardHistoryRepository
+
+        guard let content = pasteboardHistoryRepository.fetchContent(id: id) else {
+            NSSound.beep()
+            return
+        }
+
+        window?.orderOut(nil)
+        let targetApplication = previousApplication
+        previousApplication = nil
+        targetApplication?.activate(options: [.activateIgnoringOtherApps])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            AppEnvironment.current.pasteService.paste(id: id, content: content)
+        }
+    }
+
+    func reactivatePreviousApplication() {
+        previousApplication?.activate(options: [.activateIgnoringOtherApps])
+        previousApplication = nil
+    }
+}
+
+extension HistorySearchWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        reactivatePreviousApplication()
+    }
+}
+
+private final class HistorySearchViewModel: ObservableObject {
+    @Published var query = ""
+    @Published private(set) var results = [PasteboardHistoryDetail]()
+    @Published var selectedHistoryID: PasteboardHistory.ID?
+    @Published private(set) var focusRequest = UUID()
+
+    var onPaste: ((PasteboardHistory.ID) -> Void)?
+
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        $query
+            .removeDuplicates()
+            .debounce(for: .milliseconds(120), scheduler: RunLoop.main)
+            .sink { [weak self] _ in self?.search() }
+            .store(in: &cancellables)
+
+        pasteboardHistoryRepository.observeHistories()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard self?.query.isEmpty == false else { return }
+                self?.search()
+            }
+            .store(in: &cancellables)
+    }
+
+    func reset() {
+        query = ""
+        results = []
+        selectedHistoryID = nil
+        focusRequest = UUID()
+    }
+
+    func pasteSelectedHistory() {
+        guard let id = selectedHistoryID ?? results.first?.history.id else { return }
+        onPaste?(id)
+    }
+
+    func pasteHistory(id: PasteboardHistory.ID) {
+        onPaste?(id)
+    }
+
+    private func search() {
+        let fragment = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !fragment.isEmpty else {
+            results = []
+            selectedHistoryID = nil
+            return
+        }
+
+        let results = pasteboardHistoryRepository.searchHistoryDetails(
+            containing: fragment,
+            includesThumbnailAsset: true,
+            limit: 100
+        )
+        self.results = results
+        if !results.contains(where: { $0.history.id == selectedHistoryID }) {
+            selectedHistoryID = results.first?.history.id
+        }
+    }
+}
+
+private struct HistorySearchView: View {
+    @ObservedObject var viewModel: HistorySearchViewModel
+    @FocusState private var searchFieldIsFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(String(localized: "Search clipboard history"), text: $viewModel.query)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($searchFieldIsFocused)
+            }
+
+            searchContent
+
+            HStack {
+                Spacer()
+                Button(String(localized: "Paste")) {
+                    viewModel.pasteSelectedHistory()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(viewModel.results.isEmpty)
+            }
+        }
+        .padding(16)
+        .onAppear {
+            searchFieldIsFocused = true
+        }
+        .onChange(of: viewModel.focusRequest) { _ in
+            searchFieldIsFocused = true
+        }
+    }
+
+    @ViewBuilder
+    private var searchContent: some View {
+        if viewModel.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            emptyState(
+                systemImage: "text.magnifyingglass",
+                message: String(localized: "Enter a continuous text fragment to search your clipboard history")
+            )
+        } else if viewModel.results.isEmpty {
+            emptyState(
+                systemImage: "doc.text.magnifyingglass",
+                message: String(localized: "No matching history")
+            )
+        } else {
+            List(viewModel.results, id: \.history.id, selection: $viewModel.selectedHistoryID) { detail in
+                HistorySearchResultRow(detail: detail, query: viewModel.query)
+                    .tag(detail.history.id)
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(
+                        TapGesture(count: 2).onEnded {
+                            viewModel.pasteHistory(id: detail.history.id)
+                        }
+                    )
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    private func emptyState(systemImage: String, message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct HistorySearchResultRow: View {
+    let detail: PasteboardHistoryDetail
+    let query: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            thumbnail
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(detail.history.searchPreview(matching: query))
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text(
+                    Date(timeIntervalSince1970: TimeInterval(detail.history.updateAt))
+                        .formatted(date: .abbreviated, time: .shortened)
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let data = detail.thumbnailAsset?.data, let image = NSImage(data: data) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 40, height: 40)
+                .cornerRadius(4)
+        } else {
+            Image(systemName: "doc.on.clipboard")
+                .font(.system(size: 22))
+                .foregroundStyle(.secondary)
+                .frame(width: 40, height: 40)
+        }
+    }
+}
+
+private extension PasteboardHistory {
+    func searchPreview(matching query: String) -> String {
+        let fragment = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source: String
+        if title.range(of: fragment, options: .caseInsensitive) != nil {
+            source = title
+        } else if let ocrText, ocrText.range(of: fragment, options: .caseInsensitive) != nil {
+            source = ocrText
+        } else {
+            source = title
+        }
+
+        guard !source.isEmpty else { return typedTitle }
+        guard let match = source.range(of: fragment, options: .caseInsensitive) else {
+            return source.replacingOccurrences(of: "\n", with: " ")
+        }
+
+        let radius = 60
+        let lowerBound = source.index(match.lowerBound, offsetBy: -radius, limitedBy: source.startIndex) ?? source.startIndex
+        let upperBound = source.index(match.upperBound, offsetBy: radius, limitedBy: source.endIndex) ?? source.endIndex
+        var preview = String(source[lowerBound..<upperBound])
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        if lowerBound != source.startIndex {
+            preview = "…" + preview
+        }
+        if upperBound != source.endIndex {
+            preview += "…"
+        }
+        return preview
+    }
+}

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -245,11 +245,19 @@ private extension MenuManager {
         labelItem.isEnabled = false
         menu.addItem(labelItem)
 
+        menu.addItem(
+            NSMenuItem(
+                title: String(localized: "Search History"),
+                action: #selector(AppDelegate.showHistorySearchWindow),
+                keyEquivalent: ""
+            )
+        )
+
         // History
         let firstIndex = firstIndexOfMenuItems()
         var listNumber = firstIndex
         var subMenuCount = placeInLine
-        var subMenuIndex = 1 + placeInLine
+        var subMenuIndex = menu.numberOfItems + placeInLine
 
         let reorderClipsAfterPasting = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
         let isShowImage = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showImageInTheMenu)

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -23,6 +23,11 @@ protocol PasteboardHistoryRepositoryProtocol {
         includesThumbnailAsset: Bool,
         limit: Int,
     ) -> [PasteboardHistoryDetail]
+    func searchHistoryDetails(
+        containing fragment: String,
+        includesThumbnailAsset: Bool,
+        limit: Int
+    ) -> [PasteboardHistoryDetail]
     func fetchHistory(id: PasteboardHistory.ID) -> PasteboardHistory?
     func fetchContent(id: PasteboardHistory.ID) -> PasteboardContent?
 
@@ -83,6 +88,54 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                     .leftJoin(PasteboardHistoryThumbnailAsset.all) { $0.id.eq($1.pasteboardHistoryID) }
                     .select { PasteboardHistoryDetail.Columns(history: $0, thumbnailAsset: $1) }
                     .fetchAll(database)
+            }
+        } ?? []
+    }
+
+    func searchHistoryDetails(
+        containing fragment: String,
+        includesThumbnailAsset: Bool,
+        limit: Int
+    ) -> [PasteboardHistoryDetail] {
+        let fragment = fragment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !fragment.isEmpty, limit > 0 else { return [] }
+
+        return withErrorReporting {
+            try database.read { database in
+                let histories: [PasteboardHistory]
+                if fragment.count < 3 {
+                    histories = try PasteboardHistory.all
+                        .order { $0.updateAt.desc() }
+                        .fetchAll(database)
+                } else {
+                    let escapedFragment = fragment.replacingOccurrences(of: "\"", with: "\"\"")
+                    histories = try searchHistories(
+                        matching: "\"\(escapedFragment)\"",
+                        database: database
+                    )
+                }
+
+                let matches = Array(
+                    histories
+                        .lazy
+                        .filter { history in
+                            history.title.range(of: fragment, options: .caseInsensitive) != nil
+                                || history.ocrText?.range(of: fragment, options: .caseInsensitive) != nil
+                        }
+                        .prefix(limit)
+                )
+                guard includesThumbnailAsset, !matches.isEmpty else {
+                    return matches.map { PasteboardHistoryDetail(history: $0, thumbnailAsset: nil) }
+                }
+
+                let ids = matches.map(\.id)
+                let thumbnailAssets = try PasteboardHistoryThumbnailAsset
+                    .where { $0.pasteboardHistoryID.in(ids) }
+                    .fetchAll(database)
+                let thumbnailAssetsByID = Dictionary(uniqueKeysWithValues: thumbnailAssets.map { ($0.pasteboardHistoryID, $0) })
+                return matches.map {
+                    PasteboardHistoryDetail(history: $0, thumbnailAsset: thumbnailAssetsByID[$0.id])
+                }
             }
         } ?? []
     }
@@ -208,6 +261,19 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
 }
 
 private extension PasteboardHistoryRepository {
+    func searchHistories(
+        matching query: String,
+        database: Database
+    ) throws -> [PasteboardHistory] {
+        try PasteboardHistorySearch
+            .where { $0.match(query) }
+            .leftJoin(PasteboardHistory.all) { $0.id.eq($1.id) }
+            .select { $1 }
+            .fetchAll(database)
+            .compactMap { $0 }
+            .sorted { $0.updateAt > $1.updateAt }
+    }
+
     func thumbnailAsset(from content: PasteboardContent, id: PasteboardHistory.ID) -> PasteboardHistoryThumbnailAsset? {
         var asset: PasteboardHistoryThumbnailAsset?
         if let thumbnailImage = content.thumbnailImage, let thumbnailData = thumbnailImage.tiffRepresentation {

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -182,6 +182,83 @@ struct PasteboardHistoryRepositoryTests {
     }
 
     @Test
+    func searchHistoryDetailsMatchesContinuousFragments() throws {
+        let continuousContent = try #require(PasteboardContent("Alpha beta gamma"))
+        let separatedContent = try #require(PasteboardContent("Alpha beta then gamma"))
+        let newestContent = try #require(PasteboardContent("Prefix BETA GAMMA suffix"))
+        let continuousID = PasteboardHistory.ID(rawValue: continuousContent.hash)
+        let separatedID = PasteboardHistory.ID(rawValue: separatedContent.hash)
+        let newestID = PasteboardHistory.ID(rawValue: newestContent.hash)
+
+        repository.save(id: continuousID, content: continuousContent, updateAt: 1)
+        repository.save(id: separatedID, content: separatedContent, updateAt: 2)
+        repository.save(id: newestID, content: newestContent, updateAt: 3)
+
+        #expect(
+            repository
+                .searchHistoryDetails(containing: "beta gamma", includesThumbnailAsset: false, limit: 10)
+                .map(\.history.id) == [newestID, continuousID]
+        )
+    }
+
+    @Test
+    func searchHistoryDetailsHandlesShortAndQuotedFragments() throws {
+        let shortContent = try #require(PasteboardContent("Find XY here"))
+        let quotedContent = try #require(PasteboardContent("A \"quoted fragment\" here"))
+        let chineseContent = try #require(PasteboardContent("这里有一段连续片段内容"))
+        let shortID = PasteboardHistory.ID(rawValue: shortContent.hash)
+        let quotedID = PasteboardHistory.ID(rawValue: quotedContent.hash)
+        let chineseID = PasteboardHistory.ID(rawValue: chineseContent.hash)
+
+        repository.save(id: shortID, content: shortContent, updateAt: 1)
+        repository.save(id: quotedID, content: quotedContent, updateAt: 2)
+        repository.save(id: chineseID, content: chineseContent, updateAt: 3)
+
+        #expect(
+            repository
+                .searchHistoryDetails(containing: "xy", includesThumbnailAsset: false, limit: 10)
+                .map(\.history.id) == [shortID]
+        )
+        #expect(
+            repository
+                .searchHistoryDetails(containing: "\"quoted", includesThumbnailAsset: false, limit: 10)
+                .map(\.history.id) == [quotedID]
+        )
+        #expect(
+            repository
+                .searchHistoryDetails(containing: "连续片段", includesThumbnailAsset: false, limit: 10)
+                .map(\.history.id) == [chineseID]
+        )
+        #expect(repository.searchHistoryDetails(containing: "   ", includesThumbnailAsset: false, limit: 10).isEmpty)
+    }
+
+    @Test
+    func searchHistoryDetailsIncludesOCRTextAndHonorsLimit() throws {
+        let oldestContent = try #require(PasteboardContent("needle oldest"))
+        let newestContent = try #require(PasteboardContent("needle newest"))
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))
+        )
+        let oldestID = PasteboardHistory.ID(rawValue: oldestContent.hash)
+        let newestID = PasteboardHistory.ID(rawValue: newestContent.hash)
+        let imageID = PasteboardHistory.ID(rawValue: imageContent.hash)
+
+        repository.save(id: oldestID, content: oldestContent, updateAt: 1)
+        repository.save(id: imageID, content: imageContent, updateAt: 2)
+        repository.updateOCRText(id: imageID, ocrText: "needle recognized in image")
+        repository.save(id: newestID, content: newestContent, updateAt: 3)
+
+        let results = repository.searchHistoryDetails(
+            containing: "needle",
+            includesThumbnailAsset: true,
+            limit: 2
+        )
+        #expect(results.map(\.history.id) == [newestID, imageID])
+        #expect(results[0].thumbnailAsset == nil)
+        #expect(results[1].thumbnailAsset?.pasteboardHistoryID == imageID)
+    }
+
+    @Test
     func updateOCRTextStoresRecognizedText() throws {
         let imageContent = try #require(
             PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))


### PR DESCRIPTION
## Summary

- Add a **Search History** action to the status menu and a dedicated SwiftUI search window.
- Match case-insensitive contiguous fragments across clipboard text and OCR content, using the existing FTS5 index for longer queries and direct substring matching for short queries.
- Show recent matches with image thumbnails and allow pasting by pressing Return, clicking **Paste**, or double-clicking a result.
- Restore focus to the previously active application before pasting.
- Localize the new interface and add repository tests for contiguous matching, case insensitivity, quoted and short queries, Chinese text, OCR results, ordering, limits, and thumbnails.

## Testing

- `PasteboardHistoryRepositoryTests`: 15 passed, 0 failed with Xcode 26.6 in an arm64 Release verification build.
- The Release app bundle compiled, linked, and passed ad-hoc code-sign verification.
- A fresh test run after rebasing was blocked during Swift Package resolution by TLS/timeouts while downloading Firebase binary targets from `dl.google.com`; no compilation or test failure was reported.