### PR TITLE
Remove legacy PINCache cleanup and dependency

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 		C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9D2FBA939E0083839F /* RxCocoa */; };
 		C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76D9F2FBA939E0083839F /* RxSwift */; };
 		C5D76DA52FBA98A90083839F /* AEXML in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DA42FBA98A90083839F /* AEXML */; };
-		C5D76DA82FBA9C150083839F /* PINCache in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DA72FBA9C150083839F /* PINCache */; };
 		C5D76DAB2FBA9D2E0083839F /* SwiftHEXColors in Frameworks */ = {isa = PBXBuildFile; productRef = C5D76DAA2FBA9D2E0083839F /* SwiftHEXColors */; };
 		C5E3D0512FB43570005D632A /* Screeen in Frameworks */ = {isa = PBXBuildFile; productRef = C5E3D0502FB43570005D632A /* Screeen */; };
 		C5E8EE642FFA260700270F1F /* PasteboardHistoryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */; };
@@ -321,7 +320,6 @@
 				FAC43E291B35DFDA00C06102 /* Cocoa.framework in Frameworks */,
 				FAC43E271B35DFD300C06102 /* Carbon.framework in Frameworks */,
 				C5D76DA52FBA98A90083839F /* AEXML in Frameworks */,
-				C5D76DA82FBA9C150083839F /* PINCache in Frameworks */,
 				FAC43E251B35DFD000C06102 /* AppKit.framework in Frameworks */,
 				C5D76DA02FBA939E0083839F /* RxSwift in Frameworks */,
 				C5D76D9E2FBA939E0083839F /* RxCocoa in Frameworks */,
@@ -859,7 +857,6 @@
 				C5A4B2002FC9D76000B71510 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				C5D76D9C2FBA939E0083839F /* XCRemoteSwiftPackageReference "RxSwift" */,
 				C5D76DA32FBA98A90083839F /* XCRemoteSwiftPackageReference "AEXML" */,
-				C5D76DA62FBA9C140083839F /* XCRemoteSwiftPackageReference "pincache" */,
 				C5D76DA92FBA9D2E0083839F /* XCRemoteSwiftPackageReference "SwiftHEXColors" */,
 				C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */,
 				C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */,
@@ -1509,14 +1506,6 @@
 				minimumVersion = 4.7.0;
 			};
 		};
-		C5D76DA62FBA9C140083839F /* XCRemoteSwiftPackageReference "pincache" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pinterest/pincache";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 3.0.4;
-			};
-		};
 		C5D76DA92FBA9D2E0083839F /* XCRemoteSwiftPackageReference "SwiftHEXColors" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/thii/SwiftHEXColors";
@@ -1615,11 +1604,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5D76DA32FBA98A90083839F /* XCRemoteSwiftPackageReference "AEXML" */;
 			productName = AEXML;
-		};
-		C5D76DA72FBA9C150083839F /* PINCache */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C5D76DA62FBA9C140083839F /* XCRemoteSwiftPackageReference "pincache" */;
-			productName = PINCache;
 		};
 		C5D76DAA2FBA9D2E0083839F /* SwiftHEXColors */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8406461c0ee4c6ded60f8b736d69f44c3c5f470b86a4f7442150adfc20105792",
+  "originHash" : "a79bdd68278bff630297cfdc7511ebeeea3cc6c3789440daf385a5bc291afdd7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -152,24 +152,6 @@
       "state" : {
         "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
         "version" : "2.30910.0"
-      }
-    },
-    {
-      "identity" : "pincache",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pinterest/pincache",
-      "state" : {
-        "revision" : "2fb85948463292c2e824148cf17dc62a4c217a94",
-        "version" : "3.0.4"
-      }
-    },
-    {
-      "identity" : "pinoperation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pinterest/PINOperation.git",
-      "state" : {
-        "revision" : "a74f978733bdaf982758bfa23d70a189f4b4c1b6",
-        "version" : "1.2.3"
       }
     },
     {

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -13,7 +13,6 @@
 import Cocoa
 import Dependencies
 import Foundation
-import PINCache
 import RxSwift
 import RxCocoa
 
@@ -59,7 +58,6 @@ final class ClipService {
     func clearAll() {
         pasteboardHistoryRepository.deleteAll()
         // Clear legacy Realm-backed history caches used through v1.2.1.
-        PINCache.shared.removeAllObjects()
         try? FileManager.default.removeItem(atPath: CPYUtilities.applicationSupportFolder())
     }
 


### PR DESCRIPTION
## Summary

- Remove the legacy PINCache cleanup call from `ClipService.clearAll()`.
- Remove the PINCache package product from the Xcode project.
- Remove PINCache and its PINOperation transitive dependency from `Package.resolved`.

## Context

PINCache was only retained to clear legacy Realm-backed history data used through v1.2.1. That cleanup is no longer required, so the unused code path and library can be removed without affecting current pasteboard history deletion.

A Debug build of the Clipy scheme completed successfully with code signing disabled.