### PR TITLE
Add fuzzy search panel for history and snippets

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -85,8 +85,10 @@
 		FA1DB4B91DDCB452007F95C8 /* NSMenuItem+Initialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4AE1DDCB452007F95C8 /* NSMenuItem+Initialize.swift */; };
 		FA1DB4BA1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4AF1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift */; };
 		FA1DB4C91DDCB460007F95C8 /* MenuManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4C31DDCB460007F95C8 /* MenuManager.swift */; };
+		C5FA5EA0000000000000AA02 /* CPYFuzzySearchWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FA5EA0000000000000AA01 /* CPYFuzzySearchWindowController.swift */; };
 		FA1DB4D21DDCB479007F95C8 /* CPYAppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4CC1DDCB479007F95C8 /* CPYAppInfo.swift */; };
 		FA1DB4E51DDCB49C007F95C8 /* CPYUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4D91DDCB49C007F95C8 /* CPYUtilities.swift */; };
+		C5FA5EA0000000000000AA04 /* FuzzyMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FA5EA0000000000000AA03 /* FuzzyMatcher.swift */; };
 		FA1DB4E71DDCB49C007F95C8 /* CPYDesignableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4DD1DDCB49C007F95C8 /* CPYDesignableButton.swift */; };
 		FA1DB4E81DDCB49C007F95C8 /* CPYDesignableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4DE1DDCB49C007F95C8 /* CPYDesignableView.swift */; };
 		FA1DB4E91DDCB49C007F95C8 /* CPYSplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DB4E01DDCB49C007F95C8 /* CPYSplitView.swift */; };
@@ -240,8 +242,10 @@
 		FA1DB4AE1DDCB452007F95C8 /* NSMenuItem+Initialize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMenuItem+Initialize.swift"; sourceTree = "<group>"; };
 		FA1DB4AF1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+ArchiveData.swift"; sourceTree = "<group>"; };
 		FA1DB4C31DDCB460007F95C8 /* MenuManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuManager.swift; sourceTree = "<group>"; };
+		C5FA5EA0000000000000AA01 /* CPYFuzzySearchWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYFuzzySearchWindowController.swift; sourceTree = "<group>"; };
 		FA1DB4CC1DDCB479007F95C8 /* CPYAppInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYAppInfo.swift; sourceTree = "<group>"; };
 		FA1DB4D91DDCB49C007F95C8 /* CPYUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYUtilities.swift; sourceTree = "<group>"; };
+		C5FA5EA0000000000000AA03 /* FuzzyMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuzzyMatcher.swift; sourceTree = "<group>"; };
 		FA1DB4DD1DDCB49C007F95C8 /* CPYDesignableButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYDesignableButton.swift; sourceTree = "<group>"; };
 		FA1DB4DE1DDCB49C007F95C8 /* CPYDesignableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYDesignableView.swift; sourceTree = "<group>"; };
 		FA1DB4E01DDCB49C007F95C8 /* CPYSplitView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYSplitView.swift; sourceTree = "<group>"; };
@@ -588,6 +592,7 @@
 			isa = PBXGroup;
 			children = (
 				FA1DB4C31DDCB460007F95C8 /* MenuManager.swift */,
+				C5FA5EA0000000000000AA01 /* CPYFuzzySearchWindowController.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -608,6 +613,7 @@
 			isa = PBXGroup;
 			children = (
 				FA1DB4D91DDCB49C007F95C8 /* CPYUtilities.swift */,
+				C5FA5EA0000000000000AA03 /* FuzzyMatcher.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -946,6 +952,7 @@
 				FA3778931F3B691A003B5BAB /* AppEnvironment.swift in Sources */,
 				FAC0DCF11DE576F300309C49 /* PasteService.swift in Sources */,
 				FA1DB4E51DDCB49C007F95C8 /* CPYUtilities.swift in Sources */,
+				C5FA5EA0000000000000AA04 /* FuzzyMatcher.swift in Sources */,
 				FA1DB4B81DDCB452007F95C8 /* NSLock+Clipy.swift in Sources */,
 				C57235112FF24ADE002158F7 /* NSMenu+Highlight.swift in Sources */,
 				FA1DB4BA1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift in Sources */,
@@ -967,6 +974,7 @@
 				FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */,
 				C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */,
 				FA1DB4C91DDCB460007F95C8 /* MenuManager.swift in Sources */,
+				C5FA5EA0000000000000AA02 /* CPYFuzzySearchWindowController.swift in Sources */,
 				FA1189331E4CD58C00244F12 /* ExcludeAppService.swift in Sources */,
 				FA1DB4E91DDCB49C007F95C8 /* CPYSplitView.swift in Sources */,
 				FA1DB4E81DDCB49C007F95C8 /* CPYDesignableView.swift in Sources */,

--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -104,6 +104,8 @@ struct Constants {
         static let mainKeyCombo = "kCPYHotKeyMainKeyCombo"
         static let historyKeyCombo = "kCPYHotKeyHistoryKeyCombo"
         static let snippetKeyCombo = "kCPYHotKeySnippetKeyCombo"
+        static let fuzzySearchKeyCombo = "kCPYHotKeyFuzzySearchKeyCombo"
+        static let fuzzySearchKeyComboSeeded = "kCPYHotKeyFuzzySearchKeyComboSeeded"
         static let migrateNewKeyCombo = "kCPYMigrateNewKeyCombo"
         static let folderKeyCombos = "kCPYFolderKeyCombos"
         static let clearHistoryKeyCombo = "kCPYClearHistoryKeyCombo"

--- a/Clipy/Sources/Extensions/PasteboardHistoryExtensions.swift
+++ b/Clipy/Sources/Extensions/PasteboardHistoryExtensions.swift
@@ -15,19 +15,32 @@ import Dependencies
 import Sharing
 
 extension PasteboardHistory {
-    var typedTitle: String {
+    /// Prefix marking non-text clips, e.g. "(Image)", "(PDF)", "(Files)".
+    private var typePrefix: String? {
         let primaryType = pasteboardTypes.first
-        let prefix: String?
         if primaryType == .png || primaryType == .tiff || primaryType == .deprecatedTIFF {
-            prefix = "(Image)"
+            return "(Image)"
         } else if primaryType == .pdf || primaryType == .deprecatedPDF {
-            prefix = "(PDF)"
+            return "(PDF)"
         } else if primaryType == .fileURL || primaryType == .deprecatedFilenames {
-            prefix = "(Files)"
-        } else {
-            prefix = nil
+            return "(Files)"
         }
-        return [prefix, title.trimmedMenuTitle]
+        return nil
+    }
+
+    var typedTitle: String {
+        return [typePrefix, title.trimmedMenuTitle]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    /// Prefix + the full (multi-line) clip text with only the outer whitespace
+    /// trimmed, for UIs that linearize and truncate the text themselves — unlike
+    /// `typedTitle`, this keeps interior line breaks and applies no length cap.
+    var fullDisplaySource: String {
+        let body = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return [typePrefix, body]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
             .joined(separator: " ")

--- a/Clipy/Sources/Managers/CPYFuzzySearchWindowController.swift
+++ b/Clipy/Sources/Managers/CPYFuzzySearchWindowController.swift
@@ -1,0 +1,517 @@
+//
+//  CPYFuzzySearchWindowController.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Dependencies
+
+// MARK: - Item
+/// A single searchable entry shown in the fuzzy panel.
+private struct FuzzySearchItem {
+    enum Kind {
+        case history(PasteboardHistory.ID)
+        case snippet(content: String)
+    }
+
+    let kind: Kind
+    /// Source badge, e.g. "History" or the owning snippet folder title.
+    let source: String
+    /// Characters shown to the user, with line breaks and tabs replaced by
+    /// visible glyphs so multi-line clips read on a single row.
+    let displayCharacters: [Character]
+    /// Lowercased characters matched against. Line breaks/tabs are kept as plain
+    /// whitespace here (not the glyphs), so the glyphs are never searched. Same
+    /// length as `displayCharacters`, so match positions map 1:1 for highlighting.
+    let searchCharacters: [Character]
+
+    /// - Parameter rawText: the (already end-trimmed) text, possibly multi-line.
+    init(kind: Kind, rawText: String, source: String, maxLength: Int = 500) {
+        self.kind = kind
+        self.source = source
+
+        var display = [Character]()
+        var search = [Character]()
+        display.reserveCapacity(Swift.min(rawText.count, maxLength))
+        search.reserveCapacity(Swift.min(rawText.count, maxLength))
+        for character in rawText.prefix(maxLength) {
+            switch character {
+            case "\n", "\r", "\r\n":
+                display.append(DisplayGlyph.newline)
+                search.append(" ")
+            case "\t":
+                display.append(DisplayGlyph.tab)
+                search.append(" ")
+            default:
+                display.append(character)
+                // Lowercase per-character, keeping length 1:1 with the display.
+                search.append(character.lowercased().first ?? character)
+            }
+        }
+        self.displayCharacters = display
+        self.searchCharacters = search
+    }
+}
+
+// MARK: - Display Glyphs
+/// Single-character substitutes shown in place of whitespace that would
+/// otherwise collapse a multi-line clip to its first line.
+private enum DisplayGlyph {
+    static let newline: Character = "↵"
+    static let tab: Character = "⇥"
+
+    static let all: Set<Character> = [newline, tab]
+}
+
+// MARK: - Panel
+/// Borderless panel that is allowed to become key so its search field can
+/// receive keystrokes even though Clipy runs as a menu-bar agent.
+private final class CPYFuzzySearchPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+// MARK: - Window Controller
+final class CPYFuzzySearchWindowController: NSWindowController {
+
+    // MARK: - Properties
+    private let searchField = NSTextField()
+    private let tableView = NSTableView()
+    private let scrollView = NSScrollView()
+    private let placeholderLabel = NSTextField(labelWithString: "")
+
+    private var allItems = [FuzzySearchItem]()
+    private var filteredItems = [FuzzySearchItem]()
+    /// Matched character positions for the currently filtered rows.
+    private var highlightPositions = [[Int]]()
+
+    private let rowHeight: CGFloat = 34
+    private let maxVisibleRows = 10
+
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
+    @Dependency(\.snippetRepository)
+    private var snippetRepository
+
+    // MARK: - Initialize
+    init() {
+        let panel = CPYFuzzySearchPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 400),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.level = .modalPanel
+        panel.hidesOnDeactivate = false
+        panel.isMovableByWindowBackground = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        super.init(window: panel)
+        panel.delegate = self
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Show
+    func showPanel() {
+        guard let window = window else { return }
+
+        reloadItems()
+        searchField.stringValue = ""
+        applyFilter(query: "")
+
+        positionWindow()
+
+        // Deliberately do NOT activate the app. As a non-activating panel it can
+        // still become key and receive typing, while the app the user was in
+        // stays frontmost — so pressing Enter pastes into it immediately, exactly
+        // like selecting from the history menu.
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+        window.makeFirstResponder(searchField)
+    }
+
+    private func closePanel() {
+        window?.orderOut(nil)
+    }
+}
+
+// MARK: - Setup
+private extension CPYFuzzySearchWindowController {
+    func setupViews() {
+        guard let window = window else { return }
+
+        let contentView = NSVisualEffectView()
+        contentView.material = .popover
+        contentView.state = .active
+        contentView.blendingMode = .behindWindow
+        contentView.wantsLayer = true
+        contentView.layer?.cornerRadius = 10
+        contentView.layer?.masksToBounds = true
+        window.contentView = contentView
+
+        // Search field
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.font = .systemFont(ofSize: 22, weight: .light)
+        searchField.placeholderString = String(localized: "Search history and snippets…")
+        searchField.isBordered = false
+        searchField.drawsBackground = false
+        searchField.focusRingType = .none
+        searchField.delegate = self
+        searchField.maximumNumberOfLines = 1
+        searchField.cell?.usesSingleLineMode = true
+        searchField.cell?.lineBreakMode = .byTruncatingTail
+        contentView.addSubview(searchField)
+
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separator)
+
+        // Table
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+        // Make the single column stretch to fill the full table width so long
+        // entries use all the available horizontal space instead of truncating.
+        tableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        tableView.headerView = nil
+        tableView.backgroundColor = .clear
+        tableView.rowHeight = rowHeight
+        tableView.intercellSpacing = NSSize(width: 0, height: 0)
+        tableView.selectionHighlightStyle = .regular
+        tableView.style = .fullWidth
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.action = #selector(tableViewClicked)
+        tableView.target = self
+        tableView.doubleAction = #selector(tableViewClicked)
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.automaticallyAdjustsContentInsets = false
+        contentView.addSubview(scrollView)
+
+        // Placeholder shown when there are no results.
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        placeholderLabel.font = .systemFont(ofSize: 13)
+        placeholderLabel.textColor = .secondaryLabelColor
+        placeholderLabel.alignment = .center
+        placeholderLabel.stringValue = String(localized: "No results")
+        placeholderLabel.isHidden = true
+        contentView.addSubview(placeholderLabel)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            searchField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18),
+            searchField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -18),
+
+            separator.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 12),
+            separator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: separator.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            placeholderLabel.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            placeholderLabel.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
+        ])
+    }
+
+    func positionWindow() {
+        guard let window = window else { return }
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) } ?? NSScreen.main
+        guard let visibleFrame = screen?.visibleFrame else { return }
+
+        let width: CGFloat = min(900, visibleFrame.width - 80)
+        let height = windowHeight()
+        let originX = visibleFrame.midX - width / 2
+        // Anchor the top edge in the upper third (Spotlight-style) so the list
+        // grows downward instead of the whole window jumping as results change.
+        let topAnchorY = visibleFrame.origin.y + visibleFrame.height * 0.82
+        let originY = topAnchorY - height
+        window.setFrame(NSRect(x: originX, y: originY, width: width, height: height), display: true)
+        // Stretch the column to the new table width so entries fill the row.
+        tableView.sizeLastColumnToFit()
+    }
+
+    func windowHeight() -> CGFloat {
+        let headerHeight: CGFloat = 16 + searchField.intrinsicContentSize.height + 12 + 1
+        let visibleRows = max(1, min(maxVisibleRows, filteredItems.count))
+        let listHeight = CGFloat(visibleRows) * rowHeight + 8
+        return headerHeight + listHeight
+    }
+}
+
+// MARK: - Data
+private extension CPYFuzzySearchWindowController {
+    func reloadItems() {
+        var items = [FuzzySearchItem]()
+
+        // Search up to the configured history maximum, same as the rest of the app.
+        let reorderClipsAfterPasting = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+        let maxHistory = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.maxHistorySize)
+        let historyLabel = String(localized: "History")
+        let historyDetails = pasteboardHistoryRepository.fetchHistoryDetails(
+            sortsByCreatedAt: !reorderClipsAfterPasting,
+            includesThumbnailAsset: false,
+            limit: maxHistory
+        )
+        for detail in historyDetails {
+            let rawText = detail.history.fullDisplaySource
+            guard !rawText.isEmpty else { continue }
+            items.append(FuzzySearchItem(kind: .history(detail.history.id), rawText: rawText, source: historyLabel))
+        }
+
+        // Enabled snippets from enabled folders.
+        for folderDetail in snippetRepository.fetchFolderDetails() where folderDetail.folder.isEnabled {
+            for snippet in folderDetail.snippets where snippet.isEnabled {
+                let rawText = snippet.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !rawText.isEmpty else { continue }
+                items.append(FuzzySearchItem(kind: .snippet(content: snippet.content), rawText: rawText, source: folderDetail.folder.title))
+            }
+        }
+
+        allItems = items
+    }
+
+    func applyFilter(query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            filteredItems = allItems
+            highlightPositions = Array(repeating: [], count: allItems.count)
+        } else {
+            let queryCharacters = Array(trimmed.lowercased())
+            var scored = [(item: FuzzySearchItem, match: FuzzyMatcher.Match, order: Int)]()
+            for (index, item) in allItems.enumerated() {
+                if let match = FuzzyMatcher.match(query: queryCharacters, in: item.searchCharacters) {
+                    scored.append((item, match, index))
+                }
+            }
+            scored.sort { lhs, rhs in
+                if lhs.match.score != rhs.match.score {
+                    return lhs.match.score > rhs.match.score
+                }
+                return lhs.order < rhs.order
+            }
+            filteredItems = scored.map { $0.item }
+            highlightPositions = scored.map { $0.match.positions }
+        }
+
+        placeholderLabel.isHidden = !filteredItems.isEmpty
+        tableView.reloadData()
+        if !filteredItems.isEmpty {
+            tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            tableView.scrollRowToVisible(0)
+        }
+        positionWindow()
+    }
+}
+
+// MARK: - Selection
+private extension CPYFuzzySearchWindowController {
+    @objc func tableViewClicked() {
+        guard tableView.clickedRow >= 0 else { return }
+        performSelection(at: tableView.clickedRow)
+    }
+
+    func performSelection(at row: Int) {
+        guard filteredItems.indices.contains(row) else {
+            NSSound.beep()
+            return
+        }
+        let item = filteredItems[row]
+        let pasteService = AppEnvironment.current.pasteService
+
+        // Resolve everything up front so that, once the panel is dismissed,
+        // nothing but the paste itself happens.
+        let pasteAction: () -> Void
+        switch item.kind {
+        case .history(let id):
+            guard let content = pasteboardHistoryRepository.fetchContent(id: id) else {
+                NSSound.beep()
+                return
+            }
+            pasteAction = { pasteService.paste(id: id, content: content) }
+        case .snippet(let content):
+            pasteAction = {
+                pasteService.copyToPasteboard(with: content)
+                pasteService.paste()
+            }
+        }
+
+        // Dismiss and paste straight away. The panel never activated Clipy, so
+        // the previously focused app is still frontmost and receives the ⌘V
+        // immediately — matching the history menu's behaviour.
+        closePanel()
+        pasteAction()
+    }
+
+    func moveSelection(by delta: Int) {
+        guard !filteredItems.isEmpty else { return }
+        let current = tableView.selectedRow
+        var next = current + delta
+        next = max(0, min(filteredItems.count - 1, next))
+        tableView.selectRowIndexes(IndexSet(integer: next), byExtendingSelection: false)
+        tableView.scrollRowToVisible(next)
+    }
+}
+
+// MARK: - NSTableViewDataSource
+extension CPYFuzzySearchWindowController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return filteredItems.count
+    }
+}
+
+// MARK: - NSTableViewDelegate
+extension CPYFuzzySearchWindowController: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let identifier = NSUserInterfaceItemIdentifier("FuzzyCell")
+        let cell = (tableView.makeView(withIdentifier: identifier, owner: self) as? FuzzySearchCellView) ?? {
+            let view = FuzzySearchCellView()
+            view.identifier = identifier
+            return view
+        }()
+        let item = filteredItems[row]
+        let positions = highlightPositions.indices.contains(row) ? highlightPositions[row] : []
+        cell.configure(displayCharacters: item.displayCharacters, source: item.source, highlighted: positions)
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        return FuzzySearchRowView()
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+extension CPYFuzzySearchWindowController: NSTextFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        applyFilter(query: searchField.stringValue)
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        switch commandSelector {
+        case #selector(NSResponder.moveUp(_:)):
+            moveSelection(by: -1)
+            return true
+        case #selector(NSResponder.moveDown(_:)):
+            moveSelection(by: 1)
+            return true
+        case #selector(NSResponder.insertNewline(_:)):
+            performSelection(at: tableView.selectedRow)
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            closePanel()
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - NSWindowDelegate
+extension CPYFuzzySearchWindowController: NSWindowDelegate {
+    func windowDidResignKey(_ notification: Notification) {
+        // Dismiss when the user clicks away or switches apps.
+        closePanel()
+    }
+}
+
+// MARK: - Row View
+/// Rounds the selection highlight to match the panel style.
+private final class FuzzySearchRowView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        guard selectionHighlightStyle != .none else { return }
+        let rect = bounds.insetBy(dx: 6, dy: 2)
+        let path = NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6)
+        NSColor.selectedContentBackgroundColor.setFill()
+        path.fill()
+    }
+}
+
+// MARK: - Cell View
+private final class FuzzySearchCellView: NSTableCellView {
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let sourceLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.maximumNumberOfLines = 1
+        titleLabel.cell?.usesSingleLineMode = true
+        titleLabel.cell?.lineBreakMode = .byTruncatingTail
+        titleLabel.font = .systemFont(ofSize: 13)
+        addSubview(titleLabel)
+
+        sourceLabel.translatesAutoresizingMaskIntoConstraints = false
+        sourceLabel.font = .systemFont(ofSize: 10, weight: .medium)
+        sourceLabel.textColor = .secondaryLabelColor
+        sourceLabel.alignment = .right
+        sourceLabel.setContentHuggingPriority(.required, for: .horizontal)
+        sourceLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        addSubview(sourceLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            sourceLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
+            sourceLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -18),
+            sourceLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func configure(displayCharacters: [Character], source: String, highlighted: [Int]) {
+        let attributed = NSMutableAttributedString(
+            string: String(displayCharacters),
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 13),
+                .foregroundColor: NSColor.labelColor
+            ]
+        )
+        // Dim the whitespace glyphs so they read as subtle markers.
+        for (position, character) in displayCharacters.enumerated() where DisplayGlyph.all.contains(character) {
+            attributed.addAttribute(
+                .foregroundColor,
+                value: NSColor.tertiaryLabelColor,
+                range: NSRange(location: position, length: 1)
+            )
+        }
+        // Matched characters win over the dimming above.
+        let highlightSet = Set(highlighted)
+        for position in highlightSet where position < displayCharacters.count {
+            attributed.addAttributes(
+                [
+                    .font: NSFont.systemFont(ofSize: 13, weight: .bold),
+                    .foregroundColor: NSColor.controlAccentColor
+                ],
+                range: NSRange(location: position, length: 1)
+            )
+        }
+        titleLabel.attributedStringValue = attributed
+        sourceLabel.stringValue = source.uppercased()
+    }
+}

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -23,6 +23,8 @@ final class MenuManager: NSObject {
     private var clipMenu: NSMenu?
     private var historyMenu: NSMenu?
     private var snippetMenu: NSMenu?
+    // Fuzzy search
+    private lazy var fuzzySearchWindowController = CPYFuzzySearchWindowController()
     // StatusMenu
     private lazy var statusBarItem: NSStatusItem = {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -81,6 +83,10 @@ extension MenuManager {
         }
         menu?.highlightingFirstItemIfPossible()
         menu?.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
+    }
+
+    func popUpFuzzySearch() {
+        fuzzySearchWindowController.showPanel()
     }
 
     func popUpSnippetFolder(_ folderDetail: SnippetFolderDetail) {

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
@@ -8,6 +8,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="CPYShortcutsPreferenceViewController" customModule="Clipy" customModuleProvider="target">
             <connections>
                 <outlet property="clearHistoryShortcutRecordView" destination="pCf-EG-Cp9" id="K22-8R-Gk9"/>
+                <outlet property="fuzzySearchShortcutRecordView" destination="Fz1-Sr-Ch0" id="Fz4-Ot-Ch0"/>
                 <outlet property="historyShortcutRecordView" destination="hDA-gc-n3S" id="fzg-O8-Fze"/>
                 <outlet property="mainShortcutRecordView" destination="ABK-GW-Xwm" id="Jr7-Dz-hqZ"/>
                 <outlet property="snippetShortcutRecordView" destination="q8v-jS-CAr" id="Ay0-Zr-azr"/>
@@ -17,11 +18,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="275"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="323"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="5oP-dg-DwL">
-                    <rect key="frame" x="59" y="244" width="210" height="17"/>
+                    <rect key="frame" x="59" y="292" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Menu" id="X5L-5V-1eH">
                         <font key="font" metaFont="systemBold"/>
@@ -30,9 +31,36 @@
                     </textFieldCell>
                 </textField>
                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uTq-IP-dYk">
-                    <rect key="frame" x="44" y="96" width="392" height="140"/>
+                    <rect key="frame" x="44" y="96" width="392" height="188"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fz2-Lb-Ch0">
+                            <rect key="frame" x="15" y="157" width="121" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Fuzzy Search:" id="Fz3-Cl-Ch0">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fz1-Sr-Ch0" customClass="RecordView" customModule="KeyHolder">
+                            <rect key="frame" x="142" y="149" width="250" height="34"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="17"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
+                                    <color key="value" red="0.1647058824" green="0.51764705879999995" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                    <color key="value" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                    <real key="value" value="1"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </customView>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vzz-Iq-77h">
                             <rect key="frame" x="15" y="62" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
@@ -20,6 +20,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     @IBOutlet private weak var mainShortcutRecordView: RecordView!
     @IBOutlet private weak var historyShortcutRecordView: RecordView!
     @IBOutlet private weak var snippetShortcutRecordView: RecordView!
+    @IBOutlet private weak var fuzzySearchShortcutRecordView: RecordView!
     @IBOutlet private weak var clearHistoryShortcutRecordView: RecordView!
 
     // MARK: - Initialize
@@ -28,6 +29,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
         mainShortcutRecordView.delegate = self
         historyShortcutRecordView.delegate = self
         snippetShortcutRecordView.delegate = self
+        fuzzySearchShortcutRecordView.delegate = self
         clearHistoryShortcutRecordView.delegate = self
         prepareHotKeys()
     }
@@ -40,6 +42,7 @@ private extension CPYShortcutsPreferenceViewController {
         mainShortcutRecordView.keyCombo = AppEnvironment.current.hotKeyService.mainKeyCombo
         historyShortcutRecordView.keyCombo = AppEnvironment.current.hotKeyService.historyKeyCombo
         snippetShortcutRecordView.keyCombo = AppEnvironment.current.hotKeyService.snippetKeyCombo
+        fuzzySearchShortcutRecordView.keyCombo = AppEnvironment.current.hotKeyService.fuzzySearchKeyCombo
         clearHistoryShortcutRecordView.keyCombo = AppEnvironment.current.hotKeyService.clearHistoryKeyCombo
     }
 }
@@ -62,6 +65,8 @@ extension CPYShortcutsPreferenceViewController: RecordViewDelegate {
             AppEnvironment.current.hotKeyService.change(with: .history, keyCombo: keyCombo)
         case snippetShortcutRecordView:
             AppEnvironment.current.hotKeyService.change(with: .snippet, keyCombo: keyCombo)
+        case fuzzySearchShortcutRecordView:
+            AppEnvironment.current.hotKeyService.changeFuzzySearchKeyCombo(keyCombo)
         case clearHistoryShortcutRecordView:
             AppEnvironment.current.hotKeyService.changeClearHistoryKeyCombo(keyCombo)
         default: break

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -31,6 +31,7 @@ final class HotKeyService: NSObject {
     fileprivate(set) var historyKeyCombo: KeyCombo?
     fileprivate(set) var snippetKeyCombo: KeyCombo?
     fileprivate(set) var clearHistoryKeyCombo: KeyCombo?
+    fileprivate(set) var fuzzySearchKeyCombo: KeyCombo?
 
     @Dependency(\.snippetRepository)
     private var snippetRepository
@@ -55,6 +56,11 @@ extension HotKeyService {
     @objc func popUpSnippetMenu() {
         AppEnvironment.current.menuManager.popUpMenu(.snippet)
         firebase.logEvent(event: .popUpMenu(.snippet))
+    }
+
+    @objc func popUpFuzzySearchPanel() {
+        AppEnvironment.current.menuManager.popUpFuzzySearch()
+        firebase.logEvent(event: .popUpMenu(.history))
     }
 
     @objc func popUpClearHistoryAlert() {
@@ -83,6 +89,24 @@ extension HotKeyService {
         change(with: .snippet, keyCombo: savedKeyCombo(forKey: Constants.HotKey.snippetKeyCombo))
         // Clear History
         changeClearHistoryKeyCombo(savedKeyCombo(forKey: Constants.HotKey.clearHistoryKeyCombo))
+        // Fuzzy Search panel
+        setupFuzzySearchDefaultHotKey()
+    }
+
+    /// Registers the fuzzy-search hotkey, seeding a ⌘⌥V default the first time
+    /// only, so a user who later clears it is not overridden on the next launch.
+    private func setupFuzzySearchDefaultHotKey() {
+        if !appStorage.bool(forKey: Constants.HotKey.fuzzySearchKeyComboSeeded) {
+            appStorage.set(true, forKey: Constants.HotKey.fuzzySearchKeyComboSeeded)
+            appStorage.synchronize()
+            if appStorage.object(forKey: Constants.HotKey.fuzzySearchKeyCombo) == nil,
+               // ⌘ + ⌥ + V  (keyCode 9 = "V", carbon modifiers cmdKey | optionKey = 256 | 2048)
+               let defaultKeyCombo = KeyCombo(QWERTYKeyCode: 9, carbonModifiers: 2304) {
+                changeFuzzySearchKeyCombo(defaultKeyCombo)
+                return
+            }
+        }
+        changeFuzzySearchKeyCombo(savedKeyCombo(forKey: Constants.HotKey.fuzzySearchKeyCombo))
     }
 
     func change(with type: MenuType, keyCombo: KeyCombo?) {
@@ -106,6 +130,18 @@ extension HotKeyService {
         // Register new hotkey
         guard let keyCombo = keyCombo else { return }
         let hotkey = HotKey(identifier: "ClearHistory", keyCombo: keyCombo, target: self, action: #selector(HotKeyService.popUpClearHistoryAlert))
+        hotkey.register()
+    }
+
+    func changeFuzzySearchKeyCombo(_ keyCombo: KeyCombo?) {
+        fuzzySearchKeyCombo = keyCombo
+        appStorage.set(keyCombo?.archive(), forKey: Constants.HotKey.fuzzySearchKeyCombo)
+        appStorage.synchronize()
+        // Reset hotkey
+        HotKeyCenter.shared.unregisterHotKey(with: "FuzzySearch")
+        // Register new hotkey
+        guard let keyCombo = keyCombo else { return }
+        let hotkey = HotKey(identifier: "FuzzySearch", keyCombo: keyCombo, target: self, action: #selector(HotKeyService.popUpFuzzySearchPanel))
         hotkey.register()
     }
 

--- a/Clipy/Sources/Utility/FuzzyMatcher.swift
+++ b/Clipy/Sources/Utility/FuzzyMatcher.swift
@@ -1,0 +1,67 @@
+//
+//  FuzzyMatcher.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Foundation
+
+/// Lightweight fzf-style fuzzy matcher.
+///
+/// Performs a case-insensitive subsequence match of `query` against a candidate
+/// string and returns a score plus the matched character positions so callers
+/// can highlight them. Higher scores are better matches; `nil` means no match.
+enum FuzzyMatcher {
+    struct Match: Equatable {
+        let score: Int
+        let positions: [Int]
+    }
+
+    /// - Parameters:
+    ///   - query: Lowercased query characters.
+    ///   - text: Lowercased candidate characters.
+    static func match(query: [Character], in text: [Character]) -> Match? {
+        guard !query.isEmpty else { return Match(score: 0, positions: []) }
+        guard query.count <= text.count else { return nil }
+
+        var positions = [Int]()
+        positions.reserveCapacity(query.count)
+        var score = 0
+        var queryIndex = 0
+        var previousMatch = -2
+
+        for (index, character) in text.enumerated() {
+            guard queryIndex < query.count else { break }
+            guard character == query[queryIndex] else { continue }
+
+            var bonus = 1
+            // Reward consecutive matches (e.g. typing "cli" matching "clipy").
+            if index == previousMatch + 1 {
+                bonus += 8
+            }
+            // Reward matches at the start of a word / after a separator.
+            if index == 0 || isBoundary(text[index - 1]) {
+                bonus += 10
+            }
+            score += bonus
+            positions.append(index)
+            previousMatch = index
+            queryIndex += 1
+        }
+
+        guard queryIndex == query.count, let first = positions.first else { return nil }
+        // Prefer matches that start earlier in the string.
+        score -= first / 4
+        return Match(score: score, positions: positions)
+    }
+
+    private static func isBoundary(_ character: Character) -> Bool {
+        return character == " " || character == "_" || character == "-" ||
+            character == "/" || character == "." || character == ":" ||
+            character == "\t" || character == "\n"
+    }
+}


### PR DESCRIPTION
The native history menu is an NSMenu, which cannot be filtered while open, this adds a separate floating panel, opened with a dedicated and configurable shortcut (default Cmd+Opt+V), that fuzzy-filters the clipboard history and snippets as the user types, ranking matches and highlighting the matched characters.

The panel is non-activating: the app the user was working in stays frontmost, so pressing Enter or clicking a row pastes into it immediately, matching the history menu's behaviour. Unlike the menu, rows are not capped to the menu title length, and multi-line clips are linearised with visible glyphs for line breaks and tabs while the search still runs against the real text.

The existing main, history and snippet menus are unchanged.