### PR TITLE
Filter whitespace-only clipboard text

### DIFF
--- a/Clipy/Sources/Models/PasteboardContent.swift
+++ b/Clipy/Sources/Models/PasteboardContent.swift
@@ -25,15 +25,22 @@ struct PasteboardContent: Equatable {
     let assets: [Asset]
     let hash: String
 
-    var isOnlyStringType: Bool {
-        types == [.string] || types == [.deprecatedString]
+    var isBlankText: Bool {
+        guard
+            let primaryType = types.first,
+            [.string, .deprecatedString, .rtf, .deprecatedRTF].contains(primaryType),
+            let stringValue
+        else {
+            return false
+        }
+        return stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-    var stringValue: String {
-        guard let data = data(for: .string) ?? data(for: .deprecatedString) else { return "" }
-        return String(data: data, encoding: .utf8) ?? ""
+    var stringValue: String? {
+        guard let data = data(for: .string) ?? data(for: .deprecatedString) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
     var colorCodeImage: NSImage? {
-        guard let color = NSColor(hexString: stringValue) else { return nil }
+        guard let stringValue, let color = NSColor(hexString: stringValue) else { return nil }
         return NSImage.create(with: color, size: NSSize(width: 20, height: 20))
     }
     var thumbnailImage: NSImage? {

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -119,7 +119,7 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                     .fetchOne(database)
                 let history = PasteboardHistory(
                     id: id,
-                    title: String(content.stringValue.prefix(10000)),
+                    title: content.stringValue.map { String($0.prefix(10000)) } ?? "",
                     ocrText: existingHistory?.ocrText,
                     pasteboardTypes: content.types,
                     createdAt: existingHistory?.createdAt ?? updateAt,

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -109,8 +109,8 @@ extension ClipService {
         let historyID = PasteboardHistory.ID(rawValue: content.hash)
         if pasteboardHistoryRepository.fetchHistory(id: historyID) != nil, !isCopySameHistory { return }
 
-        // Don't save empty string history
-        if content.isOnlyStringType && content.stringValue.isEmpty { return }
+        // Don't save empty or whitespace-only text history
+        if content.isBlankText { return }
 
         // Overwrite same history
         let isOverwriteHistory = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.overwriteSameHistory)

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -77,7 +77,7 @@ extension PasteService {
         }
         // Paste history
         if isPastePlainText {
-            copyToPasteboard(with: content.stringValue)
+            copyToPasteboard(with: content.stringValue ?? "")
             paste()
         } else if isPasteAndDeleteHistory {
             copyToPasteboard(with: content)
@@ -101,7 +101,7 @@ extension PasteService {
         lock.lock(); defer { lock.unlock() }
 
         if isPastePlainText {
-            copyToPasteboard(with: content.stringValue)
+            copyToPasteboard(with: content.stringValue ?? "")
             return
         }
 

--- a/ClipyTests/Models/PasteboardContentTests.swift
+++ b/ClipyTests/Models/PasteboardContentTests.swift
@@ -16,7 +16,7 @@ import Testing
 
 @MainActor
 @Suite
-struct PasteboardContentTests {
+struct PasteboardContentTests { // swiftlint:disable:this type_body_length
     @Test
     func typesAreDerivedFromAssetsInOrder() throws {
         let content = try #require(
@@ -197,13 +197,22 @@ struct PasteboardContentTests {
                 ]
             )
         )
+        let nonStringContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .pdf, data: Data("pdf".utf8))
+                ]
+            )
+        )
 
-        #expect(modernContent.isOnlyStringType)
+        #expect(!modernContent.isBlankText)
         #expect(modernContent.stringValue == "Hello")
-        #expect(deprecatedContent.isOnlyStringType)
+        #expect(!deprecatedContent.isBlankText)
         #expect(deprecatedContent.stringValue == "Legacy")
-        #expect(!mixedContent.isOnlyStringType)
+        #expect(!mixedContent.isBlankText)
         #expect(mixedContent.stringValue == "Hello")
+        #expect(!nonStringContent.isBlankText)
+        #expect(nonStringContent.stringValue == nil)
     }
 
     @Test
@@ -292,6 +301,66 @@ struct PasteboardContentTests {
         #expect(content.hash == equivalentContent.hash)
         #expect(content.hash != changedDataContent.hash)
         #expect(content.hash != changedOrderContent.hash)
+    }
+
+    @Test(arguments: ["", " ", "\t\r\n", "\u{00a0}\u{3000}"])
+    func emptyAndWhitespaceOnlyStringsAreBlank(string: String) throws {
+        let modernContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .string, data: Data(string.utf8))
+                ]
+            )
+        )
+        let deprecatedContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .deprecatedString, data: Data(string.utf8))
+                ]
+            )
+        )
+        let mixedContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .string, data: Data(string.utf8)),
+                    PasteboardContent.Asset(type: .concealed, data: Data())
+                ]
+            )
+        )
+
+        #expect(modernContent.isBlankText)
+        #expect(deprecatedContent.isBlankText)
+        #expect(mixedContent.isBlankText)
+    }
+
+    @Test(arguments: ["a", " text ", "\ntext\n"])
+    func stringsContainingNonWhitespaceAreNotBlank(string: String) throws {
+        let modernContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .string, data: Data(string.utf8))
+                ]
+            )
+        )
+        let deprecatedContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .deprecatedString, data: Data(string.utf8))
+                ]
+            )
+        )
+        let mixedContent = try #require(
+            PasteboardContent(
+                assets: [
+                    PasteboardContent.Asset(type: .string, data: Data(string.utf8)),
+                    PasteboardContent.Asset(type: .concealed, data: Data())
+                ]
+            )
+        )
+
+        #expect(!modernContent.isBlankText)
+        #expect(!deprecatedContent.isBlankText)
+        #expect(!mixedContent.isBlankText)
     }
 }
 


### PR DESCRIPTION
## Summary

- Filter empty and whitespace-only clipboard text before saving it to history.
- Support modern and deprecated String/RTF pasteboard types by checking the primary type and trimming the plain-text representation.
- Preserve RTFD and other non-text-primary clipboard content.
- Make `stringValue` optional so missing text data is distinct from an empty string.
- Confirm the change with the full test suite (92 tests).

## Background

The existing guard only rejected exact String pasteboard entries when `String.isEmpty` was true. As a result, whitespace-only text and RTF clipboard content with a blank plain-text representation could still produce empty-looking history items.

Related issue: [#280 Avoid empty selection](https://github.com/Clipy/Clipy/issues/280)