### PR TITLE
Improve accessibility permission guidance

### DIFF
--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -725,37 +725,37 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Um diese Aktion auszuführen, erlauben Sie Clipy unter „Systemeinstellungen“ > „Datenschutz & Sicherheit“ > „Bedienungshilfen“ den Zugriff.\n\nWenn diese Meldung wiederholt angezeigt wird, obwohl Clipy aktiviert ist, entfernen Sie Clipy aus der Liste, fügen Sie es erneut hinzu und aktivieren Sie es wieder."
+            "value" : "Erlauben Sie Clipy für diese Aktion unter „Systemeinstellungen“ > „Datenschutz & Sicherheit“ > „Bedienungshilfen“ den Zugriff. Wird die Meldung weiterhin angezeigt, entfernen Sie Clipy aus der Liste und fügen Sie es erneut hinzu."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To perform this action, allow Clipy under System Settings > Privacy & Security > Accessibility.\n\nIf this message keeps appearing even though Clipy is enabled, remove Clipy from the Accessibility list, then add and enable it again."
+            "value" : "To perform this action, allow Clipy in System Settings > Privacy & Security > Accessibility. If this message still appears, remove Clipy from the list and add it again."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Per eseguire questa azione, consenti l'accesso a Clipy in Impostazioni di Sistema > Privacy e sicurezza > Accessibilità.\n\nSe questo messaggio continua a comparire anche se Clipy è abilitato, rimuovi Clipy dall'elenco Accessibilità, quindi aggiungilo e abilitalo di nuovo."
+            "value" : "Per eseguire questa azione, consenti l'accesso a Clipy in Impostazioni di Sistema > Privacy e sicurezza > Accessibilità. Se il messaggio ricompare, rimuovi Clipy dall'elenco e aggiungilo di nuovo."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "この動作を行うには、「システム設定」＞「プライバシーとセキュリティ」＞「アクセシビリティ」で、Clipyへのアクセスを許可してください。\n\nClipyを有効にしていてもこのメッセージが何度も表示される場合は、アクセシビリティの一覧からClipyを一度削除し、再度追加して有効にしてみてください。"
+            "value" : "この動作を行うには、システム設定の「プライバシーとセキュリティ」＞「アクセシビリティ」でClipyへのアクセスを許可してください。有効にしても表示される場合は、一覧からClipyを一度削除し、追加し直してみてください。"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Para realizar esta ação, permita o acesso do Clipy em Ajustes do Sistema > Privacidade e Segurança > Acessibilidade.\n\nSe esta mensagem continuar aparecendo mesmo com o Clipy ativado, remova o Clipy da lista de Acessibilidade e, em seguida, adicione-o novamente e ative-o."
+            "value" : "Para realizar esta ação, permita o acesso do Clipy em Ajustes do Sistema > Privacidade e Segurança > Acessibilidade. Se a mensagem continuar aparecendo, remova o Clipy da lista e adicione-o novamente."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "要执行此操作，请在“系统设置”>“隐私与安全性”>“辅助功能”中允许 Clipy 访问。\n\n如果 Clipy 已启用但此提示仍反复出现，请先从“辅助功能”列表中移除 Clipy，然后重新添加并启用。"
+            "value" : "要执行此操作，请在“系统设置”>“隐私与安全性”>“辅助功能”中允许 Clipy 访问。如果仍显示此提示，请从列表中移除 Clipy，然后重新添加。"
           }
         }
       }

--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -725,37 +725,37 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erlauben Sie Clipy für diese Aktion unter „Systemeinstellungen“ > „Datenschutz & Sicherheit“ > „Bedienungshilfen“ den Zugriff. Wird die Meldung weiterhin angezeigt, entfernen Sie Clipy aus der Liste und fügen Sie es erneut hinzu."
+            "value" : "Erlauben Sie Clipy für diese Aktion unter „Systemeinstellungen“ > „Datenschutz & Sicherheit“ > „Bedienungshilfen“ den Zugriff.\n\nWird die Meldung weiterhin angezeigt, entfernen Sie Clipy aus der Liste und fügen Sie es erneut hinzu."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To perform this action, allow Clipy in System Settings > Privacy & Security > Accessibility. If this message still appears, remove Clipy from the list and add it again."
+            "value" : "To perform this action, allow Clipy in System Settings > Privacy & Security > Accessibility.\n\nIf this message still appears, remove Clipy from the list and add it again."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Per eseguire questa azione, consenti l'accesso a Clipy in Impostazioni di Sistema > Privacy e sicurezza > Accessibilità. Se il messaggio ricompare, rimuovi Clipy dall'elenco e aggiungilo di nuovo."
+            "value" : "Per eseguire questa azione, consenti l'accesso a Clipy in Impostazioni di Sistema > Privacy e sicurezza > Accessibilità.\n\nSe il messaggio ricompare, rimuovi Clipy dall'elenco e aggiungilo di nuovo."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "この動作を行うには、システム設定の「プライバシーとセキュリティ」＞「アクセシビリティ」でClipyへのアクセスを許可してください。有効にしても表示される場合は、一覧からClipyを一度削除し、追加し直してみてください。"
+            "value" : "この動作を行うには、システム設定の「プライバシーとセキュリティ」＞「アクセシビリティ」でClipyへのアクセスを許可してください。\n\n有効にしても表示される場合は、一覧からClipyを一度削除し、追加し直してみてください。"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Para realizar esta ação, permita o acesso do Clipy em Ajustes do Sistema > Privacidade e Segurança > Acessibilidade. Se a mensagem continuar aparecendo, remova o Clipy da lista e adicione-o novamente."
+            "value" : "Para realizar esta ação, permita o acesso do Clipy em Ajustes do Sistema > Privacidade e Segurança > Acessibilidade.\n\nSe a mensagem continuar aparecendo, remova o Clipy da lista e adicione-o novamente."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "要执行此操作，请在“系统设置”>“隐私与安全性”>“辅助功能”中允许 Clipy 访问。如果仍显示此提示，请从列表中移除 Clipy，然后重新添加。"
+            "value" : "要执行此操作，请在“系统设置”>“隐私与安全性”>“辅助功能”中允许 Clipy 访问。\n\n如果仍显示此提示，请从列表中移除 Clipy，然后重新添加。"
           }
         }
       }

--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -3,12 +3,6 @@
   "strings" : {
     "Add" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27,6 +21,12 @@
             "value" : "追加"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37,12 +37,6 @@
     },
     "Are you sure want to delete this item?" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza de que deseja excluir este item?"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +55,12 @@
             "value" : "本当に削除してもよろしいですか？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tem certeza de que deseja excluir este item?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71,12 +71,6 @@
     },
     "Are you sure you want to clear your clipboard history?" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza de que deseja limpar seu histórico da área de transferência?"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -95,6 +89,12 @@
             "value" : "本当にクリップボード履歴をクリアしますか？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tem certeza de que deseja limpar seu histórico da área de transferência?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -105,12 +105,6 @@
     },
     "Cancel" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +123,12 @@
             "value" : "キャンセル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -139,12 +139,6 @@
     },
     "Clear History" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpar Histórico"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -163,6 +157,12 @@
             "value" : "履歴をクリア"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpar Histórico"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -173,12 +173,6 @@
     },
     "Delete Item" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excluir Item"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -197,6 +191,12 @@
             "value" : "スニペットを削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excluir Item"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -207,12 +207,6 @@
     },
     "Don't Launch" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não Iniciar"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -231,6 +225,12 @@
             "value" : "起動しない"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não Iniciar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -241,12 +241,6 @@
     },
     "Edit Snippets" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar Snippets..."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -271,6 +265,12 @@
             "value" : "スニペットを編集..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar Snippets..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -282,12 +282,6 @@
     "General" : {
       "extractionState" : "manual",
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geral"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -312,6 +306,12 @@
             "value" : "一般"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geral"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -322,12 +322,6 @@
     },
     "History" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Histórico"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -346,6 +340,12 @@
             "value" : "履歴"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Histórico"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -356,12 +356,6 @@
     },
     "Launch Clipy on system startup?" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar o Clipy ao iniciar o sistema?"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -380,6 +374,12 @@
             "value" : "システム起動時にClipyを起動しますか?"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar o Clipy ao iniciar o sistema?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -390,12 +390,6 @@
     },
     "Launch on system startup" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar com o sistema"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -414,6 +408,12 @@
             "value" : "起動する"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar com o sistema"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -425,12 +425,6 @@
     "Menu" : {
       "extractionState" : "manual",
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menu"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -455,6 +449,12 @@
             "value" : "メニュー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -465,12 +465,6 @@
     },
     "Open System Preferences" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Preferências do Sistema"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -489,6 +483,12 @@
             "value" : "\"システム環境設定\"を開く"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Preferências do Sistema"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -499,12 +499,6 @@
     },
     "Please allow Accessibility" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, permita Acessibilidade"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -529,6 +523,12 @@
             "value" : "アクセシビリティを有効にしてください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor, permita Acessibilidade"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -539,12 +539,6 @@
     },
     "Please fill in the contents of the snippet" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, preencha o conteúdo do snippet"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -563,6 +557,12 @@
             "value" : "スニペットの内容を記入してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor, preencha o conteúdo do snippet"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -573,12 +573,6 @@
     },
     "Preferences" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferências..."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -603,6 +597,12 @@
             "value" : "環境設定..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferências..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -613,12 +613,6 @@
     },
     "Quit Clipy" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encerrar Clipy"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -637,6 +631,12 @@
             "value" : "Clipyを終了"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encerrar Clipy"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -648,12 +648,6 @@
     "Shortcuts" : {
       "extractionState" : "manual",
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atalhos"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -678,6 +672,12 @@
             "value" : "ショートカット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atalhos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -688,12 +688,6 @@
     },
     "Snippet" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snippet"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -712,6 +706,12 @@
             "value" : "スニペット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snippet"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -722,40 +722,40 @@
     },
     "To do this action please allow Accessibility in Security Privacy preferences located in System Preferences" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para realizar esta ação, permita Acessibilidade nas preferências de Segurança e Privacidade localizadas nas Preferências do Sistema."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences."
+            "value" : "Um diese Aktion auszuführen, erlauben Sie Clipy unter „Systemeinstellungen“ > „Datenschutz & Sicherheit“ > „Bedienungshilfen“ den Zugriff.\n\nWenn diese Meldung wiederholt angezeigt wird, obwohl Clipy aktiviert ist, entfernen Sie Clipy aus der Liste, fügen Sie es erneut hinzu und aktivieren Sie es wieder."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences."
+            "value" : "To perform this action, allow Clipy under System Settings > Privacy & Security > Accessibility.\n\nIf this message keeps appearing even though Clipy is enabled, remove Clipy from the Accessibility list, then add and enable it again."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences."
+            "value" : "Per eseguire questa azione, consenti l'accesso a Clipy in Impostazioni di Sistema > Privacy e sicurezza > Accessibilità.\n\nSe questo messaggio continua a comparire anche se Clipy è abilitato, rimuovi Clipy dall'elenco Accessibilità, quindi aggiungilo e abilitalo di nuovo."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "この動作を行うためにはシステム環境設定の\"セキュリティとプライバシー\"環境設定で、Clipyへのアクセシビリティのアクセスを許可してください。"
+            "value" : "この動作を行うには、「システム設定」＞「プライバシーとセキュリティ」＞「アクセシビリティ」で、Clipyへのアクセスを許可してください。\n\nClipyを有効にしていてもこのメッセージが何度も表示される場合は、アクセシビリティの一覧からClipyを一度削除し、再度追加して有効にしてみてください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para realizar esta ação, permita o acesso do Clipy em Ajustes do Sistema > Privacidade e Segurança > Acessibilidade.\n\nSe esta mensagem continuar aparecendo mesmo com o Clipy ativado, remova o Clipy da lista de Acessibilidade e, em seguida, adicione-o novamente e ative-o."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To do this action please allow Accessibility in Security & Privacy preferences, located in System Preferences."
+            "value" : "要执行此操作，请在“系统设置”>“隐私与安全性”>“辅助功能”中允许 Clipy 访问。\n\n如果 Clipy 已启用但此提示仍反复出现，请先从“辅助功能”列表中移除 Clipy，然后重新添加并启用。"
           }
         }
       }
@@ -763,12 +763,6 @@
     "Updates" : {
       "extractionState" : "manual",
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizações"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -793,6 +787,12 @@
             "value" : "アップデート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualizações"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -803,12 +803,6 @@
     },
     "You can change this setting in the Preferences if you want" : {
       "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Você pode alterar essa configuração nas Preferências, se desejar."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
@@ -831,6 +825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "この設定はいつでも変更できます"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você pode alterar essa configuração nas Preferências, se desejar."
           }
         },
         "zh-Hans" : {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -146,6 +146,10 @@ extension AppDelegate: NSApplicationDelegate {
 
         // SDKs
         firebase.configure()
+        // Check Accessibility Permission
+        if appStorage.bool(forKey: Constants.UserDefaults.inputPasteCommand) {
+            Accessibility.isAccessibilityEnabled(isPrompt: true)
+        }
 
         // Show Login Item
         if !appStorage.bool(forKey: Constants.UserDefaults.loginItem) && !appStorage.bool(forKey: Constants.UserDefaults.suppressAlertForLoginItem) {
@@ -194,7 +198,7 @@ extension AppDelegate: NSApplicationDelegate {
 private extension AppDelegate {
     func bind() {
         // Accessibility Permission
-        appStorage.rx.observe(Bool.self, Constants.UserDefaults.inputPasteCommand, retainSelf: false)
+        appStorage.rx.observe(Bool.self, Constants.UserDefaults.inputPasteCommand, options: [.new], retainSelf: false)
             .compactMap { $0 }
             .distinctUntilChanged()
             .filter { $0 }

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     }
 
     @objc func clearAllHistory() {
-        let isShowAlert = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
+        let isShowAlert = appStorage.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
         if isShowAlert {
             let alert = NSAlert()
             alert.messageText = String(localized: "Clear History")
@@ -80,9 +80,9 @@ class AppDelegate: NSObject, NSMenuItemValidation {
             if result != NSApplication.ModalResponse.alertFirstButtonReturn { return }
 
             if alert.suppressionButton?.state == NSControl.StateValue.on {
-                AppEnvironment.current.defaults.set(false, forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
+                appStorage.set(false, forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
             }
-            AppEnvironment.current.defaults.synchronize()
+            appStorage.synchronize()
         }
 
         AppEnvironment.current.clipService.clearAll()
@@ -122,13 +122,13 @@ class AppDelegate: NSObject, NSMenuItemValidation {
 
         //  Launch on system startup
         if alert.runModal() == NSApplication.ModalResponse.alertFirstButtonReturn {
-            AppEnvironment.current.defaults.set(true, forKey: Constants.UserDefaults.loginItem)
-            AppEnvironment.current.defaults.synchronize()
+            appStorage.set(true, forKey: Constants.UserDefaults.loginItem)
+            appStorage.synchronize()
         }
         // Do not show this message again
         if alert.suppressionButton?.state == NSControl.StateValue.on {
-            AppEnvironment.current.defaults.set(true, forKey: Constants.UserDefaults.suppressAlertForLoginItem)
-            AppEnvironment.current.defaults.synchronize()
+            appStorage.set(true, forKey: Constants.UserDefaults.suppressAlertForLoginItem)
+            appStorage.synchronize()
         }
     }
 }
@@ -140,27 +140,25 @@ extension AppDelegate: NSApplicationDelegate {
         // Environments
         AppEnvironment.replaceCurrent(environment: AppEnvironment.fromStorage())
         // UserDefaults
-        CPYUtilities.registerUserDefaultKeys(AppEnvironment.current.defaults)
+        CPYUtilities.registerUserDefaultKeys(appStorage)
 
         guard context != .test else { return }
 
         // SDKs
         firebase.configure()
-        // Check Accessibility Permission
-        Accessibility.isAccessibilityEnabled(isPrompt: true)
 
         // Show Login Item
-        if !AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.loginItem) && !AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.suppressAlertForLoginItem) {
+        if !appStorage.bool(forKey: Constants.UserDefaults.loginItem) && !appStorage.bool(forKey: Constants.UserDefaults.suppressAlertForLoginItem) {
             promptToAddLoginItems()
         }
 
         // Sparkle
         self.updaterController = SPUStandardUpdaterController(
-            startingUpdater: AppEnvironment.current.defaults.bool(forKey: Constants.Update.enableAutomaticCheck),
+            startingUpdater: appStorage.bool(forKey: Constants.Update.enableAutomaticCheck),
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
-        updaterController?.updater.updateCheckInterval = TimeInterval(AppEnvironment.current.defaults.integer(forKey: Constants.Update.checkInterval))
+        updaterController?.updater.updateCheckInterval = TimeInterval(appStorage.integer(forKey: Constants.Update.checkInterval))
         updaterController?.updater.clearFeedURLFromUserDefaults()
 
         // Binding Events
@@ -195,8 +193,17 @@ extension AppDelegate: NSApplicationDelegate {
 // MARK: - Bind
 private extension AppDelegate {
     func bind() {
+        // Accessibility Permission
+        appStorage.rx.observe(Bool.self, Constants.UserDefaults.inputPasteCommand, retainSelf: false)
+            .compactMap { $0 }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .subscribe(onNext: { _ in
+                Accessibility.isAccessibilityEnabled(isPrompt: true)
+            })
+            .disposed(by: disposeBag)
         // Login Item
-        AppEnvironment.current.defaults.rx.observe(Bool.self, Constants.UserDefaults.loginItem, retainSelf: false)
+        appStorage.rx.observe(Bool.self, Constants.UserDefaults.loginItem, retainSelf: false)
             .compactMap { $0 }
             .subscribe(onNext: { isEnabled in
                 if isEnabled {
@@ -209,7 +216,7 @@ private extension AppDelegate {
             })
             .disposed(by: disposeBag)
         // Observe Screenshot
-        let observerScreenshot = AppEnvironment.current.defaults.rx.observe(Bool.self, Constants.Beta.observerScreenshot, retainSelf: false)
+        let observerScreenshot = appStorage.rx.observe(Bool.self, Constants.Beta.observerScreenshot, retainSelf: false)
             .compactMap { $0 }
             .share(replay: 1)
         observerScreenshot

--- a/Clipy/Sources/ClipyApp.swift
+++ b/Clipy/Sources/ClipyApp.swift
@@ -31,7 +31,7 @@ struct ClipyApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra("", isInserted: .constant(false)) {
+        MenuBarExtra(String(), isInserted: .constant(false)) {
             EmptyView()
         }
     }


### PR DESCRIPTION
## Summary

- Request Accessibility permission only while automatic paste is enabled, including when the setting becomes enabled through UserDefaults observation.
- Expand the Accessibility alert guidance to suggest removing and re-adding Clipy when permission detection repeatedly fails.
- Update the supported localizations for the new guidance.
- Pass a non-localized empty title to the inactive `MenuBarExtra` so it does not generate an empty localization entry.

## Testing

- Ran the Clipy macOS test suite with `xcodebuild`; all tests passed.