### PR TITLE
Migrate environment defaults to dependencies

### DIFF
--- a/Clipy/Sources/Environments/Environment.swift
+++ b/Clipy/Sources/Environments/Environment.swift
@@ -10,8 +10,6 @@
 //  Copyright © 2015-2018 Clipy Project.
 //
 
-import Foundation
-
 struct Environment {
 
     // MARK: - Properties
@@ -20,20 +18,15 @@ struct Environment {
     let pasteService: PasteService
     let menuManager: MenuManager
 
-    let defaults: UserDefaults
-
     // MARK: - Initialize
     init(clipService: ClipService = ClipService(),
          hotKeyService: HotKeyService = HotKeyService(),
          pasteService: PasteService = PasteService(),
-         menuManager: MenuManager = MenuManager(),
-         defaults: UserDefaults = .standard) {
-
+         menuManager: MenuManager = MenuManager()) {
         self.clipService = clipService
         self.hotKeyService = hotKeyService
         self.pasteService = pasteService
         self.menuManager = menuManager
-        self.defaults = defaults
     }
 
 }

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -43,6 +43,8 @@ final class MenuManager: NSObject {
     private var snippetRepository
     @Dependency(\.mainQueue)
     private var mainQueue
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
     private var cancellables: Set<AnyCancellable> = []
     private var snippetFolderDetails = [SnippetFolderDetail]()
 
@@ -117,7 +119,7 @@ private extension MenuManager {
             }
             .store(in: &cancellables)
         // Menu icon
-        AppEnvironment.current.defaults.rx.observe(Int.self, Constants.UserDefaults.showStatusItem, retainSelf: false)
+        appStorage.rx.observe(Int.self, Constants.UserDefaults.showStatusItem, retainSelf: false)
             .compactMap { $0 }
             .asDriver(onErrorDriveWith: .empty())
             .drive(onNext: { [weak self] key in
@@ -125,42 +127,40 @@ private extension MenuManager {
             })
             .disposed(by: disposeBag)
         // Sort clips
-        AppEnvironment.current.defaults.rx.observe(Bool.self, Constants.UserDefaults.reorderClipsAfterPasting, options: [.new], retainSelf: false)
+        appStorage.rx.observe(Bool.self, Constants.UserDefaults.reorderClipsAfterPasting, options: [.new], retainSelf: false)
             .compactMap { $0 }
             .asDriver(onErrorDriveWith: .empty())
             .drive(onNext: { [weak self] _ in
-                guard let wSelf = self else { return }
-                wSelf.createClipMenu()
+                self?.createClipMenu()
             })
             .disposed(by: disposeBag)
         // Observe change preference settings
-        let defaults = AppEnvironment.current.defaults
         var menuChangedObservables = [Observable<Void>]()
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.addClearHistoryMenuItem, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.addClearHistoryMenuItem, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Int.self, Constants.UserDefaults.maxHistorySize, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Int.self, Constants.UserDefaults.maxHistorySize, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.showIconInTheMenu, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.showIconInTheMenu, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Int.self, Constants.UserDefaults.numberOfItemsPlaceInline, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Int.self, Constants.UserDefaults.numberOfItemsPlaceInline, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Int.self, Constants.UserDefaults.numberOfItemsPlaceInsideFolder, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Int.self, Constants.UserDefaults.numberOfItemsPlaceInsideFolder, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Int.self, Constants.UserDefaults.maxMenuItemTitleLength, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Int.self, Constants.UserDefaults.maxMenuItemTitleLength, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.menuItemsTitleStartWithZero, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.menuItemsTitleStartWithZero, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.menuItemsAreMarkedWithNumbers, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.menuItemsAreMarkedWithNumbers, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.showToolTipOnMenuItem, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.showToolTipOnMenuItem, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.showImageInTheMenu, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.showImageInTheMenu, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.addNumericKeyEquivalents, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.addNumericKeyEquivalents, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Int.self, Constants.UserDefaults.maxLengthOfToolTip, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Int.self, Constants.UserDefaults.maxLengthOfToolTip, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
-        menuChangedObservables.append(defaults.rx.observe(Bool.self, Constants.UserDefaults.showColorPreviewInTheMenu, options: [.new], retainSelf: false)
+        menuChangedObservables.append(appStorage.rx.observe(Bool.self, Constants.UserDefaults.showColorPreviewInTheMenu, options: [.new], retainSelf: false)
                                         .compactMap { $0 }.distinctUntilChanged().map { _ in })
         Observable.merge(menuChangedObservables)
             .throttle(.seconds(1), scheduler: MainScheduler.instance)
@@ -187,7 +187,7 @@ private extension MenuManager {
 
         clipMenu?.addItem(NSMenuItem.separator())
 
-        if AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.addClearHistoryMenuItem) {
+        if appStorage.bool(forKey: Constants.UserDefaults.addClearHistoryMenuItem) {
             clipMenu?.addItem(NSMenuItem(title: String(localized: "Clear History"), action: #selector(AppDelegate.clearAllHistory)))
         }
 
@@ -220,7 +220,7 @@ private extension MenuManager {
         let subMenu = NSMenu(title: "")
         let subMenuItem = NSMenuItem(title: title, action: nil)
         subMenuItem.submenu = subMenu
-        subMenuItem.image = (AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showIconInTheMenu)) ? folderIcon : nil
+        subMenuItem.image = (appStorage.bool(forKey: Constants.UserDefaults.showIconInTheMenu)) ? folderIcon : nil
         return subMenuItem
     }
 }
@@ -228,9 +228,9 @@ private extension MenuManager {
 // MARK: - Clips
 private extension MenuManager {
     func addHistoryItems(_ menu: NSMenu) {
-        let placeInLine = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInline)
-        let placeInsideFolder = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInsideFolder)
-        let maxHistory = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.maxHistorySize)
+        let placeInLine = appStorage.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInline)
+        let placeInsideFolder = appStorage.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInsideFolder)
+        let maxHistory = appStorage.integer(forKey: Constants.UserDefaults.maxHistorySize)
 
         // History title
         let labelItem = NSMenuItem(title: String(localized: "History"), action: nil)
@@ -243,9 +243,9 @@ private extension MenuManager {
         var subMenuCount = placeInLine
         var subMenuIndex = 1 + placeInLine
 
-        let reorderClipsAfterPasting = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
-        let isShowImage = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
-        let isShowColorCode = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+        let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+        let isShowImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
+        let isShowColorCode = appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
         let historyDetails = pasteboardHistoryRepository.fetchHistoryDetails(
             sortsByCreatedAt: !reorderClipsAfterPasting,
             includesThumbnailAsset: isShowImage || isShowColorCode,
@@ -285,14 +285,14 @@ private extension MenuManager {
 
     func makeClipMenuItem(_ historyDetail: PasteboardHistoryDetail, index: Int, listNumber: Int) -> NSMenuItem {
         let history = historyDetail.history
-        let isMarkWithNumber = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.menuItemsAreMarkedWithNumbers)
-        let isShowImage = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
-        let isShowColorCode = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
-        let addNumbericKeyEquivalents = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.addNumericKeyEquivalents)
+        let isMarkWithNumber = appStorage.bool(forKey: Constants.UserDefaults.menuItemsAreMarkedWithNumbers)
+        let isShowImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
+        let isShowColorCode = appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+        let addNumbericKeyEquivalents = appStorage.bool(forKey: Constants.UserDefaults.addNumericKeyEquivalents)
 
         var keyEquivalent = ""
         if addNumbericKeyEquivalents && (index < kMaxKeyEquivalents) {
-            let isStartFromZero = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.menuItemsTitleStartWithZero)
+            let isStartFromZero = appStorage.bool(forKey: Constants.UserDefaults.menuItemsTitleStartWithZero)
 
             var shortCutNumber = (isStartFromZero) ? index : index + 1
             if shortCutNumber == kMaxKeyEquivalents {
@@ -311,8 +311,8 @@ private extension MenuManager {
            let thumbnailAsset = historyDetail.thumbnailAsset,
            let image = NSImage(data: thumbnailAsset.data),
            (thumbnailAsset.kind == .image && isShowImage) || (thumbnailAsset.kind == .colorCode && isShowColorCode) {
-            let width = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.thumbnailWidth)
-            let height = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.thumbnailHeight)
+            let width = appStorage.integer(forKey: Constants.UserDefaults.thumbnailWidth)
+            let height = appStorage.integer(forKey: Constants.UserDefaults.thumbnailHeight)
             menuItem.image = image.aspectFitImage(CGFloat(width), CGFloat(height))
         }
 
@@ -358,8 +358,8 @@ private extension MenuManager {
     }
 
     func makeSnippetMenuItem(_ snippet: Snippet, listNumber: Int) -> NSMenuItem {
-        let isMarkWithNumber = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.menuItemsAreMarkedWithNumbers)
-        let isShowIcon = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showIconInTheMenu)
+        let isMarkWithNumber = appStorage.bool(forKey: Constants.UserDefaults.menuItemsAreMarkedWithNumbers)
+        let isShowIcon = appStorage.bool(forKey: Constants.UserDefaults.showIconInTheMenu)
 
         let titleWithMark = menuItemTitle(snippet.title.trimmedMenuTitle, listNumber: listNumber, isMarkWithNumber: isMarkWithNumber)
 
@@ -395,6 +395,6 @@ private extension MenuManager {
 // MARK: - Settings
 private extension MenuManager {
     func firstIndexOfMenuItems() -> NSInteger {
-        return AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.menuItemsTitleStartWithZero) ? 0 : 1
+        return appStorage.bool(forKey: Constants.UserDefaults.menuItemsTitleStartWithZero) ? 0 : 1
     }
 }

--- a/Clipy/Sources/Preferences/Panels/CPYTypePreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYTypePreferenceViewController.swift
@@ -11,14 +11,18 @@
 //
 
 import Cocoa
+import Dependencies
 
 final class CPYTypePreferenceViewController: NSViewController {
     // MARK: - Properties
     @objc var storeTypes: NSMutableDictionary!
 
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
+
     // MARK: - Initialize
     override func loadView() {
-        if let dictionary = AppEnvironment.current.defaults.object(forKey: Constants.UserDefaults.storeTypes) as? [String: Any] {
+        if let dictionary = appStorage.object(forKey: Constants.UserDefaults.storeTypes) as? [String: Any] {
             storeTypes = NSMutableDictionary(dictionary: dictionary)
         } else {
             storeTypes = NSMutableDictionary()
@@ -38,6 +42,6 @@ final class CPYTypePreferenceViewController: NSViewController {
     // swiftlint:disable:next block_based_kvo
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let dictionary = object as? NSMutableDictionary, dictionary == storeTypes else { return }
-        AppEnvironment.current.defaults.set(storeTypes, forKey: Constants.UserDefaults.storeTypes)
+        appStorage.set(storeTypes, forKey: Constants.UserDefaults.storeTypes)
     }
 }

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -32,6 +32,8 @@ final class ClipService {
     private var pasteboardHistoryRepository
     @Dependency(\.textRecognizer)
     private var textRecognizer
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
 
     // MARK: - Clips
     func startMonitoring() {
@@ -49,8 +51,8 @@ final class ClipService {
             }
         }
         // Store types
-        storeTypes = AppEnvironment.current.defaults.object(forKey: Constants.UserDefaults.storeTypes) as? [String: NSNumber] ?? [:]
-        AppEnvironment.current.defaults.rx
+        storeTypes = appStorage.object(forKey: Constants.UserDefaults.storeTypes) as? [String: NSNumber] ?? [:]
+        appStorage.rx
             .observe([String: NSNumber].self, Constants.UserDefaults.storeTypes)
             .compactMap { $0 }
             .asDriver(onErrorDriveWith: .empty())
@@ -91,7 +93,7 @@ extension ClipService {
         let types = PasteboardAvailableType.availableTypes(
             from: pasteboard.types ?? pasteboard.pasteboardItems?.flatMap(\.types) ?? [],
             storeAvailableTypes: storeTypes.filter { $0.value.boolValue }.compactMap { PasteboardAvailableType(rawValue: $0.key) },
-            ignoresConcealedType: AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.ignoreConcealedPasteboardType)
+            ignoresConcealedType: appStorage.bool(forKey: Constants.UserDefaults.ignoreConcealedPasteboardType)
         )
         guard !types.isEmpty else { return }
 
@@ -113,7 +115,7 @@ extension ClipService {
 
     private func save(_ content: PasteboardContent) {
         // Copy already copied history
-        let isCopySameHistory = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.copySameHistory)
+        let isCopySameHistory = appStorage.bool(forKey: Constants.UserDefaults.copySameHistory)
         let historyID = PasteboardHistory.ID(rawValue: content.hash)
         if pasteboardHistoryRepository.fetchHistory(id: historyID) != nil, !isCopySameHistory { return }
 
@@ -121,7 +123,7 @@ extension ClipService {
         if content.isBlankText { return }
 
         // Overwrite same history
-        let isOverwriteHistory = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.overwriteSameHistory)
+        let isOverwriteHistory = appStorage.bool(forKey: Constants.UserDefaults.overwriteSameHistory)
         let savedHash = (isOverwriteHistory) ? content.hash : UUID().uuidString
 
         let unixTime = Int(Date().timeIntervalSince1970)

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -11,6 +11,7 @@
 //
 
 import Cocoa
+import Dependencies
 import Foundation
 import Sauce
 
@@ -22,23 +23,27 @@ final class PasteService {
             .flatMap { $0.submenu?.items ?? [] }
             .first { $0.action == #selector(NSText.paste(_:)) }
     }()
-    fileprivate let lock = NSRecursiveLock(name: "com.clipy-app.Clipy.Pastable")
-    fileprivate var isPastePlainText: Bool {
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.Beta.pastePlainText) else { return false }
+    private let lock = NSRecursiveLock(name: "com.clipy-app.Clipy.Pastable")
 
-        let modifierSetting = AppEnvironment.current.defaults.integer(forKey: Constants.Beta.pastePlainTextModifier)
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
+
+    private var isPastePlainText: Bool {
+        guard appStorage.bool(forKey: Constants.Beta.pastePlainText) else { return false }
+
+        let modifierSetting = appStorage.integer(forKey: Constants.Beta.pastePlainTextModifier)
         return isPressedModifier(modifierSetting)
     }
-    fileprivate var isDeleteHistory: Bool {
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.Beta.deleteHistory) else { return false }
+    private var isDeleteHistory: Bool {
+        guard appStorage.bool(forKey: Constants.Beta.deleteHistory) else { return false }
 
-        let modifierSetting = AppEnvironment.current.defaults.integer(forKey: Constants.Beta.deleteHistoryModifier)
+        let modifierSetting = appStorage.integer(forKey: Constants.Beta.deleteHistoryModifier)
         return isPressedModifier(modifierSetting)
     }
-    fileprivate var isPasteAndDeleteHistory: Bool {
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.Beta.pasteAndDeleteHistory) else { return false }
+    private var isPasteAndDeleteHistory: Bool {
+        guard appStorage.bool(forKey: Constants.Beta.pasteAndDeleteHistory) else { return false }
 
-        let modifierSetting = AppEnvironment.current.defaults.integer(forKey: Constants.Beta.pasteAndDeleteHistoryModifier)
+        let modifierSetting = appStorage.integer(forKey: Constants.Beta.pasteAndDeleteHistoryModifier)
         return isPressedModifier(modifierSetting)
     }
 
@@ -113,7 +118,7 @@ extension PasteService {
 // MARK: - Paste
 extension PasteService {
     func paste() {
-        guard AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.inputPasteCommand) else { return }
+        guard appStorage.bool(forKey: Constants.UserDefaults.inputPasteCommand) else { return }
         // Check Accessibility Permission
         guard Accessibility.isAccessibilityEnabled(isPrompt: false) else {
             Accessibility.showAccessibilityAuthenticationAlert()


### PR DESCRIPTION
## Summary

- Remove `UserDefaults` storage from `Environment`.
- Resolve `defaultAppStorage` through `@Dependency` in menu, clipboard, paste, and preference components.
- Keep preference observation and persistence behavior on the injected app storage.
- Tighten touched implementation details while completing the migration.

## Why

This removes the remaining `Environment.defaults` coupling and makes app-storage access consistent with the existing dependency system, including dependency overrides used by tests and previews.