### PR TITLE
Fix app delegate-dependent actions after SwiftUI migration

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		C576AD7C2FBD345000B71213 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C576AD7B2FBD345000B71213 /* Localizable.xcstrings */; };
 		C587AF512FBF4E040043D5E7 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C587AF502FBF4E040043D5E7 /* SQLiteData */; };
 		C58E0A822FDAB5B100B3A901 /* ClipyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58E0A812FDAB5B100B3A901 /* ClipyApp.swift */; };
+		C599B2323015B12600F563A6 /* Sparkle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C599B2313015B12300F563A6 /* Sparkle.swift */; };
 		C5A67BC42FECF03C0015A0DE /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A67BC32FECF0380015A0DE /* Accessibility.swift */; };
 		C5A67BCA2FECF8670015A0DE /* Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A67BC92FECF8640015A0DE /* Firebase.swift */; };
 		C5A67BCC2FED00E10015A0DE /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = C5A67BCB2FED00E10015A0DE /* DependenciesMacros */; };
@@ -202,6 +203,7 @@
 		C57447252FD09FD9000D64D3 /* RealmConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmConfiguration.swift; sourceTree = "<group>"; };
 		C576AD7B2FBD345000B71213 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		C58E0A812FDAB5B100B3A901 /* ClipyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipyApp.swift; sourceTree = "<group>"; };
+		C599B2313015B12300F563A6 /* Sparkle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		C5A67BC32FECF0380015A0DE /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		C5A67BC92FECF8640015A0DE /* Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Firebase.swift; sourceTree = "<group>"; };
 		C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V1.swift"; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			children = (
 				C57447252FD09FD9000D64D3 /* RealmConfiguration.swift */,
 				C5A67BC92FECF8640015A0DE /* Firebase.swift */,
+				C599B2313015B12300F563A6 /* Sparkle.swift */,
 			);
 			path = Dependencies;
 			sourceTree = "<group>";
@@ -940,6 +943,7 @@
 				FA1DB5141DDCB4C0007F95C8 /* CPYBetaPreferenceViewController.swift in Sources */,
 				C522FB952FCBD6AA00E61800 /* PasteboardAvailableType.swift in Sources */,
 				C5700B462FC40BBF00C8F965 /* SnippetRepository.swift in Sources */,
+				C599B2323015B12600F563A6 /* Sparkle.swift in Sources */,
 				C57100032FCEB00000C8F965 /* PasteboardHistoryRepository.swift in Sources */,
 				C5E8EE6A2FFA2A5600270F1F /* SnippetExtensions.swift in Sources */,
 				FA1DB4B91DDCB452007F95C8 /* NSMenuItem+Initialize.swift in Sources */,

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -19,12 +19,10 @@ import RxSwift
 import Screeen
 import ServiceManagement
 import Sharing
-import Sparkle
 
 class AppDelegate: NSObject, NSMenuItemValidation {
 
     // MARK: - Properties
-    private(set) var updaterController: SPUStandardUpdaterController?
     private let screenshotObserver = ScreenShotObserver(searchDirectoryPaths: AppDelegate.screenshotSearchDirectoryPaths())
     private let disposeBag = DisposeBag()
 
@@ -48,6 +46,8 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     private var pasteService
     @Dependency(\.menuManager)
     private var menuManager
+    @Dependency(\.sparkle)
+    private var sparkle
 
     // MARK: - NSMenuItem Validation
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
@@ -73,27 +73,7 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     }
 
     @objc func clearAllHistory() {
-        let isShowAlert = appStorage.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
-        if isShowAlert {
-            let alert = NSAlert()
-            alert.messageText = String(localized: "Clear History")
-            alert.informativeText = String(localized: "Are you sure you want to clear your clipboard history?")
-            alert.addButton(withTitle: String(localized: "Clear History"))
-            alert.addButton(withTitle: String(localized: "Cancel"))
-            alert.showsSuppressionButton = true
-
-            NSApp.activate(ignoringOtherApps: true)
-
-            let result = alert.runModal()
-            if result != NSApplication.ModalResponse.alertFirstButtonReturn { return }
-
-            if alert.suppressionButton?.state == NSControl.StateValue.on {
-                appStorage.set(false, forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
-            }
-            appStorage.synchronize()
-        }
-
-        clipService.clearAll()
+        clipService.clearAllHistory()
     }
 
     @objc func selectClipMenuItem(_ sender: NSMenuItem) {
@@ -163,13 +143,7 @@ extension AppDelegate: NSApplicationDelegate {
         }
 
         // Sparkle
-        self.updaterController = SPUStandardUpdaterController(
-            startingUpdater: appStorage.bool(forKey: Constants.Update.enableAutomaticCheck),
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
-        updaterController?.updater.updateCheckInterval = TimeInterval(appStorage.integer(forKey: Constants.Update.checkInterval))
-        updaterController?.updater.clearFeedURLFromUserDefaults()
+        sparkle.configure()
 
         // Binding Events
         bind()

--- a/Clipy/Sources/Dependencies/Sparkle.swift
+++ b/Clipy/Sources/Dependencies/Sparkle.swift
@@ -1,0 +1,61 @@
+//
+//  Sparkle.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/07/26.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Combine
+import Dependencies
+import DependenciesMacros
+import Sharing
+import Sparkle
+
+@DependencyClient
+struct Sparkle {
+    var configure: () -> Void
+    var lastUpdateCheckDate: () -> AnyPublisher<Any?, Never> = { Empty().eraseToAnyPublisher() }
+    var checkForUpdates: (_ sender: Any?) -> Void
+}
+
+extension DependencyValues {
+    var sparkle: Sparkle {
+        get { self[SparkleKey.self] }
+        set { self[SparkleKey.self] = newValue }
+    }
+
+    private enum SparkleKey: DependencyKey {
+        static var liveValue: Sparkle {
+            let updaterController = SPUStandardUpdaterController(
+                startingUpdater: false,
+                updaterDelegate: nil,
+                userDriverDelegate: nil
+            )
+
+            return Sparkle(
+                configure: {
+                    @Dependency(\.defaultAppStorage) var appStorage
+
+                    if appStorage.bool(forKey: Constants.Update.enableAutomaticCheck) {
+                        updaterController.startUpdater()
+                    }
+                    updaterController.updater.updateCheckInterval = TimeInterval(appStorage.integer(forKey: Constants.Update.checkInterval))
+                    updaterController.updater.clearFeedURLFromUserDefaults()
+                },
+                lastUpdateCheckDate: {
+                    updaterController.updater.publisher(for: \.lastUpdateCheckDate)
+                        .compactMap { $0 }
+                        .eraseToAnyPublisher()
+                },
+                checkForUpdates: { sender in
+                    updaterController.checkForUpdates(sender)
+                }
+            )
+        }
+    }
+}

--- a/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYUpdatesPreferenceViewController.swift
@@ -12,6 +12,7 @@
 
 import Cocoa
 import Combine
+import Dependencies
 import Sparkle
 
 class CPYUpdatesPreferenceViewController: NSViewController {
@@ -20,24 +21,20 @@ class CPYUpdatesPreferenceViewController: NSViewController {
     @IBOutlet private weak var lastUpdateCheckDateTextField: NSTextField!
     @IBOutlet private weak var versionTextField: NSTextField!
 
-    private var updaterController: SPUStandardUpdaterController? {
-        guard let appDelegate = NSApp.delegate as? AppDelegate else { return nil }
-        return appDelegate.updaterController
-    }
+    @Dependency(\.sparkle)
+    private var sparkle
     private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Initialize
     override func loadView() {
         super.loadView()
-        updaterController?.updater.publisher(for: \.lastUpdateCheckDate)
-            .compactMap { $0 }
+        sparkle.lastUpdateCheckDate()
             .assign(to: \.objectValue, on: lastUpdateCheckDateTextField)
             .store(in: &cancellables)
         versionTextField.stringValue = "v\(Bundle.main.appVersion ?? "")"
     }
 
     @IBAction private func checkForUpdates(_ sender: Any) {
-        guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
-        appDelegate.updaterController?.checkForUpdates(sender)
+        sparkle.checkForUpdates(sender: sender)
     }
 }

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -62,7 +62,27 @@ final class ClipService {
             .disposed(by: disposeBag)
     }
 
-    func clearAll() {
+    @objc func clearAllHistory() {
+        let isShowAlert = appStorage.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
+        if isShowAlert {
+            let alert = NSAlert()
+            alert.messageText = String(localized: "Clear History")
+            alert.informativeText = String(localized: "Are you sure you want to clear your clipboard history?")
+            alert.addButton(withTitle: String(localized: "Clear History"))
+            alert.addButton(withTitle: String(localized: "Cancel"))
+            alert.showsSuppressionButton = true
+
+            NSApp.activate(ignoringOtherApps: true)
+
+            let result = alert.runModal()
+            if result != NSApplication.ModalResponse.alertFirstButtonReturn { return }
+
+            if alert.suppressionButton?.state == NSControl.StateValue.on {
+                appStorage.set(false, forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
+            }
+            appStorage.synchronize()
+        }
+
         pasteboardHistoryRepository.deleteAll()
         // Clear legacy Realm-backed history caches used through v1.2.1.
         try? FileManager.default.removeItem(atPath: CPYUtilities.applicationSupportFolder())

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -40,6 +40,8 @@ final class HotKeyService: NSObject {
     private var appStorage
     @Dependency(\.menuManager)
     private var menuManager
+    @Dependency(\.clipService)
+    private var clipService
 }
 
 // MARK: - Actions
@@ -60,8 +62,7 @@ extension HotKeyService {
     }
 
     @objc func popUpClearHistoryAlert() {
-        guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
-        appDelegate.clearAllHistory()
+        clipService.clearAllHistory()
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `NSApp.delegate as? AppDelegate` lookups with controlled dependencies.
- Move clear-history handling into `ClipService` so the global hot key no longer depends on the application delegate.
- Add a shared Sparkle dependency for updater configuration, update checks, and the last-check-date publisher.

## Root cause
PR #635 converted the application entry point to SwiftUI with `@NSApplicationDelegateAdaptor`. After that migration, `NSApp.delegate` could no longer be reliably cast to Clipy's `AppDelegate`, so the clear-history hot key and update preferences silently stopped working.

## Impact
Clear History works again from the configured global hot key, and the Updates preference pane can observe the last update check date and trigger manual update checks without reaching through `NSApp.delegate`.

## Checks
- `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug -derivedDataPath /private/tmp/ClipyDerivedDataDelegateReview build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Clipy.xcodeproj -scheme Clipy -configuration Debug -derivedDataPath /private/tmp/ClipyDerivedDataDelegateReview CODE_SIGNING_ALLOWED=NO` (86 tests in 14 suites)