### PR TITLE
Use monospaced digits in menu titles

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		C50767032FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */; };
+		C50D1A013021000100000001 /* MonospacedDigitFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50D1A013021000100000002 /* MonospacedDigitFormatterTests.swift */; };
+		C50D1A013021000100000003 /* MonospacedDigitFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50D1A013021000100000004 /* MonospacedDigitFormatter.swift */; };
 		C522FB952FCBD6AA00E61800 /* PasteboardAvailableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB942FCBD69A00E61800 /* PasteboardAvailableType.swift */; };
 		C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C522FB982FCC019100E61800 /* PasteboardAvailableTypeTests.swift */; };
 		C5348FB130008FE4008DFEB3 /* WaitUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5348FB030008FE1008DFEB3 /* WaitUntil.swift */; };
@@ -174,6 +176,8 @@
 		A07D83952FC384F100390DB2 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/CPYUpdatesPreferenceViewController.strings"; sourceTree = "<group>"; };
 		A07D83962FC384F100390DB2 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/CPYSnippetsEditorWindowController.strings"; sourceTree = "<group>"; };
 		C50767022FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataDatabase+TriggerTests.swift"; sourceTree = "<group>"; };
+		C50D1A013021000100000002 /* MonospacedDigitFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospacedDigitFormatterTests.swift; sourceTree = "<group>"; };
+		C50D1A013021000100000004 /* MonospacedDigitFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospacedDigitFormatter.swift; sourceTree = "<group>"; };
 		C5208B882FC6E7FF00BC4568 /* Clipy.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Clipy.xcconfig; sourceTree = "<group>"; };
 		C5208B8D2FC6E88E00BC4568 /* CodeSigning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CodeSigning.xcconfig; sourceTree = "<group>"; };
 		C5208B8E2FC6E8B000BC4568 /* CodeSigning-AdHoc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CodeSigning-AdHoc.xcconfig"; sourceTree = "<group>"; };
@@ -348,6 +352,22 @@
 				FAC43E221B35DFC800C06102 /* Foundation.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C50D1A013021000100000005 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				C50D1A013021000100000004 /* MonospacedDigitFormatter.swift */,
+			);
+			path = Formatters;
+			sourceTree = "<group>";
+		};
+		C50D1A013021000100000006 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				C50D1A013021000100000002 /* MonospacedDigitFormatterTests.swift */,
+			);
+			path = Formatters;
 			sourceTree = "<group>";
 		};
 		C5208B822FC6E74B00BC4568 /* Configurations */ = {
@@ -534,6 +554,7 @@
 				C5700B452FC40BBF00C8F965 /* Repositories */,
 				C5F1AD0330190005AA110003 /* OCR */,
 				C5A67BC22FECF0010015A0DE /* Accessibility */,
+				C50D1A013021000100000005 /* Formatters */,
 				FA0D5CE61DDCC5D000AC9052 /* Services */,
 				FA1DB4EC1DDCB4C0007F95C8 /* Preferences */,
 				FA1DB50C1DDCB4C0007F95C8 /* Snippets */,
@@ -724,6 +745,7 @@
 				C5348FAF30008FDF008DFEB3 /* TestSupport */,
 				C5700B472FC5C0DB00C8F965 /* Database */,
 				C5F1AD0630190005AA110006 /* OCR */,
+				C50D1A013021000100000006 /* Formatters */,
 				C571000D2FCEB44000C8F965 /* Extensions */,
 				C571000C2FCEB03000C8F965 /* Models */,
 				C5700B4F2FC5C8C800C8F965 /* Repositories */,
@@ -921,6 +943,7 @@
 		FAC43DC21B35D8B100C06102 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
+				C50D1A013021000100000003 /* MonospacedDigitFormatter.swift in Sources */,
 				FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */,
 				FA1DB4A61DDCB443007F95C8 /* MenuType.swift in Sources */,
 				C5A67BC42FECF03C0015A0DE /* Accessibility.swift in Sources */,
@@ -984,6 +1007,7 @@
 		FAC43DD41B35D8B100C06102 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
+				C50D1A013021000100000001 /* MonospacedDigitFormatterTests.swift in Sources */,
 				C5700B502FD106000C8F965 /* DatabaseMigrationTests.swift in Sources */,
 				C5700B492FC5C0E500C8F965 /* SQLiteDataMigratorTests.swift in Sources */,
 				C5D41A0C2FDB4A0C00EF30FB /* SQLiteDataMigratorTests+V1.swift in Sources */,

--- a/Clipy/Sources/Formatters/MonospacedDigitFormatter.swift
+++ b/Clipy/Sources/Formatters/MonospacedDigitFormatter.swift
@@ -1,0 +1,62 @@
+//
+//  MonospacedDigitFormatter.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/02.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import CoreText
+
+enum MonospacedDigitFormatter {
+    /// Creates a numbered title whose digits use monospaced spacing.
+    ///
+    /// - Parameter font: The base font. Defaults to `NSFont.menuFont(ofSize: 0)`,
+    ///   where passing `0` returns the default menu font.
+    static func numberedTitle(
+        _ title: String,
+        listNumber: Int,
+        showsNumber: Bool,
+        font: NSFont = NSFont.menuFont(ofSize: 0)
+    ) -> NSAttributedString {
+        guard showsNumber else { return NSAttributedString(string: title) }
+
+        let text = NSMutableAttributedString()
+        text.append(monospacedDigits(listNumber, font: font))
+        text.append(NSAttributedString(string: ". \(title)"))
+        return text
+    }
+
+    /// Creates a numeric range title whose digits use monospaced spacing.
+    ///
+    /// - Parameter font: The base font. Defaults to `NSFont.menuFont(ofSize: 0)`,
+    ///   where passing `0` returns the default menu font.
+    static func rangeTitle(
+        firstNumber: Int,
+        lastNumber: Int,
+        font: NSFont = NSFont.menuFont(ofSize: 0)
+    ) -> NSAttributedString {
+        let text = NSMutableAttributedString()
+        text.append(monospacedDigits(firstNumber, font: font))
+        text.append(NSAttributedString(string: " - "))
+        text.append(monospacedDigits(lastNumber, font: font))
+        return text
+    }
+
+    private static func monospacedDigits(_ number: Int, font: NSFont) -> NSAttributedString {
+        let monospacedSettings: [NSFontDescriptor.FeatureKey: Any] = [
+            .typeIdentifier: kNumberSpacingType,
+            .selectorIdentifier: kMonospacedNumbersSelector
+        ]
+        let monospacedFont = NSFont(
+            descriptor: font.fontDescriptor.addingAttributes([.featureSettings: [monospacedSettings]]),
+            size: font.pointSize
+        )
+        return NSAttributedString(string: String(number), attributes: [.font: monospacedFont ?? font])
+    }
+}

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -199,10 +199,6 @@ private extension MenuManager {
         statusBarItem.menu = clipMenu
     }
 
-    func menuItemTitle(_ title: String, listNumber: NSInteger, isMarkWithNumber: Bool) -> String {
-        return (isMarkWithNumber) ? "\(listNumber). \(title)" : title
-    }
-
     func makeSubmenuItem(_ count: Int, start: Int, end: Int, numberOfItems: Int) -> NSMenuItem {
         var count = count
         if start == 0 {
@@ -212,8 +208,13 @@ private extension MenuManager {
         if end < lastNumber {
             lastNumber = end
         }
-        let menuItemTitle = "\(count + 1) - \(lastNumber)"
-        return makeSubmenuItem(menuItemTitle)
+        let menuItemTitle = MonospacedDigitFormatter.rangeTitle(
+            firstNumber: count + 1,
+            lastNumber: lastNumber
+        )
+        let subMenuItem = makeSubmenuItem(menuItemTitle.string)
+        subMenuItem.attributedTitle = menuItemTitle
+        return subMenuItem
     }
 
     func makeSubmenuItem(_ title: String) -> NSMenuItem {
@@ -301,9 +302,9 @@ private extension MenuManager {
             keyEquivalent = "\(shortCutNumber)"
         }
 
-        let titleWithMark = menuItemTitle(history.typedTitle, listNumber: listNumber, isMarkWithNumber: isMarkWithNumber)
-
-        let menuItem = NSMenuItem(title: titleWithMark, action: #selector(AppDelegate.selectClipMenuItem(_:)), keyEquivalent: keyEquivalent)
+        let titleWithMark = MonospacedDigitFormatter.numberedTitle(history.typedTitle, listNumber: listNumber, showsNumber: isMarkWithNumber)
+        let menuItem = NSMenuItem(title: titleWithMark.string, action: #selector(AppDelegate.selectClipMenuItem(_:)), keyEquivalent: keyEquivalent)
+        menuItem.attributedTitle = titleWithMark
         menuItem.representedObject = history.id
         menuItem.toolTip = history.toolTip
 
@@ -361,9 +362,9 @@ private extension MenuManager {
         let isMarkWithNumber = appStorage.bool(forKey: Constants.UserDefaults.menuItemsAreMarkedWithNumbers)
         let isShowIcon = appStorage.bool(forKey: Constants.UserDefaults.showIconInTheMenu)
 
-        let titleWithMark = menuItemTitle(snippet.title.trimmedMenuTitle, listNumber: listNumber, isMarkWithNumber: isMarkWithNumber)
-
-        let menuItem = NSMenuItem(title: titleWithMark, action: #selector(AppDelegate.selectSnippetMenuItem(_:)), keyEquivalent: "")
+        let titleWithMark = MonospacedDigitFormatter.numberedTitle(snippet.title.trimmedMenuTitle, listNumber: listNumber, showsNumber: isMarkWithNumber)
+        let menuItem = NSMenuItem(title: titleWithMark.string, action: #selector(AppDelegate.selectSnippetMenuItem(_:)), keyEquivalent: "")
+        menuItem.attributedTitle = titleWithMark
         menuItem.representedObject = snippet.id
         menuItem.toolTip = snippet.toolTip
         menuItem.image = (isShowIcon) ? snippetIcon : nil

--- a/ClipyTests/Formatters/MonospacedDigitFormatterTests.swift
+++ b/ClipyTests/Formatters/MonospacedDigitFormatterTests.swift
@@ -1,0 +1,84 @@
+//
+//  MonospacedDigitFormatterTests.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/02.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import CoreText
+import Testing
+@testable import Clipy
+
+@MainActor
+@Suite
+struct MonospacedDigitFormatterTests {
+    @Test
+    func numberedTitleUsesMonospacedDigitsOnlyForTheNumber() throws {
+        let baseFont = NSFont.systemFont(ofSize: 17, weight: .bold)
+        let title = MonospacedDigitFormatter.numberedTitle(
+            "History",
+            listNumber: 12,
+            showsNumber: true,
+            font: baseFont
+        )
+
+        #expect(title.string == "12. History")
+        try expectMonospacedDigits(at: 0, in: title, basedOn: baseFont)
+        try expectMonospacedDigits(at: 1, in: title, basedOn: baseFont)
+        #expect(font(at: 2, in: title) == nil)
+    }
+
+    @Test
+    func rangeTitleUsesMonospacedDigitsOnlyForBothNumbers() throws {
+        let baseFont = NSFont.menuFont(ofSize: 0)
+        let title = MonospacedDigitFormatter.rangeTitle(firstNumber: 1, lastNumber: 10)
+
+        #expect(title.string == "1 - 10")
+        try expectMonospacedDigits(at: 0, in: title, basedOn: baseFont)
+        #expect(font(at: 1, in: title) == nil)
+        #expect(font(at: 2, in: title) == nil)
+        #expect(font(at: 3, in: title) == nil)
+        try expectMonospacedDigits(at: 4, in: title, basedOn: baseFont)
+        try expectMonospacedDigits(at: 5, in: title, basedOn: baseFont)
+    }
+
+    @Test
+    func unnumberedTitleKeepsTheDefaultFont() {
+        let title = MonospacedDigitFormatter.numberedTitle(
+            "History",
+            listNumber: 1,
+            showsNumber: false
+        )
+
+        #expect(title.string == "History")
+        #expect(font(at: 0, in: title) == nil)
+    }
+
+    private func expectMonospacedDigits(
+        at index: Int,
+        in title: NSAttributedString,
+        basedOn baseFont: NSFont
+    ) throws {
+        let font = font(at: index, in: title)
+        #expect(font?.familyName == baseFont.familyName)
+        #expect(font?.pointSize == baseFont.pointSize)
+        #expect(font?.fontDescriptor.symbolicTraits == baseFont.fontDescriptor.symbolicTraits)
+
+        let monospacedSettings: [NSFontDescriptor.FeatureKey: Int] = [
+            .typeIdentifier: kNumberSpacingType,
+            .selectorIdentifier: kMonospacedNumbersSelector
+        ]
+        let featureSettings = try #require(font?.fontDescriptor.fontAttributes[.featureSettings] as? [[NSFontDescriptor.FeatureKey: Int]])
+        #expect(featureSettings == [monospacedSettings])
+    }
+
+    private func font(at index: Int, in title: NSAttributedString) -> NSFont? {
+        title.attribute(.font, at: index, effectiveRange: nil) as? NSFont
+    }
+}


### PR DESCRIPTION
## Summary

- add a formatter that applies monospaced number spacing while preserving the supplied base font
- use attributed titles for numbered history and snippet items and folder range menus
- cover numbered, range, and unnumbered titles with focused tests

## Tests

- `xcodebuild test -project Clipy.xcodeproj -scheme Clipy -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /private/tmp/ClipyDerivedDataVerify -only-testing:ClipyTests/MonospacedDigitFormatterTests CODE_SIGNING_ALLOWED=NO`