### PR TITLE
Update Swift package dependencies

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		C5A67BCC2FED00E10015A0DE /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = C5A67BCB2FED00E10015A0DE /* DependenciesMacros */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
 		C5D220A82FBD2655005CD45E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D220A72FBD2655005CD45E /* RealmSwift */; };
+		C5D220AA2FBD2655005CD45E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D220A92FBD2655005CD45E /* RealmSwift */; };
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
 		C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75E2FB86A0200C9DCB6 /* Magnet */; };
 		C5D3A7622FB86A1C00C9DCB6 /* KeyHolder in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A7612FB86A1C00C9DCB6 /* KeyHolder */; };
@@ -337,6 +338,7 @@
 			isa = PBXFrameworksBuildPhase;
 			files = (
 				C5700B4E2FC5C3D500C8F965 /* DependenciesTestSupport in Frameworks */,
+				C5D220AA2FBD2655005CD45E /* RealmSwift in Frameworks */,
 			);
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -813,6 +815,7 @@
 			name = ClipyTests;
 			packageProductDependencies = (
 				C5700B4D2FC5C3D500C8F965 /* DependenciesTestSupport */,
+				C5D220A92FBD2655005CD45E /* RealmSwift */,
 			);
 			productName = ClipyTests;
 			productReference = FAC43DD81B35D8B100C06102 /* ClipyTests.xctest */;
@@ -1436,7 +1439,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 12.16.0;
+				minimumVersion = 12.17.0;
 			};
 		};
 		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
@@ -1444,7 +1447,7 @@
 			repositoryURL = "https://github.com/pointfreeco/sqlite-data";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.7.0;
+				minimumVersion = 1.8.2;
 			};
 			traits = (
 				Tagged,
@@ -1463,7 +1466,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.9.4;
+				minimumVersion = 2.9.5;
 			};
 		};
 		C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */ = {
@@ -1471,7 +1474,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 10.7.2;
+				version = 20.0.5;
 			};
 		};
 		C5D3A75A2FB869EA00C9DCB6 /* XCRemoteSwiftPackageReference "sauce" */ = {
@@ -1479,7 +1482,7 @@
 			repositoryURL = "https://github.com/clipy/sauce";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.5.0;
+				minimumVersion = 2.5.2;
 			};
 		};
 		C5D3A75D2FB86A0200C9DCB6 /* XCRemoteSwiftPackageReference "Magnet" */ = {
@@ -1579,6 +1582,11 @@
 			productName = Sparkle;
 		};
 		C5D220A72FBD2655005CD45E /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		C5D220A92FBD2655005CD45E /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5",
-        "version" : "12.16.0"
+        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
+        "version" : "12.17.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ce606e3768abddff0510783e1a6d2f270b943b35",
-        "version" : "12.16.0"
+        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
+        "version" : "12.17.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core",
       "state" : {
-        "revision" : "bab46acdca91c417a0d4849b8f4992a3c17e29a5",
-        "version" : "10.5.5"
+        "revision" : "b4192c46305570577c4d08df790fddec5ab3aa04",
+        "version" : "20.1.5"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift",
       "state" : {
-        "revision" : "ae8e646590396dfc13c1abbf8aa2e48c43766dce",
-        "version" : "10.7.2"
+        "revision" : "ca03df491ec5e4bb8af0bca1e9957d08c10ec2da",
+        "version" : "20.0.5"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clipy/sauce",
       "state" : {
-        "revision" : "84d03fcddebf78e08f3105b1159300bfdae3b217",
-        "version" : "2.5.1"
+        "revision" : "1fce89ccc9cbb091022c17ef8f9939901d4e951a",
+        "version" : "2.5.2"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "93e0540441a6bfdba51df27ca6d01eb6508c82a5",
-        "version" : "1.7.0"
+        "revision" : "26471412f457f2c640bf5759a63870353a19f9e1",
+        "version" : "1.8.2"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "9c2935e47b0ed9627e4278c566e0ac386be5472e",
-        "version" : "0.33.3"
+        "revision" : "dafddd843f10630aa6b5be47c1b6a59cc4ab6586",
+        "version" : "0.34.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Update five direct Swift package dependencies to the newest stable versions allowed by the 168-hour release-age policy.
- Adopt Sparkle 2.9.5 before the normal cooldown expires because it completes a security fix in Clipy's updater runtime path.
- Keep the younger SQLiteData 1.9.0 and transitive swift-structured-queries 0.35.0 releases deferred.
- Link RealmSwift directly to `ClipyTests` after Realm 20 changed Realm/RealmSwift into separate dynamic products.
- Regenerate and validate `Package.resolved` with SwiftPM/Xcode resolvers.

Evaluation time: **2026-08-08 02:29:07 UTC**.

## Dependency updates

| Library | Previous version / revision | New version / revision | Update type | Release date | Age at evaluation |
|---|---|---|---|---|---|
| Firebase Apple SDK | 12.16.0 / `9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5` | 12.17.0 / `33a468adfdb75b53f05a37e7c886ca7c962b5c17` | Minor | 2026-07-28 16:15:54 UTC | 10d 10h (250.22h) |
| SQLiteData | 1.7.0 / `93e0540441a6bfdba51df27ca6d01eb6508c82a5` | 1.8.2 / `26471412f457f2c640bf5759a63870353a19f9e1` | Minor + patches | 2026-07-29 16:58:00 UTC | 9d 9h (225.52h) |
| Sparkle | 2.9.4 / `b6496a74a087257ef5e6da1c5b29a447a60f5bd7` | 2.9.5 / `79bc9e872948e47877e76f194cb0c8e0412b0b90` | Security patch; cooldown exception | 2026-08-02 14:07:07 UTC | 5d 12h (132.37h) |
| Realm Swift | 10.7.2 / `ae8e646590396dfc13c1abbf8aa2e48c43766dce` | 20.0.5 / `ca03df491ec5e4bb8af0bca1e9957d08c10ec2da` | Major | 2026-06-14 23:57:56 UTC | 54d 2h (1298.52h) |
| Sauce | 2.5.1 / `84d03fcddebf78e08f3105b1159300bfdae3b217` | 2.5.2 / `1fce89ccc9cbb091022c17ef8f9939901d4e951a` | Patch | 2026-07-20 07:11:57 UTC | 18d 19h (451.29h) |

Resolver-driven transitive changes:

- GoogleAppMeasurement 12.16.0 (`ce606e3`) → 12.17.0 (`fceaffa`)
- realm-core 10.5.5 (`bab46ac`) → 20.1.5 (`b4192c4`)
- swift-structured-queries 0.33.3 (`9c2935e`) → 0.34.0 (`dafddd8`)

## Notable upstream changes and Clipy impact

### Firebase Apple SDK 12.17.0

- Crashlytics fixes improperly initialized binary image details; Analytics is updated to 12.17.0.
- Other release fixes affect products that Clipy does not link directly.
- Clipy links `FirebaseCrashlytics` and `FirebaseAnalyticsCore`; their existing APIs compile without source changes.
- References: [release](https://github.com/firebase/firebase-ios-sdk/releases/tag/12.17.0), [official release notes](https://firebase.google.com/support/release-notes/ios#12.17.0), [Crashlytics changelog](https://github.com/firebase/firebase-ios-sdk/blob/12.17.0/Crashlytics/CHANGELOG.md#12170), [compare](https://github.com/firebase/firebase-ios-sdk/compare/12.16.0...12.17.0).

### SQLiteData 1.8.2

- 1.8.0 adds sectioned fetch APIs and fixes mock CloudKit record handling.
- 1.8.1 and 1.8.2 add CloudKit/test-helper and sectioning fixes.
- Clipy does not adopt the new sectioning APIs or CloudKit paths, so no source migration is required. Existing database, repository, trigger, and migration tests cover the linked runtime paths.
- SQLiteData 1.8.2 raises its swift-structured-queries minimum to 0.34.0. That eligible version was resolver-selected explicitly rather than accepting younger 0.35.0.
- References: [1.8.0](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.0), [1.8.1](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.1), [1.8.2](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.2), [compare](https://github.com/pointfreeco/sqlite-data/compare/1.7.0...1.8.2), [swift-structured-queries 0.34.0](https://github.com/pointfreeco/swift-structured-queries/releases/tag/0.34.0).

### Sparkle 2.9.5 — cooldown exception

- Published at **2026-08-02 14:07:07 UTC**; age at evaluation was **132.37 hours**, below the normal 168-hour threshold.
- The release completes the symlink hardening for binary delta patch destinations. Upstream classifies it as a high-complexity security fix and notes that practical exploitation requires compromise of both the developer's update server and EdDSA signing keys.
- Clipy configures `SPUStandardUpdaterController` and executes Sparkle in its application-update runtime path. The currently pinned 2.9.4 is in the affected line, so waiting would leave a known updater hardening gap. This concrete security exposure justifies the exception despite the high attack complexity.
- No Clipy API migration is required.
- References: [release](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.5), [security discussion](https://github.com/sparkle-project/Sparkle/discussions/2838), [fix PR](https://github.com/sparkle-project/Sparkle/pull/2891), [changelog](https://github.com/sparkle-project/Sparkle/blob/2.9.5/CHANGELOG), [compare](https://github.com/sparkle-project/Sparkle/compare/2.9.4...2.9.5).

### Realm Swift 20.0.5

- Realm 20 removes Atlas App Services and Device Sync. Clipy uses only local Realm storage, configuration, objects, lists, linking objects, writes, and migrations, so the removed sync surface is not used.
- The 20.x line adds Swift 6 compatibility work, local-query fixes, privacy resources, Xcode 26 support, and realm-core 20.1.5. Version 20.0.5 supports Xcode 26.1–27 and is compatible with this Xcode 26.5 validation environment.
- Realm 20 exposes Realm and RealmSwift as separate dynamic products. The initial focused test build reproduced undefined Realm symbols in the host-app test bundle. `RealmSwift` is now linked directly to `ClipyTests`; no application source API changes were necessary.
- Migration guidance is contained in the [20.0.0 breaking changes](https://github.com/realm/realm-swift/blob/v20.0.5/CHANGELOG.md#2000-release-notes-2024-09-09); upstream does not publish a separate local-Realm migration guide for this update.
- References: [20.0.5 release](https://github.com/realm/realm-swift/releases/tag/v20.0.5), [changelog](https://github.com/realm/realm-swift/blob/v20.0.5/CHANGELOG.md), [compare](https://github.com/realm/realm-swift/compare/v10.7.2...v20.0.5).

### Sauce 2.5.2

- Fixes keypad Enter key-code mapping.
- This is relevant to Clipy's keyboard shortcut path. Existing `HotKeyServiceTests` pass without an API migration.
- References: [release](https://github.com/Clipy/Sauce/releases/tag/v2.5.2), [compare](https://github.com/Clipy/Sauce/compare/v2.5.1...v2.5.2). No separate changelog or migration guide was published.

## Clipy-side changes

- Raised the five direct requirements in `project.pbxproj`.
- Added `RealmSwift` to the `ClipyTests` package products and frameworks build phase to support Realm 20's dynamic product layout.
- No source behavior changes were needed.

## Package resolution

- Ran the normal Xcode resolver after updating direct requirements.
- The normal resolver selected transitive swift-structured-queries 0.35.0, which was only 104.66 hours old. A disposable SwiftPM probe resolved SQLiteData 1.8.2 with an exact eligible swift-structured-queries 0.34.0 constraint.
- Applied that resolver-produced 0.34.0 pin and validated the complete project graph with:

```sh
xcodebuild -resolvePackageDependencies \
  -project Clipy.xcodeproj \
  -scheme Clipy \
  -onlyUsePackageVersionsFromResolvedFile \
  -skipPackagePluginValidation \
  -skipMacroValidation
```

- Verified all updated versions and revisions in `Package.resolved`; it remains part of this change and contains 40 unique pins.

## Verification

Focused dependency-path tests after the Realm test-link adaptation:

```sh
xcodebuild \
  CODE_SIGN_IDENTITY=- \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  -scheme Clipy \
  -project Clipy.xcodeproj \
  -destination 'platform=macOS,arch=arm64' \
  -onlyUsePackageVersionsFromResolvedFile \
  -skipPackagePluginValidation \
  -skipMacroValidation \
  -only-testing:ClipyTests/DatabaseMigrationTests \
  -only-testing:ClipyTests/SQLiteDataDatabaseTriggerTests \
  -only-testing:ClipyTests/SQLiteDataMigratorTests \
  -only-testing:ClipyTests/HotKeyServiceTests \
  test
```

Result: **Passed — 15 tests, 0 failures, 0 skipped.**

Full test suite:

```sh
xcodebuild \
  CODE_SIGN_IDENTITY=- \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  -scheme Clipy \
  -project Clipy.xcodeproj \
  -destination 'platform=macOS,arch=arm64' \
  -onlyUsePackageVersionsFromResolvedFile \
  -skipPackagePluginValidation \
  -skipMacroValidation \
  clean test
```

Result: **Passed — 89 tests (104 test runs including dynamic parameters), 0 failures, 0 skipped.**

Clean Release build and architecture check:

```sh
xcodebuild \
  CODE_SIGN_IDENTITY=- \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  ARCHS=arm64 \
  ONLY_ACTIVE_ARCH=NO \
  -scheme Clipy \
  -project Clipy.xcodeproj \
  -configuration Release \
  -derivedDataPath /tmp/ClipyDependencyUpdateBuild \
  -onlyUsePackageVersionsFromResolvedFile \
  -skipPackagePluginValidation \
  -skipMacroValidation \
  clean build
lipo /tmp/ClipyDependencyUpdateBuild/Build/Products/Release/Clipy.app/Contents/MacOS/Clipy -verify_arch arm64
```

Result: **Build succeeded; arm64 verification succeeded.** Existing deprecation, Interface Builder, and SwiftLint warnings remain unchanged.

## Deferred releases

| Library | Deferred version | Published at | Age at evaluation | Re-evaluate after | Reason |
|---|---|---|---|---|---|
| SQLiteData | 1.9.0 | 2026-08-03 18:05:59 UTC | 4d 8h (104.39h) | 2026-08-10 18:05:59 UTC | Below 168 hours. Its in-memory metadatabase fix and platform-floor changes do not establish an urgent Clipy runtime/security exception. |
| swift-structured-queries (transitive) | 0.35.0 | 2026-08-03 17:49:36 UTC | 4d 8h (104.66h) | 2026-08-10 17:49:36 UTC | Below 168 hours. JSON features, diagnostics, and platform-floor changes do not establish an urgent Clipy exception; 0.34.0 satisfies SQLiteData 1.8.2. |

This pull request was created via Hermes Agent.
