### PR TITLE
Update Swift package dependencies

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -1424,7 +1424,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.14.1;
+				minimumVersion = 1.15.0;
 			};
 			traits = (
 				Clocks,
@@ -1436,7 +1436,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 12.16.0;
+				minimumVersion = 12.17.0;
 			};
 		};
 		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
@@ -1444,7 +1444,7 @@
 			repositoryURL = "https://github.com/pointfreeco/sqlite-data";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.7.0;
+				minimumVersion = 1.10.0;
 			};
 			traits = (
 				Tagged,
@@ -1463,7 +1463,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.9.4;
+				minimumVersion = 2.9.6;
 			};
 		};
 		C5D220A62FBD2655005CD45E /* XCRemoteSwiftPackageReference "realm-swift" */ = {
@@ -1479,7 +1479,7 @@
 			repositoryURL = "https://github.com/clipy/sauce";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.5.0;
+				minimumVersion = 2.5.2;
 			};
 		};
 		C5D3A75D2FB86A0200C9DCB6 /* XCRemoteSwiftPackageReference "Magnet" */ = {

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5",
-        "version" : "12.16.0"
+        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
+        "version" : "12.17.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ce606e3768abddff0510783e1a6d2f270b943b35",
-        "version" : "12.16.0"
+        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
+        "version" : "12.17.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clipy/sauce",
       "state" : {
-        "revision" : "84d03fcddebf78e08f3105b1159300bfdae3b217",
-        "version" : "2.5.1"
+        "revision" : "1fce89ccc9cbb091022c17ef8f9939901d4e951a",
+        "version" : "2.5.2"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "93e0540441a6bfdba51df27ca6d01eb6508c82a5",
-        "version" : "1.7.0"
+        "revision" : "fcd8dced6edad0f1f97b1141de528116cd19eadb",
+        "version" : "1.10.0"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
-        "version" : "1.14.1"
+        "revision" : "9381ab822de01c4e9f3a7eb8eabb6ae808febed3",
+        "version" : "1.15.0"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "9c2935e47b0ed9627e4278c566e0ac386be5472e",
-        "version" : "0.33.3"
+        "revision" : "8a733f414adc1224c5185c3a35c30ee1ef217171",
+        "version" : "0.36.0"
       }
     },
     {

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -194,7 +194,8 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                             columns.updateAt.desc()
                         }
                     }
-                    .limit(-1, offset: maxHistorySize)
+                    .limit(-1)
+                    .offset(maxHistorySize)
                     .select { $0.id }
                     .fetchAll(database)
                 guard !deletingIDs.isEmpty else { return }


### PR DESCRIPTION
## Summary

- Update five direct Swift package dependencies to the newest stable releases allowed by the 168-hour observation policy, plus Sparkle 2.9.6 under the documented urgent-security exception.
- Regenerate the SwiftPM graph, including the corresponding GoogleAppMeasurement and swift-structured-queries transitive updates.
- Migrate Clipy's deprecated combined StructuredQueries limit/offset call to the composable API introduced in 0.35.0.
- Preserve the intentionally fixed Realm requirement and resolved Realm pins exactly.

Evaluation time: **2026-08-21 23:17:40 UTC**.

## Dependency updates

| Library | Previous version / revision | New version / revision | Update type | Release date | Age at evaluation |
|---|---|---|---|---|---|
| Firebase Apple SDK | 12.16.0 / `9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5` | 12.17.0 / `33a468adfdb75b53f05a37e7c886ca7c962b5c17` | Minor | 2026-07-28 16:15:54 UTC | 24d 7h (583.03h) |
| SQLiteData | 1.7.0 / `93e0540441a6bfdba51df27ca6d01eb6508c82a5` | 1.10.0 / `fcd8dced6edad0f1f97b1141de528116cd19eadb` | Minor | 2026-08-11 20:29:15 UTC | 10d 2h (242.81h) |
| Sparkle | 2.9.4 / `b6496a74a087257ef5e6da1c5b29a447a60f5bd7` | 2.9.6 / `ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a` | Security patch | 2026-08-17 01:40:46 UTC | 4d 21h (117.61h; exception) |
| Sauce | 2.5.1 / `84d03fcddebf78e08f3105b1159300bfdae3b217` | 2.5.2 / `1fce89ccc9cbb091022c17ef8f9939901d4e951a` | Patch | 2026-07-20 07:11:57 UTC | 32d 16h (784.10h) |
| swift-dependencies | 1.14.1 / `8dc1fbf2f6255a73dec53b4648164884898db4c5` | 1.15.0 / `9381ab822de01c4e9f3a7eb8eabb6ae808febed3` | Minor | 2026-08-11 21:38:41 UTC | 10d 1h (241.65h) |
| GoogleAppMeasurement (transitive) | 12.16.0 / `ce606e3768abddff0510783e1a6d2f270b943b35` | 12.17.0 / `fceaffa07d22dcd5624d3639fd970351a4a5ad8c` | Minor | 2026-07-28 16:15:54 UTC | 24d 7h (583.03h) |
| swift-structured-queries (transitive) | 0.33.3 / `9c2935e47b0ed9627e4278c566e0ac386be5472e` | 0.36.0 / `8a733f414adc1224c5185c3a35c30ee1ef217171` | Minor | 2026-08-11 20:25:18 UTC | 10d 2h (242.87h) |

## Notable upstream changes and Clipy impact

### Firebase Apple SDK 12.17.0

- Crashlytics initializes binary-image details before UUID lookup, preventing stale or invalid image metadata from being reported.
- Analytics and GoogleAppMeasurement advance to 12.17.0. Other release changes affect Firebase products that Clipy does not link directly.
- Clipy links `FirebaseCrashlytics` and `FirebaseAnalyticsCore`; the existing APIs remain compatible and require no source or configuration migration.
- References: [release](https://github.com/firebase/firebase-ios-sdk/releases/tag/12.17.0), [official release notes](https://firebase.google.com/support/release-notes/ios#12.17.0), [Crashlytics changelog](https://github.com/firebase/firebase-ios-sdk/blob/12.17.0/Crashlytics/CHANGELOG.md#12170), [compare](https://github.com/firebase/firebase-ios-sdk/compare/12.16.0...12.17.0). No separate migration guide was published for the linked products.

### SQLiteData 1.8.0–1.10.0

- Adds sectioned fetch APIs, automatic primary-key observation for `@FetchOne`, and the opt-in `StrictDecoding` trait.
- Fixes CloudKit mock/helper behavior and in-memory metadatabase creation, and raises the supported Apple-platform and swift-structured-queries floors. The macOS 13 floor matches Clipy's deployment target.
- Clipy does not use `@FetchOne`, sectioned fetches, or `StrictDecoding`; its established database, repository, trigger, migration, and OCR paths need no direct SQLiteData API migration.
- References: [1.8.0](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.0), [1.8.1](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.1), [1.8.2](https://github.com/pointfreeco/sqlite-data/releases/tag/1.8.2), [1.9.0](https://github.com/pointfreeco/sqlite-data/releases/tag/1.9.0), [1.10.0](https://github.com/pointfreeco/sqlite-data/releases/tag/1.10.0), [compare](https://github.com/pointfreeco/sqlite-data/compare/1.7.0...1.10.0), [1.10.0 package manifest](https://github.com/pointfreeco/sqlite-data/blob/1.10.0/Package.swift). No separate migration guide was published.

### swift-structured-queries 0.34.0–0.36.0

- Adds SQLite JSON/JSONB helpers, strict and typed query decoding, improved macro diagnostics, and aggregate-function back pressure.
- Restores Swift 6.1 support and avoids excessive parenthesis nesting for older SQLite versions.
- Refines `limit` and `offset` into composable APIs and deprecates the combined `limit(_:offset:)` form.
- Clipy's overflow-deletion query now uses `.limit(-1).offset(maxHistorySize)`, preserving the generated SQL semantics while removing the deprecated call.
- References: [0.34.0](https://github.com/pointfreeco/swift-structured-queries/releases/tag/0.34.0), [0.35.0](https://github.com/pointfreeco/swift-structured-queries/releases/tag/0.35.0), [0.36.0](https://github.com/pointfreeco/swift-structured-queries/releases/tag/0.36.0), [compare](https://github.com/pointfreeco/swift-structured-queries/compare/0.33.3...0.36.0). No separate migration guide was published.

### swift-dependencies 1.15.0

- Improves fire-and-forget dependencies, adds SwiftSyntax 603/604 compatibility, and restores a Swift 6.1 tools-version floor.
- Clipy's enabled `Clocks`, `CombineSchedulers`, `ConcurrencyExtras`, and macro traits remain available; no API, product-linkage, or trait migration is required.
- References: [release](https://github.com/pointfreeco/swift-dependencies/releases/tag/1.15.0), [compare](https://github.com/pointfreeco/swift-dependencies/compare/1.14.1...1.15.0), [package manifest](https://github.com/pointfreeco/swift-dependencies/blob/1.15.0/Package.swift). No separate migration guide was published.

### Sparkle 2.9.5–2.9.6

- 2.9.5 completes hardening of binary-delta destinations against symbolic-link attacks.
- 2.9.6 further hardens installer archive moves, rejects package installs after signing validation fails, and prevents a root-user cache-directory privilege-escalation path.
- Clipy runs Sparkle's application updater, including installer paths that can require authentication, so the archive-move and package-signing protections apply directly. No Sparkle API or appcast configuration migration is required.
- References: [2.9.5 release](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.5), [2.9.6 release](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.6), [security discussion](https://github.com/sparkle-project/Sparkle/discussions/2838), [package-signing fix](https://github.com/sparkle-project/Sparkle/pull/2895), [root-user fix](https://github.com/sparkle-project/Sparkle/pull/2897), [installer-move hardening](https://github.com/sparkle-project/Sparkle/pull/2898), [changelog](https://github.com/sparkle-project/Sparkle/blob/2.9.6/CHANGELOG), [compare](https://github.com/sparkle-project/Sparkle/compare/2.9.4...2.9.6). No separate migration guide was published.

### Sauce 2.5.2

- Fixes keypad Enter key-code mapping, which is relevant to Clipy's keyboard input and paste path.
- The existing Sauce API remains compatible, so no Clipy source migration is required.
- References: [release](https://github.com/Clipy/Sauce/releases/tag/v2.5.2), [compare](https://github.com/Clipy/Sauce/compare/v2.5.1...v2.5.2). No separate changelog or migration guide was published.

## Breaking and security changes

- No breaking API or configuration changes affect the products and traits linked by Clipy.
- Sparkle 2.9.5 and 2.9.6 contain upstream-classified security fixes. The 2.9.6 exception is documented below.
- SQLiteData's newer platform floor remains compatible with Clipy's macOS 13 deployment target.

## Clipy-side changes

- Raise the five direct requirements in `project.pbxproj`.
- Replace the deprecated combined StructuredQueries limit/offset call without changing overflow-deletion behavior.
- No app behavior or updater configuration is intentionally changed beyond receiving the upstream dependency fixes.
- No test source, test target, or test configuration changes are required; the existing repository, migration, trigger, and OCR coverage continues to exercise the affected SQLiteData paths.

## Package resolution

- Regenerated and checked in `Package.resolved` with Xcode's SwiftPM resolver, then confirmed that the committed resolved-file graph can be resolved as recorded.
- Confirmed that all 40 package identities are unique.
- Kept Realm Swift exactly at 10.7.2 (`ae8e646590396dfc13c1abbf8aa2e48c43766dce`) and realm-core exactly at 10.5.5 (`bab46acdca91c417a0d4849b8f4992a3c17e29a5`), matching the base branch.

## Early-adoption exception

Sparkle 2.9.6 was published at **2026-08-17 01:40:46 UTC** and was **117.61 hours old** at evaluation, below the normal 168-hour threshold.

Upstream explicitly identifies two security fixes in this release: a high-complexity symlink race affecting installer archive moves and a privilege-escalation issue for root-running Sparkle processes. It also rejects package-based updates when EdDSA signing validation fails. Clipy uses Sparkle for in-app updates, and authenticated installer execution can expose the archive-move path. Waiting would knowingly retain updater security weaknesses already fixed by the authoritative upstream release, so 2.9.6 is adopted under the security exception rather than deferring to 2026-08-24 01:40:46 UTC. Evidence: [release](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.6), [security discussion](https://github.com/sparkle-project/Sparkle/discussions/2838), [#2895](https://github.com/sparkle-project/Sparkle/pull/2895), [#2897](https://github.com/sparkle-project/Sparkle/pull/2897), and [#2898](https://github.com/sparkle-project/Sparkle/pull/2898).

## Deferred releases

| Library | Deferred version | Published at | Age at evaluation | Re-evaluate after | Reason |
|---|---|---|---|---|---|
| swift-dependencies | 1.16.0 | 2026-08-18 23:18:20 UTC | 2d 23h (71.99h) | 2026-08-25 23:18:20 UTC | Below 168 hours. Preview-trait restoration and macro diagnostics do not establish an urgent Clipy security, crash, data-loss, runtime-regression, or resolution exception. |
| SQLiteData | 1.11.0 | 2026-08-19 20:28:37 UTC | 2d 2h (50.82h) | 2026-08-26 20:28:37 UTC | Below 168 hours. Fetch-state, string-decoding, and performance fixes have no demonstrated urgent impact on Clipy's current repository paths. |
| swift-structured-queries (transitive) | 0.37.0 | 2026-08-19 18:55:16 UTC | 2d 4h (52.37h) | 2026-08-26 18:55:16 UTC | Below 168 hours. Date helpers, upsert parsing, diagnostics, and query-building improvements do not justify bypassing the observation window; the selected graph resolves with 0.36.0. |
| Firebase Apple SDK | 12.18.0 | 2026-08-19 15:12:43 UTC | 2d 8h (56.08h) | 2026-08-26 15:12:43 UTC | Below 168 hours. The linked Crashlytics change removes deprecated MetricKit integration but does not establish an urgent security or runtime exception for Clipy. |
| SwiftLintPlugins | 0.65.1 | 2026-08-21 20:30:44 UTC | 2h 46m (2.78h) | 2026-08-28 20:30:44 UTC | Below 168 hours. This build-time lint wrapper update has no urgent Clipy runtime impact. |

This pull request was created via Hermes Agent.
