### PR TITLE
Fix folder drop reordering between folders

### DIFF
--- a/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
+++ b/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
@@ -309,8 +309,18 @@ extension CPYSnippetsEditorWindowController: NSOutlineViewDataSource {
         guard let draggedData = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [DraggedData.self, NSUUID.self], from: data) as? DraggedData else { return NSDragOperation() }
 
         switch draggedData.type {
-        case .folder where item == nil:
-            return .move
+        case .folder:
+            if let targetFolder = item as? EditorSnippetFolder,
+               let targetIndex = folders.firstIndex(where: { $0.id == targetFolder.id }) {
+                // AppKit may propose dropping onto a root folder instead of between
+                // root rows. Treat that as inserting immediately before the folder.
+                outlineView.setDropItem(nil, dropChildIndex: targetIndex)
+                return .move
+            } else if item == nil {
+                return .move
+            } else {
+                return NSDragOperation()
+            }
         case .snippet where item is EditorSnippetFolder:
             return .move
         default:


### PR DESCRIPTION
## Summary

- Allow snippet folders to be reordered between other root-level folders.
- Normalize AppKit drop proposals that target a folder row into a root-level insertion before that row.

## Root cause

Folder drops were accepted only when `proposedItem` was `nil`. AppKit can propose a root folder as the target while dragging between folder rows, so those middle-position drops were rejected even though drops at the top and bottom worked.

## Validation

- Built the Debug configuration successfully with Xcode 26.6.
- Tested the built app on macOS Tahoe 26.2 using an isolated bundle identifier.
- Confirmed moving folders from the top and bottom into positions between other folders.
