### PR TITLE
Refactor utility responsibilities

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		C5A67BCA2FECF8670015A0DE /* Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A67BC92FECF8640015A0DE /* Firebase.swift */; };
 		C5A67BCC2FED00E10015A0DE /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = C5A67BCB2FED00E10015A0DE /* DependenciesMacros */; };
 		C5A6BA742FBC5A6E00C8B9EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C5A6BA732FBC5A6E00C8B9EB /* Sparkle */; };
+		C5CC3FD2303929E400875CFE /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CC3FD1303929DD00875CFE /* FileManagerExtensions.swift */; };
+		C5CC3FD430392F7000875CFE /* DeviceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CC3FD330392F6F00875CFE /* DeviceIdentifier.swift */; };
 		C5D220A82FBD2655005CD45E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C5D220A72FBD2655005CD45E /* RealmSwift */; };
 		C5D3A75C2FB869EA00C9DCB6 /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75B2FB869EA00C9DCB6 /* Sauce */; };
 		C5D3A75F2FB86A0200C9DCB6 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = C5D3A75E2FB86A0200C9DCB6 /* Magnet */; };
@@ -210,6 +212,8 @@
 		C599B2313015B12300F563A6 /* Sparkle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		C5A67BC32FECF0380015A0DE /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		C5A67BC92FECF8640015A0DE /* Firebase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Firebase.swift; sourceTree = "<group>"; };
+		C5CC3FD1303929DD00875CFE /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
+		C5CC3FD330392F6F00875CFE /* DeviceIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentifier.swift; sourceTree = "<group>"; };
 		C5D41A022FDB4A0200EF30FB /* SQLiteDataMigrator+V1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V1.swift"; sourceTree = "<group>"; };
 		C5D41A032FDB4A0300EF30FB /* SQLiteDataMigrator+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V2.swift"; sourceTree = "<group>"; };
 		C5D41A042FDB4A0400EF30FB /* SQLiteDataMigrator+V3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SQLiteDataMigrator+V3.swift"; sourceTree = "<group>"; };
@@ -465,6 +469,7 @@
 				C57447252FD09FD9000D64D3 /* RealmConfiguration.swift */,
 				C5A67BC92FECF8640015A0DE /* Firebase.swift */,
 				C599B2313015B12300F563A6 /* Sparkle.swift */,
+				C5CC3FD330392F6F00875CFE /* DeviceIdentifier.swift */,
 			);
 			path = Dependencies;
 			sourceTree = "<group>";
@@ -585,6 +590,7 @@
 				C5E8EE632FFA260200270F1F /* PasteboardHistoryExtensions.swift */,
 				C5E8EE692FFA2A5000270F1F /* SnippetExtensions.swift */,
 				C5E8EE672FFA28D900270F1F /* StringExtensions.swift */,
+				C5CC3FD1303929DD00875CFE /* FileManagerExtensions.swift */,
 				FAE911BA1DE054F1008A4BEC /* NSCoding+Archive.swift */,
 				FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */,
 				FA1DB4A91DDCB452007F95C8 /* NSBundle+Version.swift */,
@@ -971,6 +977,7 @@
 				C5E8EE6A2FFA2A5600270F1F /* SnippetExtensions.swift in Sources */,
 				FA1DB4B91DDCB452007F95C8 /* NSMenuItem+Initialize.swift in Sources */,
 				FA0D5CE81DDCC61600AC9052 /* ClipService.swift in Sources */,
+				C5CC3FD430392F7000875CFE /* DeviceIdentifier.swift in Sources */,
 				C5F1AD0130190005AA110001 /* TextRecognizer.swift in Sources */,
 				FA1DB4C91DDCB460007F95C8 /* MenuManager.swift in Sources */,
 				FA1189331E4CD58C00244F12 /* ExcludeAppService.swift in Sources */,
@@ -996,6 +1003,7 @@
 				FA1DB5201DDCB4C0007F95C8 /* CPYSnippetsEditorWindowController.swift in Sources */,
 				FA1DB4EB1DDCB49C007F95C8 /* CPYPlaceHolderTextView.swift in Sources */,
 				FA1DB5121DDCB4C0007F95C8 /* CPYPreferencesWindowController.swift in Sources */,
+				C5CC3FD2303929E400875CFE /* FileManagerExtensions.swift in Sources */,
 				FAE911BB1DE054F1008A4BEC /* NSCoding+Archive.swift in Sources */,
 				C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */,
 				C5D41A052FDB4A0500EF30FB /* SQLiteDataMigrator+V1.swift in Sources */,

--- a/Clipy/Sources/Database/DatabaseMigration.swift
+++ b/Clipy/Sources/Database/DatabaseMigration.swift
@@ -20,6 +20,8 @@ struct DatabaseMigration {
     private var database
     @Dependency(\.realmConfiguration)
     private var realmConfiguration
+    @Dependency(\.deviceIdentifier)
+    private var deviceIdentifier
 
     func migrateFromRealmToSQLiteData() {
         guard let realm = realm() else { return }
@@ -60,7 +62,7 @@ struct DatabaseMigration {
                         pasteboardTypes: content.types,
                         createdAt: clip.updateTime,
                         updateAt: clip.updateTime,
-                        deviceID: CPYUtilities.deviceID
+                        deviceID: deviceIdentifier
                     )
                 }
                 if assetsByHistoryID[id] == nil {

--- a/Clipy/Sources/Dependencies/DeviceIdentifier.swift
+++ b/Clipy/Sources/Dependencies/DeviceIdentifier.swift
@@ -1,0 +1,48 @@
+//
+//  DeviceIdentifier.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/22.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Foundation
+import Dependencies
+import IOKit
+
+extension DependencyValues {
+    var deviceIdentifier: String? {
+        get { self[DeviceIdentifierKey.self] }
+        set { self[DeviceIdentifierKey.self] = newValue }
+    }
+
+    private enum DeviceIdentifierKey: DependencyKey {
+        static let liveValue: String? = {
+            // ref: https://gist.github.com/vadimpiven/3373bb2592d59560b5d698ba1e2ed7e4
+            let platformExpert = IOServiceGetMatchingService(
+                kIOMainPortDefault,
+                IOServiceMatching("IOPlatformExpertDevice")
+            )
+            guard platformExpert != 0 else { return nil }
+            defer { IOObjectRelease(platformExpert) }
+
+            guard let property = IORegistryEntryCreateCFProperty(
+                platformExpert,
+                kIOPlatformUUIDKey as CFString,
+                kCFAllocatorDefault,
+                0
+            ) else {
+                return nil
+            }
+
+            return property.takeRetainedValue() as? String
+        }()
+
+        static let previewValue: String? = UUID().uuidString
+        static let testValue: String? = UUID().uuidString
+    }
+}

--- a/Clipy/Sources/Dependencies/DeviceIdentifier.swift
+++ b/Clipy/Sources/Dependencies/DeviceIdentifier.swift
@@ -10,8 +10,8 @@
 //  Copyright © 2015-2026 Clipy Project.
 //
 
-import Foundation
 import Dependencies
+import Foundation
 import IOKit
 
 extension DependencyValues {

--- a/Clipy/Sources/Extensions/FileManagerExtensions.swift
+++ b/Clipy/Sources/Extensions/FileManagerExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  FileManagerExtensions.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/22.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import Foundation
+
+extension FileManager {
+    func removeLegacyHistoryCacheDirectory() throws {
+        let url = try url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appending(path: Constants.Application.name, directoryHint: .isDirectory)
+        try removeItem(at: url)
+    }
+}

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -36,6 +36,8 @@ protocol PasteboardHistoryRepositoryProtocol {
 final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
     @Dependency(\.defaultDatabase)
     private var database
+    @Dependency(\.deviceIdentifier)
+    private var deviceIdentifier
 
     @FetchAll(PasteboardHistory.all.order { $0.updateAt.desc() })
     private var histories
@@ -124,7 +126,7 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                     pasteboardTypes: content.types,
                     createdAt: existingHistory?.createdAt ?? updateAt,
                     updateAt: updateAt,
-                    deviceID: CPYUtilities.deviceID
+                    deviceID: deviceIdentifier
                 )
                 try PasteboardHistory
                     .upsert { history }

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -85,7 +85,7 @@ final class ClipService {
 
         pasteboardHistoryRepository.deleteAll()
         // Clear legacy Realm-backed history caches used through v1.2.1.
-        try? FileManager.default.removeItem(atPath: CPYUtilities.applicationSupportFolder())
+        try? FileManager.default.removeLegacyHistoryCacheDirectory()
     }
 
     func delete(id: PasteboardHistory.ID) {

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -11,29 +11,8 @@
 //
 
 import Cocoa
-import IOKit
 
 final class CPYUtilities {
-    // ref: https://gist.github.com/vadimpiven/3373bb2592d59560b5d698ba1e2ed7e4
-    static let deviceID: String? = {
-        let platformExpert = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard platformExpert != 0 else { return nil }
-        defer { IOObjectRelease(platformExpert) }
-
-        guard let property = IORegistryEntryCreateCFProperty(
-            platformExpert,
-            kIOPlatformUUIDKey as CFString,
-            kCFAllocatorDefault,
-            0
-        ) else {
-            return nil
-        }
-        return property.takeRetainedValue() as? String
-    }()
-
     static func registerUserDefaultKeys(_ defaults: UserDefaults) {
         var defaultValues = [String: Any]()
 
@@ -85,11 +64,5 @@ final class CPYUtilities {
 
         defaults.register(defaults: defaultValues)
         defaults.synchronize()
-    }
-
-    static func applicationSupportFolder() -> String {
-        let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
-        let basePath: String = paths.first ?? NSTemporaryDirectory()
-        return (basePath as NSString).appendingPathComponent(Constants.Application.name)
     }
 }

--- a/ClipyTests/Database/DatabaseMigrationTests.swift
+++ b/ClipyTests/Database/DatabaseMigrationTests.swift
@@ -31,6 +31,8 @@ final class DatabaseMigrationTests {
     var database
     @Dependency(\.realmConfiguration)
     var realmConfiguration
+    @Dependency(\.deviceIdentifier)
+    var deviceIdentifier
 
     let migration: DatabaseMigration
     let temporaryDirectoryURL: URL
@@ -96,7 +98,7 @@ final class DatabaseMigrationTests {
             #expect(histories.first?.pasteboardTypes == [.string, .deprecatedFilenames, .URL, .rtf, .pdf, .tiff])
             #expect(histories.first?.createdAt == 2)
             #expect(histories.first?.updateAt == 2)
-            #expect(histories.first?.deviceID == CPYUtilities.deviceID)
+            #expect(histories.first?.deviceID == deviceIdentifier)
 
             #expect(assets.count == 6)
             #expect(assets.map(\.pasteboardHistoryID).allSatisfy { $0 == id })

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -315,6 +315,8 @@ private extension PasteboardContent {
 
 private extension PasteboardHistory {
     init(id: PasteboardHistory.ID, title: String, createdAt: Int? = nil, updateAt: Int, ocrText: String? = nil) {
+        @Dependency(\.deviceIdentifier) var deviceIdentifier
+
         self.init(
             id: id,
             title: title,
@@ -322,7 +324,7 @@ private extension PasteboardHistory {
             pasteboardTypes: [.string],
             createdAt: createdAt ?? updateAt,
             updateAt: updateAt,
-            deviceID: CPYUtilities.deviceID
+            deviceID: deviceIdentifier
         )
     }
 }


### PR DESCRIPTION
## Summary

- Move hardware device identifier lookup from `CPYUtilities` into a controllable dependency.
- Move legacy history cache removal into a `FileManager` extension with URL-based path handling.
- Update database migration, repository, and unit-test expectations for the new dependency.