### PR TITLE
Vacuum SQLite database after clearing history

### DIFF
--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -16,6 +16,7 @@ import Dependencies
 import Foundation
 import RxCocoa
 import RxSwift
+import SQLiteData
 
 final class ClipService {
 
@@ -34,6 +35,8 @@ final class ClipService {
     private var textRecognizer
     @Dependency(\.defaultAppStorage)
     private var appStorage
+    @Dependency(\.defaultDatabase)
+    private var database
 
     // MARK: - Clips
     func startMonitoring() {
@@ -84,6 +87,11 @@ final class ClipService {
         }
 
         pasteboardHistoryRepository.deleteAll()
+        Task(priority: .utility) { [database] in
+            await withErrorReporting {
+                try await database.vacuum()
+            }
+        }
         // Clear legacy Realm-backed history caches used through v1.2.1.
         try? FileManager.default.removeLegacyHistoryCacheDirectory()
     }


### PR DESCRIPTION
## Summary

- Run `VACUUM` after the user explicitly clears all clipboard history.
- Perform the database maintenance in a utility-priority asynchronous task so the clear-history action does not wait for compaction.
- Report maintenance failures through the existing error-reporting mechanism.

## Background

SQLite reuses pages freed by deletion, but the database file does not normally shrink until it is vacuumed. Since clearing all history is an explicit and infrequent user action, this change compacts the database every time that action completes instead of enabling `auto_vacuum` or applying a size threshold.

Reference: https://note.com/kou050223/n/nd1d8fcff2a1a