### PR TITLE
feat: add search panel for clipboard history and snippets

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		C54C29D72FC3E21400EF30FB /* SQLiteDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D62FC3E21000EF30FB /* SQLiteDataMigrator.swift */; };
 		C54C29D92FC3E22000EF30FB /* SQLiteDataSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C29D82FC3E21A00EF30FB /* SQLiteDataSchema.swift */; };
 		C5700B412FC40ABF00C8F965 /* SnippetFolderDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */; };
+		3F3CBD3A2FC069FA12584AA8 /* SnippetSearchMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1628BE2BC896D04F53A921CC /* SnippetSearchMatch.swift */; };
+		16AF7EABFF16B001D18B0DA0 /* SearchResultItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB5593AAD00A09135CC01D1 /* SearchResultItem.swift */; };
 		C5700B422FC40ABF00C8F965 /* DraggedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */; };
 		C5700B462FC40BBF00C8F965 /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B442FC40BBF00C8F965 /* SnippetRepository.swift */; };
 		C5700B492FC5C0E500C8F965 /* SQLiteDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */; };
@@ -117,6 +119,12 @@
 		FA6DD5151C7DEDB600317E73 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		FAC0DCEF1DE3255E00309C49 /* NSImage+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */; };
 		FAC0DCF11DE576F300309C49 /* PasteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0DCF01DE576F300309C49 /* PasteService.swift */; };
+		0B60C4FE4388649941C07CE9 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7903224BE0C979DB73B4DD02 /* SearchService.swift */; };
+		C58000032FE0000100000001 /* SearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58000022FE0000100000001 /* SearchServiceTests.swift */; };
+		C59000022FE0000200000002 /* CPYSearchPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59000012FE0000200000001 /* CPYSearchPanel.swift */; };
+		C59000042FE0000200000004 /* CPYSearchResultCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59000032FE0000200000003 /* CPYSearchResultCellView.swift */; };
+		C59000062FE0000200000006 /* CPYSearchPanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59000052FE0000200000005 /* CPYSearchPanelViewController.swift */; };
+		C59000082FE0000200000008 /* CPYSearchPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59000072FE0000200000007 /* CPYSearchPanelController.swift */; };
 		FAC43E231B35DFC800C06102 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC43E221B35DFC800C06102 /* Foundation.framework */; };
 		FAC43E251B35DFD000C06102 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC43E241B35DFD000C06102 /* AppKit.framework */; };
 		FAC43E271B35DFD300C06102 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC43E261B35DFD300C06102 /* Carbon.framework */; };
@@ -191,6 +199,8 @@
 		C54C29D82FC3E21A00EF30FB /* SQLiteDataSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataSchema.swift; sourceTree = "<group>"; };
 		C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggedData.swift; sourceTree = "<group>"; };
 		C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetFolderDetail.swift; sourceTree = "<group>"; };
+		1628BE2BC896D04F53A921CC /* SnippetSearchMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetSearchMatch.swift; sourceTree = "<group>"; };
+		DFB5593AAD00A09135CC01D1 /* SearchResultItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultItem.swift; sourceTree = "<group>"; };
 		C5700B442FC40BBF00C8F965 /* SnippetRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetRepository.swift; sourceTree = "<group>"; };
 		C5700B482FC5C0DD00C8F965 /* SQLiteDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDataMigratorTests.swift; sourceTree = "<group>"; };
 		C5700B4F2FD106000C8F965 /* DatabaseMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigrationTests.swift; sourceTree = "<group>"; };
@@ -277,6 +287,12 @@
 		FAAA888E1E6862D90088FB34 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/CPYUpdatesPreferenceViewController.strings; sourceTree = "<group>"; };
 		FAC0DCEE1DE3255E00309C49 /* NSImage+NSColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+NSColor.swift"; sourceTree = "<group>"; };
 		FAC0DCF01DE576F300309C49 /* PasteService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasteService.swift; sourceTree = "<group>"; };
+		7903224BE0C979DB73B4DD02 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		C58000022FE0000100000001 /* SearchServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchServiceTests.swift; sourceTree = "<group>"; };
+		C59000012FE0000200000001 /* CPYSearchPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYSearchPanel.swift; sourceTree = "<group>"; };
+		C59000032FE0000200000003 /* CPYSearchResultCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYSearchResultCellView.swift; sourceTree = "<group>"; };
+		C59000052FE0000200000005 /* CPYSearchPanelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYSearchPanelViewController.swift; sourceTree = "<group>"; };
+		C59000072FE0000200000007 /* CPYSearchPanelController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPYSearchPanelController.swift; sourceTree = "<group>"; };
 		FAC43DC61B35D8B100C06102 /* Clipy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clipy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAC43DD81B35D8B100C06102 /* ClipyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClipyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAC43DDD1B35D8B100C06102 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -432,6 +448,14 @@
 			path = Repositories;
 			sourceTree = "<group>";
 		};
+		C58000012FE0000100000001 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				C58000022FE0000100000001 /* SearchServiceTests.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		C571000C2FCEB03000C8F965 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -537,6 +561,7 @@
 				FA0D5CE71DDCC61600AC9052 /* ClipService.swift */,
 				FAE911B81DE045E2008A4BEC /* HotKeyService.swift */,
 				FAC0DCF01DE576F300309C49 /* PasteService.swift */,
+				7903224BE0C979DB73B4DD02 /* SearchService.swift */,
 				FA1189321E4CD58C00244F12 /* ExcludeAppService.swift */,
 			);
 			path = Services;
@@ -563,6 +588,7 @@
 				FA0D5CE61DDCC5D000AC9052 /* Services */,
 				FA1DB4EC1DDCB4C0007F95C8 /* Preferences */,
 				FA1DB50C1DDCB4C0007F95C8 /* Snippets */,
+				C59000002FE0000200000000 /* Search */,
 				FA1DB4A41DDCB443007F95C8 /* Enums */,
 				FA1DB4D81DDCB49C007F95C8 /* Utility */,
 				FA1DB4DB1DDCB49C007F95C8 /* Views */,
@@ -620,6 +646,8 @@
 				C522FB942FCBD69A00E61800 /* PasteboardAvailableType.swift */,
 				C5700B3E2FC40ABF00C8F965 /* DraggedData.swift */,
 				C5700B3F2FC40ABF00C8F965 /* SnippetFolderDetail.swift */,
+				1628BE2BC896D04F53A921CC /* SnippetSearchMatch.swift */,
+				DFB5593AAD00A09135CC01D1 /* SearchResultItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -714,6 +742,17 @@
 			path = Snippets;
 			sourceTree = "<group>";
 		};
+		C59000002FE0000200000000 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				C59000012FE0000200000001 /* CPYSearchPanel.swift */,
+				C59000072FE0000200000007 /* CPYSearchPanelController.swift */,
+				C59000052FE0000200000005 /* CPYSearchPanelViewController.swift */,
+				C59000032FE0000200000003 /* CPYSearchResultCellView.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		FAC43DBD1B35D8B100C06102 = {
 			isa = PBXGroup;
 			children = (
@@ -755,6 +794,7 @@
 				C571000D2FCEB44000C8F965 /* Extensions */,
 				C571000C2FCEB03000C8F965 /* Models */,
 				C5700B4F2FC5C8C800C8F965 /* Repositories */,
+				C58000012FE0000100000001 /* Services */,
 				FA08EDF71D1FED7D000D1D13 /* HotKeyServiceTests.swift */,
 				FA6167931D3ACCB90049FA14 /* DraggedDataTests.swift */,
 				FAC43DDC1B35D8B100C06102 /* Supporting Files */,
@@ -956,11 +996,14 @@
 				C57447272FD09FD9000D64D3 /* RealmConfiguration.swift in Sources */,
 				C54C29D52FC3E20000EF30FB /* SQLiteDataDatabase.swift in Sources */,
 				FAC0DCF11DE576F300309C49 /* PasteService.swift in Sources */,
+				0B60C4FE4388649941C07CE9 /* SearchService.swift in Sources */,
 				FA1DB4E51DDCB49C007F95C8 /* CPYUtilities.swift in Sources */,
 				FA1DB4B81DDCB452007F95C8 /* NSLock+Clipy.swift in Sources */,
 				C57235112FF24ADE002158F7 /* NSMenu+Highlight.swift in Sources */,
 				FA1DB4BA1DDCB452007F95C8 /* NSUserDefaults+ArchiveData.swift in Sources */,
 				C5700B412FC40ABF00C8F965 /* SnippetFolderDetail.swift in Sources */,
+				3F3CBD3A2FC069FA12584AA8 /* SnippetSearchMatch.swift in Sources */,
+				16AF7EABFF16B001D18B0DA0 /* SearchResultItem.swift in Sources */,
 				C5700B422FC40ABF00C8F965 /* DraggedData.swift in Sources */,
 				C5F1B7331FF74A2D00D2DA83 /* NSPasteboard+Deprecated.swift in Sources */,
 				FA1DB4A31DDCB433007F95C8 /* Constants.swift in Sources */,
@@ -1010,6 +1053,10 @@
 				C5D41A062FDB4A0600EF30FB /* SQLiteDataMigrator+V2.swift in Sources */,
 				C5D41A072FDB4A0700EF30FB /* SQLiteDataMigrator+V3.swift in Sources */,
 				C5F1AC0130190004AA110001 /* SQLiteDataMigrator+V4.swift in Sources */,
+				C59000022FE0000200000002 /* CPYSearchPanel.swift in Sources */,
+				C59000042FE0000200000004 /* CPYSearchResultCellView.swift in Sources */,
+				C59000062FE0000200000006 /* CPYSearchPanelViewController.swift in Sources */,
+				C59000082FE0000200000008 /* CPYSearchPanelController.swift in Sources */,
 			);
 		};
 		FAC43DD41B35D8B100C06102 /* Sources */ = {
@@ -1035,6 +1082,7 @@
 				C50767032FDA7B52004EF448 /* SQLiteDataDatabase+TriggerTests.swift in Sources */,
 				C522FB992FCC019100E61800 /* PasteboardAvailableTypeTests.swift in Sources */,
 				C57100012FCAE00000C8F965 /* SnippetRepositoryTests.swift in Sources */,
+				C58000032FE0000100000001 /* SearchServiceTests.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */

--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -840,6 +840,108 @@
           }
         }
       }
+    },
+    "Search" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suchen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
+          }
+        }
+      }
+    },
+    "Search clips and snippets..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clips und Snippets suchen..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca elementi e snippet..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップやスニペットを検索..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar clipes e snippets..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索剪贴板和代码片段..."
+          }
+        }
+      }
+    },
+    "No results found" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Ergebnisse gefunden"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun risultato trovato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見つかりませんでした"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum resultado encontrado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到结果"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -68,6 +68,10 @@ class AppDelegate: NSObject, NSMenuItemValidation {
         CPYSnippetsEditorWindowController.sharedController.showWindow(self)
     }
 
+    @objc func showSearchPanel() {
+        CPYSearchPanelController.sharedController.show()
+    }
+
     @objc func terminate() {
         terminateApplication()
     }
@@ -92,6 +96,20 @@ class AppDelegate: NSObject, NSMenuItemValidation {
         }
         pasteService.copyToPasteboard(with: snippet.content)
         pasteService.paste()
+    }
+
+    func paste(searchResultItem: SearchResultItem) {
+        switch searchResultItem {
+        case .history(let detail):
+            guard let content = pasteboardHistoryRepository.fetchContent(id: detail.history.id) else {
+                NSSound.beep()
+                return
+            }
+            pasteService.paste(id: detail.history.id, content: content)
+        case .snippet(let match):
+            pasteService.copyToPasteboard(with: match.snippet.content)
+            pasteService.paste()
+        }
     }
 
     func terminateApplication() {

--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -26,6 +26,7 @@ struct Constants {
         static let clip = "ClipMenu"
         static let history = "HistoryMenu"
         static let snippet = "SnippetsMenu"
+        static let search = "SearchPanel"
     }
 
     struct Common {
@@ -103,6 +104,14 @@ struct Constants {
         static let migrateNewKeyCombo = "kCPYMigrateNewKeyCombo"
         static let folderKeyCombos = "kCPYFolderKeyCombos"
         static let clearHistoryKeyCombo = "kCPYClearHistoryKeyCombo"
+        static let searchKeyCombo = "kCPYHotKeySearchKeyCombo"
+    }
+
+    struct Search {
+        /// The search indexes use the `trigram` tokenizer, which never matches shorter queries.
+        static let minimumTrigramLength = 3
+        static let resultLimit = 50
+        static let maxVisibleRows = 8
     }
 
 }

--- a/Clipy/Sources/Enums/MenuType.swift
+++ b/Clipy/Sources/Enums/MenuType.swift
@@ -16,6 +16,7 @@ enum MenuType: String {
     case main       = "ClipMenu"
     case history    = "HistoryMenu"
     case snippet    = "SnippetMenu"
+    case search     = "SearchPanel"
 
     var userDefaultsKey: String {
         switch self {
@@ -25,6 +26,8 @@ enum MenuType: String {
             return Constants.HotKey.historyKeyCombo
         case .snippet:
             return Constants.HotKey.snippetKeyCombo
+        case .search:
+            return Constants.HotKey.searchKeyCombo
         }
     }
 
@@ -36,7 +39,8 @@ enum MenuType: String {
             return #selector(HotKeyService.popupHistoryMenu)
         case .snippet:
             return #selector(HotKeyService.popUpSnippetMenu)
+        case .search:
+            return #selector(HotKeyService.popUpSearchPanel)
         }
     }
-
 }

--- a/Clipy/Sources/Extensions/StringExtensions.swift
+++ b/Clipy/Sources/Extensions/StringExtensions.swift
@@ -32,4 +32,14 @@ extension String {
         }
         return String(title.prefix(maxMenuItemTitleLength - shortenSymbol.count)) + shortenSymbol
     }
+
+    /// Wraps the receiver in an FTS5 phrase so that it is matched literally.
+    ///
+    /// Characters such as `"`, `*`, `:`, `-`, `(`, `)` and bare keywords like `NEAR` are part of the
+    /// FTS5 query syntax. Passing raw user input to `MATCH` makes SQLite throw a syntax error, which
+    /// `withErrorReporting` swallows into an empty result. Quoting the whole input as a single phrase
+    /// (with embedded double quotes doubled) keeps every query valid.
+    var fts5PhraseQuery: String {
+        "\"\(replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
 }

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -79,6 +79,9 @@ extension MenuManager {
             menu = historyMenu
         case .snippet:
             menu = snippetMenu
+        case .search:
+            assertionFailure("Search panel should be presented directly via popUpSearchPanel()")
+            return
         }
         menu?.highlightingFirstItemIfPossible()
         menu?.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
@@ -186,6 +189,8 @@ private extension MenuManager {
         addSnippetItems(snippetMenu!, separateMenu: false, details: snippetFolderDetails)
 
         clipMenu?.addItem(NSMenuItem.separator())
+        clipMenu?.addItem(NSMenuItem(title: String(localized: "Search"), action: #selector(AppDelegate.showSearchPanel)))
+        clipMenu?.addItem(NSMenuItem.separator())
 
         if appStorage.bool(forKey: Constants.UserDefaults.addClearHistoryMenuItem) {
             clipMenu?.addItem(NSMenuItem(title: String(localized: "Clear History"), action: #selector(AppDelegate.clearAllHistory)))
@@ -242,7 +247,7 @@ private extension MenuManager {
         let firstIndex = firstIndexOfMenuItems()
         var listNumber = firstIndex
         var subMenuCount = placeInLine
-        var subMenuIndex = 1 + placeInLine
+        var currentSubMenu: NSMenu?
 
         let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
         let isShowImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
@@ -260,11 +265,12 @@ private extension MenuManager {
                 if i == subMenuCount {
                     let subMenuItem = makeSubmenuItem(subMenuCount, start: firstIndex, end: currentSize, numberOfItems: placeInsideFolder)
                     menu.addItem(subMenuItem)
+                    currentSubMenu = subMenuItem.submenu
                     listNumber = firstIndex
                 }
 
                 // Clip
-                if let subMenu = menu.item(at: subMenuIndex)?.submenu {
+                if let subMenu = currentSubMenu {
                     let menuItem = makeClipMenuItem(historyDetail, index: i, listNumber: listNumber)
                     subMenu.addItem(menuItem)
                     listNumber += 1
@@ -279,7 +285,6 @@ private extension MenuManager {
             i += 1
             if i == subMenuCount + placeInsideFolder {
                 subMenuCount += placeInsideFolder
-                subMenuIndex += 1
             }
         }
     }
@@ -335,7 +340,6 @@ private extension MenuManager {
         labelItem.isEnabled = false
         menu.addItem(labelItem)
 
-        var subMenuIndex = menu.numberOfItems - 1
         let firstIndex = firstIndexOfMenuItems()
         details
             .filter { $0.folder.isEnabled }
@@ -343,17 +347,15 @@ private extension MenuManager {
                 let folderTitle = detail.folder.title
                 let subMenuItem = makeSubmenuItem(folderTitle)
                 menu.addItem(subMenuItem)
-                subMenuIndex += 1
+                let subMenu = subMenuItem.submenu
 
                 var i = firstIndex
                 detail.snippets
                     .filter { $0.isEnabled }
                     .forEach { snippet in
-                        let subMenuItem = makeSnippetMenuItem(snippet, listNumber: i)
-                        if let subMenu = menu.item(at: subMenuIndex)?.submenu {
-                            subMenu.addItem(subMenuItem)
-                            i += 1
-                        }
+                        let snippetMenuItem = makeSnippetMenuItem(snippet, listNumber: i)
+                        subMenu?.addItem(snippetMenuItem)
+                        i += 1
                     }
             }
     }

--- a/Clipy/Sources/Models/SearchResultItem.swift
+++ b/Clipy/Sources/Models/SearchResultItem.swift
@@ -1,0 +1,78 @@
+//
+//  SearchResultItem.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+
+/// A single row in the search panel, which mixes clipboard history and snippets.
+///
+/// Modelled as an enum rather than a protocol because pasting branches on the kind — history pastes
+/// its stored pasteboard content, a snippet pastes its text — and the exhaustiveness check keeps that
+/// branch honest as the cases grow.
+enum SearchResultItem: Equatable, Identifiable {
+    case history(PasteboardHistoryDetail)
+    case snippet(SnippetSearchMatch)
+
+    var id: String {
+        switch self {
+        case .history(let detail):
+            return "history:\(detail.history.id.rawValue)"
+        case .snippet(let match):
+            return "snippet:\(match.snippet.id.rawValue.uuidString)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .history(let detail):
+            return detail.history.typedTitle
+        case .snippet(let match):
+            return match.snippet.title.trimmedMenuTitle
+        }
+    }
+
+    /// The folder name for snippets, and the copied date for history entries.
+    var subtitle: String {
+        switch self {
+        case .history(let detail):
+            return Self.subtitleFormatter.localizedString(
+                for: Date(timeIntervalSince1970: TimeInterval(detail.history.updateAt)),
+                relativeTo: Date()
+            )
+        case .snippet(let match):
+            return match.folder.title
+        }
+    }
+
+    var toolTip: String? {
+        switch self {
+        case .history(let detail):
+            return detail.history.toolTip
+        case .snippet(let match):
+            return match.snippet.toolTip
+        }
+    }
+
+    var thumbnailImage: NSImage? {
+        switch self {
+        case .history(let detail):
+            return detail.thumbnailAsset.flatMap { NSImage(data: $0.data) }
+        case .snippet:
+            return nil
+        }
+    }
+
+    private static let subtitleFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+}

--- a/Clipy/Sources/Models/SnippetSearchMatch.swift
+++ b/Clipy/Sources/Models/SnippetSearchMatch.swift
@@ -1,0 +1,20 @@
+//
+//  SnippetSearchMatch.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+/// A snippet that matched a search query, paired with the folder that contains it.
+///
+/// The folder is carried along so that search results can show which folder a snippet came from,
+/// which is the only context the flat result list has (the menu conveys it through the hierarchy).
+struct SnippetSearchMatch: Equatable {
+    let snippet: Snippet
+    let folder: SnippetFolder
+}

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
@@ -10,6 +10,7 @@
                 <outlet property="clearHistoryShortcutRecordView" destination="pCf-EG-Cp9" id="K22-8R-Gk9"/>
                 <outlet property="historyShortcutRecordView" destination="hDA-gc-n3S" id="fzg-O8-Fze"/>
                 <outlet property="mainShortcutRecordView" destination="ABK-GW-Xwm" id="Jr7-Dz-hqZ"/>
+                <outlet property="searchShortcutRecordView" destination="sCh-Rv-Xwm" id="sCh-Ot-Xwm"/>
                 <outlet property="snippetShortcutRecordView" destination="q8v-jS-CAr" id="Ay0-Zr-azr"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -17,11 +18,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="275"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="323"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="5oP-dg-DwL">
-                    <rect key="frame" x="59" y="244" width="210" height="17"/>
+                    <rect key="frame" x="59" y="292" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Menu" id="X5L-5V-1eH">
                         <font key="font" metaFont="systemBold"/>
@@ -30,20 +31,11 @@
                     </textFieldCell>
                 </textField>
                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uTq-IP-dYk">
-                    <rect key="frame" x="44" y="96" width="392" height="140"/>
+                    <rect key="frame" x="44" y="96" width="392" height="188"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vzz-Iq-77h">
-                            <rect key="frame" x="15" y="62" width="121" height="17"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="History:" id="Abl-cO-JwU">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oYq-Bg-KGQ">
-                            <rect key="frame" x="15" y="109" width="121" height="17"/>
+                            <rect key="frame" x="15" y="157" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Main:" id="5sL-G8-1io">
                                 <font key="font" metaFont="system"/>
@@ -51,8 +43,17 @@
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
+                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vzz-Iq-77h">
+                            <rect key="frame" x="15" y="110" width="121" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="History:" id="Abl-cO-JwU">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ixj-RO-bKW">
-                            <rect key="frame" x="15" y="13" width="121" height="17"/>
+                            <rect key="frame" x="15" y="61" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Snippets:" id="fXr-ry-5ds">
                                 <font key="font" metaFont="system"/>
@@ -60,8 +61,17 @@
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
+                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sCh-Lb-77h">
+                            <rect key="frame" x="15" y="13" width="121" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Search:" id="sCh-Cl-77h">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ABK-GW-Xwm" customClass="RecordView" customModule="KeyHolder">
-                            <rect key="frame" x="142" y="101" width="250" height="34"/>
+                            <rect key="frame" x="142" y="149" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
@@ -82,7 +92,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hDA-gc-n3S" customClass="RecordView" customModule="KeyHolder">
-                            <rect key="frame" x="142" y="53" width="250" height="34"/>
+                            <rect key="frame" x="142" y="101" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -100,6 +110,24 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q8v-jS-CAr" customClass="RecordView" customModule="KeyHolder">
+                            <rect key="frame" x="142" y="53" width="250" height="34"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="17"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
+                                    <color key="value" red="0.1647058824" green="0.51764705879999995" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                    <color key="value" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                    <real key="value" value="1"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </customView>
+                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sCh-Rv-Xwm" customClass="RecordView" customModule="KeyHolder">
                             <rect key="frame" x="142" y="5" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>

--- a/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
@@ -21,6 +21,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     @IBOutlet private weak var mainShortcutRecordView: RecordView!
     @IBOutlet private weak var historyShortcutRecordView: RecordView!
     @IBOutlet private weak var snippetShortcutRecordView: RecordView!
+    @IBOutlet private weak var searchShortcutRecordView: RecordView!
     @IBOutlet private weak var clearHistoryShortcutRecordView: RecordView!
 
     @Dependency(\.hotKeyService)
@@ -32,6 +33,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
         mainShortcutRecordView.delegate = self
         historyShortcutRecordView.delegate = self
         snippetShortcutRecordView.delegate = self
+        searchShortcutRecordView.delegate = self
         clearHistoryShortcutRecordView.delegate = self
         prepareHotKeys()
     }
@@ -44,6 +46,7 @@ private extension CPYShortcutsPreferenceViewController {
         mainShortcutRecordView.keyCombo = hotKeyService.mainKeyCombo
         historyShortcutRecordView.keyCombo = hotKeyService.historyKeyCombo
         snippetShortcutRecordView.keyCombo = hotKeyService.snippetKeyCombo
+        searchShortcutRecordView.keyCombo = hotKeyService.searchKeyCombo
         clearHistoryShortcutRecordView.keyCombo = hotKeyService.clearHistoryKeyCombo
     }
 }
@@ -66,6 +69,8 @@ extension CPYShortcutsPreferenceViewController: RecordViewDelegate {
             hotKeyService.change(with: .history, keyCombo: keyCombo)
         case snippetShortcutRecordView:
             hotKeyService.change(with: .snippet, keyCombo: keyCombo)
+        case searchShortcutRecordView:
+            hotKeyService.change(with: .search, keyCombo: keyCombo)
         case clearHistoryShortcutRecordView:
             hotKeyService.changeClearHistoryKeyCombo(keyCombo)
         default: break

--- a/Clipy/Sources/Preferences/Panels/de.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/de.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "Snippets:";
+
+/* Class = "NSTextFieldCell"; title = "Search:"; ObjectID = "sCh-Cl-77h"; */
+"sCh-Cl-77h.title" = "Suchen:";

--- a/Clipy/Sources/Preferences/Panels/it.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/it.lproj/CPYShortcutsPreferenceViewController.strings
@@ -8,6 +8,9 @@
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "Snippet:";
 
+/* Class = "NSTextFieldCell"; title = "Search:"; ObjectID = "sCh-Cl-77h"; */
+"sCh-Cl-77h.title" = "Cerca:";
+
 /* Class = "NSTextFieldCell"; title = "Menu"; ObjectID = "X5L-5V-1eH"; */
 "X5L-5V-1eH.title" = "Menu";
 

--- a/Clipy/Sources/Preferences/Panels/ja.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/ja.lproj/CPYShortcutsPreferenceViewController.strings
@@ -8,6 +8,9 @@
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "スニペット:";
 
+/* Class = "NSTextFieldCell"; title = "Search:"; ObjectID = "sCh-Cl-77h"; */
+"sCh-Cl-77h.title" = "検索:";
+
 /* Class = "NSTextFieldCell"; title = "Menu"; ObjectID = "X5L-5V-1eH"; */
 "X5L-5V-1eH.title" = "メニュー";
 

--- a/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "Snippets:";
+
+/* Class = "NSTextFieldCell"; title = "Search:"; ObjectID = "sCh-Cl-77h"; */
+"sCh-Cl-77h.title" = "Pesquisar:";

--- a/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "片断：";
+
+/* Class = "NSTextFieldCell"; title = "Search:"; ObjectID = "sCh-Cl-77h"; */
+"sCh-Cl-77h.title" = "搜索：";

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -125,6 +125,7 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                     .leftJoin(PasteboardHistory.all) { $0.id.eq($1.id) }
                     .leftJoin(PasteboardHistoryThumbnailAsset.all) { $0.id.eq($2.pasteboardHistoryID) }
                     .select { PasteboardHistorySearchResult.Columns(history: $1, thumbnailAsset: $2) }
+                    .order { $1.updateAt.desc() }
                     .limit(limit)
                     .fetchAll(database)
                 return results.compactMap { result in

--- a/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
+++ b/Clipy/Sources/Repositories/PasteboardHistoryRepository.swift
@@ -23,6 +23,11 @@ protocol PasteboardHistoryRepositoryProtocol {
         includesThumbnailAsset: Bool,
         limit: Int,
     ) -> [PasteboardHistoryDetail]
+    func searchHistories(
+        matching query: String,
+        includesThumbnailAsset: Bool,
+        limit: Int,
+    ) -> [PasteboardHistoryDetail]
     func fetchHistory(id: PasteboardHistory.ID) -> PasteboardHistory?
     func fetchContent(id: PasteboardHistory.ID) -> PasteboardContent?
 
@@ -85,6 +90,51 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
                     .leftJoin(PasteboardHistoryThumbnailAsset.all) { $0.id.eq($1.pasteboardHistoryID) }
                     .select { PasteboardHistoryDetail.Columns(history: $0, thumbnailAsset: $1) }
                     .fetchAll(database)
+            }
+        } ?? []
+    }
+
+    func searchHistories(
+        matching query: String,
+        includesThumbnailAsset: Bool,
+        limit: Int
+    ) -> [PasteboardHistoryDetail] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return [] }
+
+        return withErrorReporting {
+            try database.read { database in
+                // The search indexes are tokenized with `trigram`, which cannot match queries shorter
+                // than three characters. Fall back to a LIKE scan so that typing the first character
+                // still narrows the candidates down instead of emptying the list.
+                guard query.count >= Constants.Search.minimumTrigramLength else {
+                    let histories = try PasteboardHistory
+                        .where { $0.title.contains(query) }
+                        .order { $0.updateAt.desc() }
+                        .limit(limit)
+                        .fetchAll(database)
+                    return try attachThumbnailAssets(
+                        to: histories,
+                        includesThumbnailAsset: includesThumbnailAsset,
+                        database: database
+                    )
+                }
+
+                let results = try PasteboardHistorySearch
+                    .where { $0.match(query.fts5PhraseQuery) }
+                    .leftJoin(PasteboardHistory.all) { $0.id.eq($1.id) }
+                    .leftJoin(PasteboardHistoryThumbnailAsset.all) { $0.id.eq($2.pasteboardHistoryID) }
+                    .select { PasteboardHistorySearchResult.Columns(history: $1, thumbnailAsset: $2) }
+                    .limit(limit)
+                    .fetchAll(database)
+                return results.compactMap { result in
+                    result.history.map {
+                        PasteboardHistoryDetail(
+                            history: $0,
+                            thumbnailAsset: includesThumbnailAsset ? result.thumbnailAsset : nil
+                        )
+                    }
+                }
             }
         } ?? []
     }
@@ -211,6 +261,26 @@ final class PasteboardHistoryRepository: PasteboardHistoryRepositoryProtocol {
 }
 
 private extension PasteboardHistoryRepository {
+    func attachThumbnailAssets(
+        to histories: [PasteboardHistory],
+        includesThumbnailAsset: Bool,
+        database: Database
+    ) throws -> [PasteboardHistoryDetail] {
+        guard includesThumbnailAsset, !histories.isEmpty else {
+            return histories.map { PasteboardHistoryDetail(history: $0, thumbnailAsset: nil) }
+        }
+        let assets = try PasteboardHistoryThumbnailAsset
+            .where { $0.pasteboardHistoryID.in(histories.map(\.id)) }
+            .fetchAll(database)
+        let assetsByHistoryID = Dictionary(
+            assets.map { ($0.pasteboardHistoryID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return histories.map {
+            PasteboardHistoryDetail(history: $0, thumbnailAsset: assetsByHistoryID[$0.id])
+        }
+    }
+
     func thumbnailAsset(from content: PasteboardContent, id: PasteboardHistory.ID) -> PasteboardHistoryThumbnailAsset? {
         var asset: PasteboardHistoryThumbnailAsset?
         if let thumbnailImage = content.thumbnailImage, let thumbnailData = thumbnailImage.tiffRepresentation {

--- a/Clipy/Sources/Repositories/SnippetRepository.swift
+++ b/Clipy/Sources/Repositories/SnippetRepository.swift
@@ -26,6 +26,7 @@ protocol SnippetRepositoryProtocol {
     func updateFolderIndexes(_ folderIDs: [SnippetFolder.ID])
     func deleteFolder(_ id: SnippetFolder.ID)
 
+    func searchSnippets(matching query: String, limit: Int) -> [SnippetSearchMatch]
     func fetchSnippet(id: Snippet.ID) -> Snippet?
     func insertSnippet(to id: SnippetFolder.ID) -> Snippet?
     func updateSnippetTitle(_ id: Snippet.ID, title: String)
@@ -162,6 +163,50 @@ final class SnippetRepository: SnippetRepositoryProtocol {
                 try SnippetFolder.delete().where { $0.id.eq(id) }.execute(database)
             }
         }
+    }
+
+    func searchSnippets(matching query: String, limit: Int) -> [SnippetSearchMatch] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return [] }
+
+        return withErrorReporting {
+            try database.read { database in
+                // The search index is tokenized with `trigram`, which cannot match queries shorter
+                // than three characters. Fall back to a LIKE scan so that typing the first character
+                // still narrows the candidates down instead of emptying the list.
+                let snippets: [Snippet]
+                if query.count >= Constants.Search.minimumTrigramLength {
+                    snippets = try SnippetSearch
+                        .where { $0.match(query.fts5PhraseQuery) }
+                        .leftJoin(Snippet.all) { $0.id.eq($1.id) }
+                        .select { SnippetSearchResult.Columns(snippet: $1) }
+                        .fetchAll(database)
+                        .compactMap(\.snippet)
+                } else {
+                    snippets = try Snippet
+                        .where { $0.title.contains(query) || $0.content.contains(query) }
+                        .order(by: \.index)
+                        .fetchAll(database)
+                }
+
+                // The search index carries no `isEnabled` column, so disabled snippets and snippets
+                // inside disabled folders have to be filtered out here to match the menu's behaviour.
+                let foldersByID = try SnippetFolder
+                    .where(\.isEnabled)
+                    .fetchAll(database)
+                    .reduce(into: [SnippetFolder.ID: SnippetFolder]()) { $0[$1.id] = $1 }
+                return snippets
+                    .lazy
+                    .filter(\.isEnabled)
+                    .compactMap { snippet in
+                        foldersByID[snippet.folderID].map {
+                            SnippetSearchMatch(snippet: snippet, folder: $0)
+                        }
+                    }
+                    .prefix(limit)
+                    .map { $0 }
+            }
+        } ?? []
     }
 
     func fetchSnippet(id: Snippet.ID) -> Snippet? {

--- a/Clipy/Sources/Search/CPYSearchPanel.swift
+++ b/Clipy/Sources/Search/CPYSearchPanel.swift
@@ -1,0 +1,48 @@
+//
+//  CPYSearchPanel.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+
+final class CPYSearchPanel: NSPanel {
+
+    // MARK: - Overrides
+    override var canBecomeKey: Bool {
+        return true
+    }
+
+    override var canBecomeMain: Bool {
+        return true
+    }
+
+    // MARK: - Initialize
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        isMovableByWindowBackground = false
+        hidesOnDeactivate = false
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        orderOut(sender)
+    }
+}

--- a/Clipy/Sources/Search/CPYSearchPanelController.swift
+++ b/Clipy/Sources/Search/CPYSearchPanelController.swift
@@ -1,0 +1,172 @@
+//
+//  CPYSearchPanelController.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Dependencies
+
+final class CPYSearchPanelController: NSWindowController {
+
+    // MARK: - Singleton
+    static let sharedController = CPYSearchPanelController()
+
+    // MARK: - Constants
+    private let panelWidth: CGFloat = 680
+    private let searchHeaderHeight: CGFloat = 50
+    private let rowHeight: CGFloat = 46
+    private let emptyContentHeight: CGFloat = 80
+    private let padding: CGFloat = 8
+
+    // MARK: - Properties
+    private let searchPanel: CPYSearchPanel
+    private let searchViewController: CPYSearchPanelViewController
+    private var previousApplication: NSRunningApplication?
+
+    @Dependency(\.mainQueue)
+    private var mainQueue
+    @Dependency(\.pasteService)
+    private var pasteService
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
+
+    // MARK: - Initialize
+    init() {
+        let initialRect = NSRect(x: 0, y: 0, width: panelWidth, height: searchHeaderHeight + padding)
+        let panel = CPYSearchPanel(contentRect: initialRect)
+        let viewController = CPYSearchPanelViewController()
+        panel.contentViewController = viewController
+
+        self.searchPanel = panel
+        self.searchViewController = viewController
+
+        super.init(window: panel)
+
+        setupEventHandlers()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+    private func setupEventHandlers() {
+        searchViewController.onSelect = { [weak self] item in
+            self?.handleSelection(item)
+        }
+
+        searchViewController.onCancel = { [weak self] in
+            self?.dismiss(restoreFocus: true)
+        }
+
+        searchViewController.onItemsCountChanged = { [weak self] count in
+            self?.updatePanelFrame(itemCount: count, animated: true)
+        }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidResignKey),
+            name: NSWindow.didResignKeyNotification,
+            object: searchPanel
+        )
+    }
+
+    // MARK: - Presentation
+    /// Shows the floating search panel.
+    ///
+    /// ## Activation & Pasting note:
+    /// Because Clipy is an `LSUIElement` (agent/menu bar app), giving the search panel reliable
+    /// keyboard focus requires calling `NSApp.activate(ignoringOtherApps: true)`.
+    ///
+    /// However, `PasteService.paste()` emits a `⌘V` CGEvent to the currently frontmost application.
+    /// If Clipy remains active when the event is posted, the paste keystroke is consumed by Clipy itself!
+    /// Therefore, we save `previousApplication = NSWorkspace.shared.frontmostApplication` upon presentation,
+    /// and restore focus to `previousApplication` upon closing and confirm before triggering `PasteService.paste()`.
+    func show() {
+        previousApplication = NSWorkspace.shared.frontmostApplication
+
+        searchViewController.resetSearch()
+        updatePanelFrame(itemCount: searchViewController.items.count, animated: false)
+
+        NSApp.activate(ignoringOtherApps: true)
+        searchPanel.makeKeyAndOrderFront(nil)
+        searchPanel.makeFirstResponder(searchViewController.searchField)
+    }
+
+    func dismiss(restoreFocus: Bool) {
+        searchPanel.orderOut(nil)
+        if restoreFocus, let prevApp = previousApplication, prevApp.bundleIdentifier != Bundle.main.bundleIdentifier {
+            prevApp.activate(options: .activateIgnoringOtherApps)
+        }
+    }
+
+    // MARK: - Frame Calculation
+    private func updatePanelFrame(itemCount: Int, animated: Bool) {
+        guard let screen = targetScreen() else { return }
+
+        let visibleRows = min(itemCount, Constants.Search.maxVisibleRows)
+        let contentHeight: CGFloat
+        if visibleRows > 0 {
+            contentHeight = searchHeaderHeight + (CGFloat(visibleRows) * rowHeight) + padding
+        } else if !searchViewController.searchField.stringValue.isEmpty {
+            contentHeight = searchHeaderHeight + emptyContentHeight
+        } else {
+            contentHeight = searchHeaderHeight + padding
+        }
+
+        let screenFrame = screen.visibleFrame
+        let newX = screenFrame.origin.x + (screenFrame.width - panelWidth) / 2
+        // Position slightly above vertical center for Spotlight-like ergonomics
+        let newY = screenFrame.origin.y + (screenFrame.height - contentHeight) * 0.65
+
+        let newFrame = NSRect(x: newX, y: newY, width: panelWidth, height: contentHeight)
+        searchPanel.setFrame(newFrame, display: true, animate: animated)
+    }
+
+    private func targetScreen() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main
+    }
+
+    // MARK: - Selection Handling
+    private func handleSelection(_ item: SearchResultItem) {
+        let prevApp = previousApplication
+        dismiss(restoreFocus: false)
+
+        // Reactivate target application before sending paste keystroke
+        if let prevApp = prevApp, prevApp.bundleIdentifier != Bundle.main.bundleIdentifier {
+            prevApp.activate(options: .activateIgnoringOtherApps)
+        }
+
+        // Wait 120ms for target app activation to complete before emitting ⌘V
+        mainQueue.schedule(after: mainQueue.now.advanced(by: .milliseconds(120))) { [weak self] in
+            self?.paste(item: item)
+        }
+    }
+
+    private func paste(item: SearchResultItem) {
+        switch item {
+        case .history(let detail):
+            guard let content = pasteboardHistoryRepository.fetchContent(id: detail.history.id) else {
+                NSSound.beep()
+                return
+            }
+            pasteService.paste(id: detail.history.id, content: content)
+        case .snippet(let match):
+            pasteService.copyToPasteboard(with: match.snippet.content)
+            pasteService.paste()
+        }
+    }
+
+    // MARK: - Notifications
+    @objc private func windowDidResignKey(_ notification: Notification) {
+        dismiss(restoreFocus: false)
+    }
+}

--- a/Clipy/Sources/Search/CPYSearchPanelViewController.swift
+++ b/Clipy/Sources/Search/CPYSearchPanelViewController.swift
@@ -1,0 +1,256 @@
+//
+//  CPYSearchPanelViewController.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Combine
+import Dependencies
+
+final class CPYSearchPanelViewController: NSViewController {
+
+    // MARK: - Properties
+    let searchField = NSTextField()
+    private let searchIconImageView = NSImageView()
+    private let separatorView = NSBox()
+    private let tableView = NSTableView()
+    private let scrollView = NSScrollView()
+    private let emptyLabel = NSTextField(labelWithString: "")
+
+    @Dependency(\.searchService)
+    private var searchService
+    @Dependency(\.mainQueue)
+    private var mainQueue
+
+    private let querySubject = PassthroughSubject<String, Never>()
+    private var cancellables: Set<AnyCancellable> = []
+
+    private(set) var items: [SearchResultItem] = []
+
+    var onSelect: ((SearchResultItem) -> Void)?
+    var onCancel: (() -> Void)?
+    var onItemsCountChanged: ((Int) -> Void)?
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        let visualEffectView = NSVisualEffectView()
+        visualEffectView.material = .hudWindow
+        visualEffectView.blendingMode = .behindWindow
+        visualEffectView.state = .active
+        visualEffectView.wantsLayer = true
+        visualEffectView.layer?.cornerRadius = 12
+        visualEffectView.layer?.masksToBounds = true
+        self.view = visualEffectView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupBindings()
+    }
+
+    // MARK: - UI Setup
+    private func setupUI() {
+        // Search Icon
+        searchIconImageView.translatesAutoresizingMaskIntoConstraints = false
+        searchIconImageView.image = NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
+        searchIconImageView.contentTintColor = .secondaryLabelColor
+        view.addSubview(searchIconImageView)
+
+        // Search Field
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.placeholderString = String(localized: "Search clips and snippets...")
+        searchField.font = .systemFont(ofSize: 16, weight: .regular)
+        searchField.focusRingType = .none
+        searchField.isBordered = false
+        searchField.drawsBackground = false
+        searchField.delegate = self
+        view.addSubview(searchField)
+
+        // Separator
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.boxType = .separator
+        view.addSubview(separatorView)
+
+        // Table View
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.headerView = nil
+        tableView.rowHeight = 44
+        tableView.intercellSpacing = NSSize(width: 0, height: 2)
+        tableView.backgroundColor = .clear
+        tableView.selectionHighlightStyle = .regular
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.target = self
+        tableView.doubleAction = #selector(tableViewDoubleClicked)
+        tableView.action = #selector(tableViewClicked)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("SearchColumn"))
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+
+        // Scroll View
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = tableView
+        view.addSubview(scrollView)
+
+        // Empty Label
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.stringValue = String(localized: "No results found")
+        emptyLabel.font = .systemFont(ofSize: 14, weight: .medium)
+        emptyLabel.textColor = .secondaryLabelColor
+        emptyLabel.alignment = .center
+        emptyLabel.isHidden = true
+        view.addSubview(emptyLabel)
+
+        NSLayoutConstraint.activate([
+            searchIconImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 14),
+            searchIconImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 14),
+            searchIconImageView.widthAnchor.constraint(equalToConstant: 20),
+            searchIconImageView.heightAnchor.constraint(equalToConstant: 20),
+
+            searchField.leadingAnchor.constraint(equalTo: searchIconImageView.trailingAnchor, constant: 10),
+            searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -14),
+            searchField.centerYAnchor.constraint(equalTo: searchIconImageView.centerYAnchor),
+            searchField.heightAnchor.constraint(equalToConstant: 28),
+
+            separatorView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            separatorView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 10),
+            separatorView.heightAnchor.constraint(equalToConstant: 1),
+
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: separatorView.bottomAnchor, constant: 4),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -4),
+
+            emptyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
+        ])
+    }
+
+    // MARK: - Bindings
+    private func setupBindings() {
+        querySubject
+            .debounce(for: .milliseconds(120), scheduler: mainQueue)
+            .removeDuplicates()
+            .sink { [weak self] query in
+                self?.performSearch(query: query)
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Search
+    func resetSearch() {
+        searchField.stringValue = ""
+        performSearch(query: "")
+    }
+
+    private func performSearch(query: String) {
+        items = searchService.search(query: query, limit: Constants.Search.resultLimit)
+        tableView.reloadData()
+
+        let hasQuery = !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        emptyLabel.isHidden = !(items.isEmpty && hasQuery)
+
+        if !items.isEmpty {
+            tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            tableView.scrollRowToVisible(0)
+        }
+
+        onItemsCountChanged?(items.count)
+    }
+
+    // MARK: - Actions
+    @objc private func tableViewClicked() {
+        let clickedRow = tableView.clickedRow
+        guard clickedRow >= 0, clickedRow < items.count else { return }
+        onSelect?(items[clickedRow])
+    }
+
+    @objc private func tableViewDoubleClicked() {
+        let selectedRow = tableView.selectedRow
+        guard selectedRow >= 0, selectedRow < items.count else { return }
+        onSelect?(items[selectedRow])
+    }
+
+    private func selectPreviousRow() {
+        let currentRow = tableView.selectedRow
+        let targetRow = max(0, currentRow - 1)
+        guard targetRow != currentRow, targetRow < items.count else { return }
+        tableView.selectRowIndexes(IndexSet(integer: targetRow), byExtendingSelection: false)
+        tableView.scrollRowToVisible(targetRow)
+    }
+
+    private func selectNextRow() {
+        let currentRow = tableView.selectedRow
+        let targetRow = min(items.count - 1, max(0, currentRow + 1))
+        guard targetRow != currentRow, targetRow < items.count else { return }
+        tableView.selectRowIndexes(IndexSet(integer: targetRow), byExtendingSelection: false)
+        tableView.scrollRowToVisible(targetRow)
+    }
+
+    private func confirmSelection() {
+        let selectedRow = tableView.selectedRow
+        guard selectedRow >= 0, selectedRow < items.count else { return }
+        onSelect?(items[selectedRow])
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+extension CPYSearchPanelViewController: NSTextFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        querySubject.send(searchField.stringValue)
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(NSResponder.moveUp(_:)) {
+            selectPreviousRow()
+            return true
+        } else if commandSelector == #selector(NSResponder.moveDown(_:)) {
+            selectNextRow()
+            return true
+        } else if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            confirmSelection()
+            return true
+        } else if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            onCancel?()
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - NSTableViewDataSource & Delegate
+extension CPYSearchPanelViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return items.count
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        return CPYSearchResultRowView()
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < items.count else { return nil }
+        let cellView: CPYSearchResultCellView
+        if let reusedView = tableView.makeView(withIdentifier: CPYSearchResultCellView.reuseIdentifier, owner: self) as? CPYSearchResultCellView {
+            cellView = reusedView
+        } else {
+            cellView = CPYSearchResultCellView()
+            cellView.identifier = CPYSearchResultCellView.reuseIdentifier
+        }
+        cellView.configure(with: items[row])
+        return cellView
+    }
+}

--- a/Clipy/Sources/Search/CPYSearchResultCellView.swift
+++ b/Clipy/Sources/Search/CPYSearchResultCellView.swift
@@ -1,0 +1,130 @@
+//
+//  CPYSearchResultCellView.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+
+final class CPYSearchResultRowView: NSTableRowView {
+
+    override func drawSelection(in dirtyRect: NSRect) {
+        if isSelected {
+            let selectionRect = bounds.insetBy(dx: 6, dy: 2)
+            let path = NSBezierPath(roundedRect: selectionRect, xRadius: 8, yRadius: 8)
+            NSColor.selectedContentBackgroundColor.withAlphaComponent(0.85).setFill()
+            path.fill()
+        }
+    }
+
+    override var interiorBackgroundStyle: NSView.BackgroundStyle {
+        isSelected ? .emphasized : .normal
+    }
+}
+
+final class CPYSearchResultCellView: NSTableCellView {
+
+    // MARK: - Properties
+    static let reuseIdentifier = NSUserInterfaceItemIdentifier("CPYSearchResultCellView")
+
+    private let iconImageView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(labelWithString: "")
+    private let kindBadgeLabel = NSTextField(labelWithString: "")
+
+    // MARK: - Initialize
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+
+    private func setupViews() {
+        wantsLayer = true
+
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        iconImageView.imageScaling = .scaleProportionallyUpOrDown
+        iconImageView.wantsLayer = true
+        iconImageView.layer?.cornerRadius = 4
+        iconImageView.layer?.masksToBounds = true
+        addSubview(iconImageView)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.maximumNumberOfLines = 1
+        addSubview(titleLabel)
+
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        subtitleLabel.textColor = .secondaryLabelColor
+        subtitleLabel.lineBreakMode = .byTruncatingTail
+        subtitleLabel.maximumNumberOfLines = 1
+        addSubview(subtitleLabel)
+
+        kindBadgeLabel.translatesAutoresizingMaskIntoConstraints = false
+        kindBadgeLabel.font = .systemFont(ofSize: 10, weight: .medium)
+        kindBadgeLabel.textColor = .tertiaryLabelColor
+        kindBadgeLabel.alignment = .right
+        addSubview(kindBadgeLabel)
+
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 10),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: kindBadgeLabel.leadingAnchor, constant: -8),
+
+            subtitleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 10),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2),
+            subtitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: kindBadgeLabel.leadingAnchor, constant: -8),
+
+            kindBadgeLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            kindBadgeLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            kindBadgeLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        ])
+    }
+
+    // MARK: - Configure
+    func configure(with item: SearchResultItem) {
+        titleLabel.stringValue = item.title
+        subtitleLabel.stringValue = item.subtitle
+        toolTip = item.toolTip
+
+        switch item {
+        case .history:
+            if let thumbnail = item.thumbnailImage {
+                iconImageView.image = thumbnail
+            } else {
+                iconImageView.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
+                    ?? NSImage(resource: .iconText)
+            }
+            kindBadgeLabel.stringValue = String(localized: "History")
+        case .snippet:
+            iconImageView.image = NSImage(resource: .iconText)
+            kindBadgeLabel.stringValue = String(localized: "Snippet")
+        }
+    }
+
+    override var backgroundStyle: NSView.BackgroundStyle {
+        didSet {
+            let isEmphasized = backgroundStyle == .emphasized
+            titleLabel.textColor = isEmphasized ? .white : .labelColor
+            subtitleLabel.textColor = isEmphasized ? NSColor.white.withAlphaComponent(0.8) : .secondaryLabelColor
+            kindBadgeLabel.textColor = isEmphasized ? NSColor.white.withAlphaComponent(0.6) : .tertiaryLabelColor
+        }
+    }
+}

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -21,15 +21,18 @@ final class HotKeyService: NSObject {
     static var defaultKeyCombos: [String: Any] = {
         // MainMenu:    ⌘ + Shift + V
         // HistoryMenu: ⌘ + Control + V
-        // SnipeetMenu: ⌘ + Shift B
+        // SnipeetMenu: ⌘ + Shift + B
+        // SearchPanel: ⌘ + Shift + F
         return [Constants.Menu.clip: ["keyCode": 9, "modifiers": 768],
                 Constants.Menu.history: ["keyCode": 9, "modifiers": 4352],
-                Constants.Menu.snippet: ["keyCode": 11, "modifiers": 768]]
+                Constants.Menu.snippet: ["keyCode": 11, "modifiers": 768],
+                Constants.Menu.search: ["keyCode": 3, "modifiers": 768]]
     }()
 
     fileprivate(set) var mainKeyCombo: KeyCombo?
     fileprivate(set) var historyKeyCombo: KeyCombo?
     fileprivate(set) var snippetKeyCombo: KeyCombo?
+    fileprivate(set) var searchKeyCombo: KeyCombo?
     fileprivate(set) var clearHistoryKeyCombo: KeyCombo?
 
     @Dependency(\.snippetRepository)
@@ -61,6 +64,11 @@ extension HotKeyService {
         firebase.logEvent(event: .popUpMenu(.snippet))
     }
 
+    @objc func popUpSearchPanel() {
+        CPYSearchPanelController.sharedController.show()
+        firebase.logEvent(event: .popUpMenu(.search))
+    }
+
     @objc func popUpClearHistoryAlert() {
         clipService.clearAllHistory()
     }
@@ -84,6 +92,8 @@ extension HotKeyService {
         change(with: .history, keyCombo: savedKeyCombo(forKey: Constants.HotKey.historyKeyCombo))
         // Snippet menu
         change(with: .snippet, keyCombo: savedKeyCombo(forKey: Constants.HotKey.snippetKeyCombo))
+        // Search panel
+        change(with: .search, keyCombo: savedKeyCombo(forKey: Constants.HotKey.searchKeyCombo))
         // Clear History
         changeClearHistoryKeyCombo(savedKeyCombo(forKey: Constants.HotKey.clearHistoryKeyCombo))
     }
@@ -96,6 +106,8 @@ extension HotKeyService {
             historyKeyCombo = keyCombo
         case .snippet:
             snippetKeyCombo = keyCombo
+        case .search:
+            searchKeyCombo = keyCombo
         }
         register(with: type, keyCombo: keyCombo)
     }
@@ -162,6 +174,12 @@ private extension HotKeyService {
         if let (keyCode, modifiers) = parse(with: keyCombos, forKey: Constants.Menu.snippet) {
             if let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers) {
                 appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.snippetKeyCombo)
+            }
+        }
+        // Search panel
+        if let (keyCode, modifiers) = parse(with: keyCombos, forKey: Constants.Menu.search) {
+            if let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers) {
+                appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.searchKeyCombo)
             }
         }
     }

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -83,6 +83,7 @@ extension HotKeyService {
             appStorage.set(true, forKey: Constants.HotKey.migrateNewKeyCombo)
             appStorage.synchronize()
         }
+        seedSearchHotKeyIfNeeded()
         // Snippet hotkey
         setupSnippetHotKeys()
 
@@ -151,6 +152,18 @@ private extension HotKeyService {
 
 // MARK: - Migration
 private extension HotKeyService {
+    func seedSearchHotKeyIfNeeded() {
+        guard appStorage.object(forKey: Constants.HotKey.searchKeyCombo) == nil else { return }
+        guard
+            let defaultKeyCombo = Self.defaultKeyCombos[Constants.Menu.search] as? [String: Int],
+            let keyCode = defaultKeyCombo["keyCode"],
+            let modifiers = defaultKeyCombo["modifiers"],
+            let keyCombo = KeyCombo(QWERTYKeyCode: keyCode, carbonModifiers: modifiers)
+        else { return }
+
+        appStorage.set(keyCombo.archive(), forKey: Constants.HotKey.searchKeyCombo)
+    }
+
     /**
      *  Migration for changing the storage with v1.1.0
      *  Changed framework, PTHotKey to Magnet

--- a/Clipy/Sources/Services/SearchService.swift
+++ b/Clipy/Sources/Services/SearchService.swift
@@ -46,7 +46,7 @@ final class SearchService: SearchServiceProtocol {
                     includesThumbnailAsset: includesThumbnailAsset,
                     limit: limit
                 )
-                .map { .history($0) }
+                .map { .history(filteredThumbnailAsset(in: $0)) }
         }
 
         let snippets = snippetRepository
@@ -58,9 +58,23 @@ final class SearchService: SearchServiceProtocol {
                 includesThumbnailAsset: includesThumbnailAsset,
                 limit: limit
             )
-            .map { SearchResultItem.history($0) }
+            .map { SearchResultItem.history(filteredThumbnailAsset(in: $0)) }
 
         return Array((snippets + histories).prefix(limit))
+    }
+
+    private func filteredThumbnailAsset(in detail: PasteboardHistoryDetail) -> PasteboardHistoryDetail {
+        let showsImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
+        let showsColorCode = appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+        let thumbnailAsset = detail.thumbnailAsset.flatMap { asset in
+            switch asset.kind {
+            case .image:
+                return showsImage ? asset : nil
+            case .colorCode:
+                return showsColorCode ? asset : nil
+            }
+        }
+        return PasteboardHistoryDetail(history: detail.history, thumbnailAsset: thumbnailAsset)
     }
 }
 

--- a/Clipy/Sources/Services/SearchService.swift
+++ b/Clipy/Sources/Services/SearchService.swift
@@ -1,0 +1,76 @@
+//
+//  SearchService.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Dependencies
+import Sharing
+
+protocol SearchServiceProtocol {
+    func search(query: String, limit: Int) -> [SearchResultItem]
+}
+
+final class SearchService: SearchServiceProtocol {
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
+    @Dependency(\.snippetRepository)
+    private var snippetRepository
+    @Dependency(\.defaultAppStorage)
+    private var appStorage
+
+    /// Searches history and snippets, returning snippets first.
+    ///
+    /// Snippets lead because they are curated by hand and therefore usually the intended target,
+    /// whereas history is a rolling buffer. Within each kind the repository's own ordering is kept
+    /// (relevance for full-text matches, recency for the short-query fallback).
+    ///
+    /// An empty query yields the most recent history, so opening the panel immediately shows
+    /// something useful instead of a blank list.
+    func search(query: String, limit: Int) -> [SearchResultItem] {
+        let includesThumbnailAsset = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
+            || appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+            return pasteboardHistoryRepository
+                .fetchHistoryDetails(
+                    sortsByCreatedAt: !reorderClipsAfterPasting,
+                    includesThumbnailAsset: includesThumbnailAsset,
+                    limit: limit
+                )
+                .map { .history($0) }
+        }
+
+        let snippets = snippetRepository
+            .searchSnippets(matching: query, limit: limit)
+            .map { SearchResultItem.snippet($0) }
+        let histories = pasteboardHistoryRepository
+            .searchHistories(
+                matching: query,
+                includesThumbnailAsset: includesThumbnailAsset,
+                limit: limit
+            )
+            .map { SearchResultItem.history($0) }
+
+        return Array((snippets + histories).prefix(limit))
+    }
+}
+
+extension DependencyValues {
+    var searchService: SearchServiceProtocol {
+        get { self[SearchServiceKey.self] }
+        set { self[SearchServiceKey.self] = newValue }
+    }
+
+    private enum SearchServiceKey: DependencyKey {
+        static let liveValue: any SearchServiceProtocol = SearchService()
+    }
+}

--- a/ClipyTests/Extensions/StringExtensionsTests.swift
+++ b/ClipyTests/Extensions/StringExtensionsTests.swift
@@ -43,4 +43,11 @@ struct StringExtensionsTests {
             #expect("Clipboard title".trimmedMenuTitle == "...")
         }
     }
+
+    @Test
+    func fts5PhraseQueryWrapsAndEscapesQuotes() {
+        #expect("hello".fts5PhraseQuery == "\"hello\"")
+        #expect("hello \"world\"".fts5PhraseQuery == "\"hello \"\"world\"\"\"")
+        #expect("special (query) * - :".fts5PhraseQuery == "\"special (query) * - :\"")
+    }
 }

--- a/ClipyTests/HotKeyServiceTests.swift
+++ b/ClipyTests/HotKeyServiceTests.swift
@@ -22,6 +22,7 @@ final class HotKeyServiceTests {
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
+        #expect(service.searchKeyCombo == nil)
 
         #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
         service.setupDefaultHotKeys()
@@ -44,6 +45,12 @@ final class HotKeyServiceTests {
         #expect(snippetKeyCombo.modifiers == 768)
         #expect(snippetKeyCombo.doubledModifiers == false)
         #expect(snippetKeyCombo.keyEquivalent.uppercased() == "B")
+
+        let searchKeyCombo = try #require(service.searchKeyCombo)
+        #expect(searchKeyCombo.QWERTYKeyCode == 3)
+        #expect(searchKeyCombo.modifiers == 768)
+        #expect(searchKeyCombo.doubledModifiers == false)
+        #expect(searchKeyCombo.keyEquivalent.uppercased() == "F")
     }
 
     @Test
@@ -52,10 +59,12 @@ final class HotKeyServiceTests {
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
+        #expect(service.searchKeyCombo == nil)
 
         let defaultKeyCombos: [String: Any] = [Constants.Menu.clip: ["keyCode": 0, "modifiers": 4352],
                                                Constants.Menu.history: ["keyCode": 9, "modifiers": 768],
-                                               Constants.Menu.snippet: ["keyCode": 11, "modifiers": 4352]]
+                                               Constants.Menu.snippet: ["keyCode": 11, "modifiers": 4352],
+                                               Constants.Menu.search: ["keyCode": 3, "modifiers": 768]]
         appStorage.register(defaults: [Constants.UserDefaults.hotKeys: defaultKeyCombos])
 
         #expect(appStorage.bool(forKey: Constants.HotKey.migrateNewKeyCombo) == false)
@@ -89,27 +98,33 @@ final class HotKeyServiceTests {
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
+        #expect(service.searchKeyCombo == nil)
 
         #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
         #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo) == nil)
         #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo) == nil)
+        #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.searchKeyCombo) == nil)
 
         service.setupDefaultHotKeys()
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
+        #expect(service.searchKeyCombo == nil)
 
         let mainKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 9, carbonModifiers: 768))
         let historyKeyCombo = try #require(KeyCombo(doubledCocoaModifiers: .command))
         let snippetKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 0, cocoaModifiers: .shift))
+        let searchKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 3, carbonModifiers: 768))
 
         service.change(with: .main, keyCombo: mainKeyCombo)
         service.change(with: .history, keyCombo: historyKeyCombo)
         service.change(with: .snippet, keyCombo: snippetKeyCombo)
+        service.change(with: .search, keyCombo: searchKeyCombo)
 
         let savedMainKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo))
         let savedHistoryKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.historyKeyCombo))
         let savedSnippetKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.snippetKeyCombo))
+        let savedSearchKeyCombo = try #require(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.searchKeyCombo))
 
         #expect(savedMainKeyCombo.QWERTYKeyCode == 9)
         #expect(savedMainKeyCombo.modifiers == 768)
@@ -126,6 +141,11 @@ final class HotKeyServiceTests {
         #expect(savedSnippetKeyCombo.doubledModifiers == false)
         #expect(savedSnippetKeyCombo.keyEquivalent.uppercased() == "A")
 
+        #expect(savedSearchKeyCombo.QWERTYKeyCode == 3)
+        #expect(savedSearchKeyCombo.modifiers == 768)
+        #expect(savedSearchKeyCombo.doubledModifiers == false)
+        #expect(savedSearchKeyCombo.keyEquivalent.uppercased() == "F")
+
         service.change(with: .main, keyCombo: nil)
         #expect(service.mainKeyCombo == nil)
         #expect(appStorage.archiveDataForKey(KeyCombo.self, key: Constants.HotKey.mainKeyCombo) == nil)
@@ -138,15 +158,18 @@ final class HotKeyServiceTests {
         let mainKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 9, carbonModifiers: 768))
         let historyKeyCombo = try #require(KeyCombo(doubledCocoaModifiers: .command))
         let snippetKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 0, cocoaModifiers: .shift))
+        let searchKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 3, carbonModifiers: 768))
 
         appStorage.setArchiveData(mainKeyCombo, forKey: Constants.HotKey.mainKeyCombo)
         appStorage.setArchiveData(historyKeyCombo, forKey: Constants.HotKey.historyKeyCombo)
         appStorage.setArchiveData(snippetKeyCombo, forKey: Constants.HotKey.snippetKeyCombo)
+        appStorage.setArchiveData(searchKeyCombo, forKey: Constants.HotKey.searchKeyCombo)
 
         let service = HotKeyService()
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
+        #expect(service.searchKeyCombo == nil)
 
         service.setupDefaultHotKeys()
 
@@ -167,6 +190,12 @@ final class HotKeyServiceTests {
         #expect(savedSnippetKeyCombo.modifiers == shiftKey)
         #expect(savedSnippetKeyCombo.doubledModifiers == false)
         #expect(savedSnippetKeyCombo.keyEquivalent.uppercased() == "A")
+
+        let savedSearchKeyCombo = try #require(service.searchKeyCombo)
+        #expect(savedSearchKeyCombo.QWERTYKeyCode == 3)
+        #expect(savedSearchKeyCombo.modifiers == 768)
+        #expect(savedSearchKeyCombo.doubledModifiers == false)
+        #expect(savedSearchKeyCombo.keyEquivalent.uppercased() == "F")
     }
 
     @Test
@@ -175,6 +204,7 @@ final class HotKeyServiceTests {
         let mainCombos = keyCombos[Constants.Menu.clip] as? [String: Int]
         let historyCombos = keyCombos[Constants.Menu.history] as? [String: Int]
         let snippetCombos = keyCombos[Constants.Menu.snippet] as? [String: Int]
+        let searchCombos = keyCombos[Constants.Menu.search] as? [String: Int]
 
         #expect(mainCombos?["keyCode"] == 9)
         #expect(mainCombos?["modifiers"] == 768)
@@ -184,6 +214,9 @@ final class HotKeyServiceTests {
 
         #expect(snippetCombos?["keyCode"] == 11)
         #expect(snippetCombos?["modifiers"] == 768)
+
+        #expect(searchCombos?["keyCode"] == 3)
+        #expect(searchCombos?["modifiers"] == 768)
     }
 
     @Test

--- a/ClipyTests/HotKeyServiceTests.swift
+++ b/ClipyTests/HotKeyServiceTests.swift
@@ -109,7 +109,11 @@ final class HotKeyServiceTests {
         #expect(service.mainKeyCombo == nil)
         #expect(service.historyKeyCombo == nil)
         #expect(service.snippetKeyCombo == nil)
-        #expect(service.searchKeyCombo == nil)
+        let seededSearchKeyCombo = try #require(service.searchKeyCombo)
+        #expect(seededSearchKeyCombo.QWERTYKeyCode == 3)
+        #expect(seededSearchKeyCombo.modifiers == 768)
+        #expect(seededSearchKeyCombo.doubledModifiers == false)
+        #expect(seededSearchKeyCombo.keyEquivalent.uppercased() == "F")
 
         let mainKeyCombo = try #require(KeyCombo(QWERTYKeyCode: 9, carbonModifiers: 768))
         let historyKeyCombo = try #require(KeyCombo(doubledCocoaModifiers: .command))

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -366,6 +366,30 @@ struct PasteboardHistoryRepositoryTests {
     }
 
     @Test
+    func searchHistoriesWithFTS5QueryOrdersByRecencyBeforeLimit() throws {
+        let content1 = try #require(PasteboardContent("shared token item 1"))
+        let content2 = try #require(PasteboardContent("shared token item 2"))
+        let content3 = try #require(PasteboardContent("shared token item 3"))
+        let content4 = try #require(PasteboardContent("shared token item 4"))
+        let content5 = try #require(PasteboardContent("shared token item 5"))
+
+        let id1 = PasteboardHistory.ID(rawValue: content1.hash)
+        let id2 = PasteboardHistory.ID(rawValue: content2.hash)
+        let id3 = PasteboardHistory.ID(rawValue: content3.hash)
+        let id4 = PasteboardHistory.ID(rawValue: content4.hash)
+        let id5 = PasteboardHistory.ID(rawValue: content5.hash)
+
+        repository.save(id: id1, content: content1, updateAt: 1)
+        repository.save(id: id2, content: content2, updateAt: 2)
+        repository.save(id: id3, content: content3, updateAt: 3)
+        repository.save(id: id4, content: content4, updateAt: 4)
+        repository.save(id: id5, content: content5, updateAt: 5)
+
+        let matches = repository.searchHistories(matching: "shared", includesThumbnailAsset: false, limit: 3)
+        #expect(matches.map(\.history.id) == [id5, id4, id3])
+    }
+
+    @Test
     func searchHistoriesWithLimit() throws {
         for i in 1...5 {
             let content = try #require(PasteboardContent("search_target item \(i)"))

--- a/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
+++ b/ClipyTests/Repositories/PasteboardHistoryRepositoryTests.swift
@@ -299,6 +299,93 @@ struct PasteboardHistoryRepositoryTests {
         repository.deleteOverflowingHistories(sortsByCreatedAt: true, maxHistorySize: 0)
         #expect(!repository.hasHistories())
     }
+
+    @Test
+    func searchHistoriesWithFTS5Query() throws {
+        let textContent = try #require(PasteboardContent("xqa apple item"))
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))
+        )
+        let textID = PasteboardHistory.ID(rawValue: textContent.hash)
+        let imageID = PasteboardHistory.ID(rawValue: imageContent.hash)
+
+        repository.save(id: textID, content: textContent, updateAt: 1)
+        repository.save(id: imageID, content: imageContent, updateAt: 2)
+        repository.updateOCRText(id: imageID, ocrText: "xqa ocr recognized text")
+
+        // Match by title
+        let titleMatches = repository.searchHistories(matching: "xqa apple", includesThumbnailAsset: false, limit: 10)
+        #expect(titleMatches.map(\.history.id).contains(textID))
+
+        // Match by OCR text
+        let ocrMatches = repository.searchHistories(matching: "ocr recognized", includesThumbnailAsset: true, limit: 10)
+        #expect(ocrMatches.map(\.history.id) == [imageID])
+        #expect(ocrMatches.first?.thumbnailAsset?.pasteboardHistoryID == imageID)
+        #expect(ocrMatches.first?.thumbnailAsset?.kind == .image)
+
+        // Non-matching query
+        let noMatches = repository.searchHistories(matching: "zztop", includesThumbnailAsset: false, limit: 10)
+        #expect(noMatches.isEmpty)
+    }
+
+    @Test
+    func searchHistoriesWithShortQueryFallsBackToLIKE() throws {
+        let content1 = try #require(PasteboardContent("ab first item"))
+        let content2 = try #require(PasteboardContent("ac second item"))
+        let content3 = try #require(PasteboardContent("xy third item"))
+        let id1 = PasteboardHistory.ID(rawValue: content1.hash)
+        let id2 = PasteboardHistory.ID(rawValue: content2.hash)
+        let id3 = PasteboardHistory.ID(rawValue: content3.hash)
+
+        repository.save(id: id1, content: content1, updateAt: 1)
+        repository.save(id: id2, content: content2, updateAt: 2)
+        repository.save(id: id3, content: content3, updateAt: 3)
+
+        // 2 characters (below trigram length 3)
+        let matches2Chars = repository.searchHistories(matching: "ab", includesThumbnailAsset: false, limit: 10)
+        #expect(matches2Chars.map(\.history.id) == [id1])
+
+        // 1 character
+        let matches1Char = repository.searchHistories(matching: "a", includesThumbnailAsset: false, limit: 10)
+        #expect(matches1Char.map(\.history.id) == [id2, id1])
+    }
+
+    @Test
+    func searchHistoriesWithSpecialCharacters() throws {
+        let content = try #require(PasteboardContent("test \"quoted\" (special) -hyphen *star:colon"))
+        let id = PasteboardHistory.ID(rawValue: content.hash)
+        repository.save(id: id, content: content, updateAt: 1)
+
+        // Queries with FTS5 special operators/characters must not throw syntax errors
+        #expect(!repository.searchHistories(matching: "\"quoted\"", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(!repository.searchHistories(matching: "(special)", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(!repository.searchHistories(matching: "-hyphen", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(!repository.searchHistories(matching: "*star", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(repository.searchHistories(matching: "\"\"\"\"\"", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(repository.searchHistories(matching: "AND OR NOT", includesThumbnailAsset: false, limit: 10).isEmpty)
+    }
+
+    @Test
+    func searchHistoriesWithLimit() throws {
+        for i in 1...5 {
+            let content = try #require(PasteboardContent("search_target item \(i)"))
+            let id = PasteboardHistory.ID(rawValue: content.hash)
+            repository.save(id: id, content: content, updateAt: i)
+        }
+
+        let limitedMatches = repository.searchHistories(matching: "search_target", includesThumbnailAsset: false, limit: 2)
+        #expect(limitedMatches.count == 2)
+    }
+
+    @Test
+    func searchHistoriesWithEmptyOrWhitespaceQuery() throws {
+        let content = try #require(PasteboardContent("any item"))
+        let id = PasteboardHistory.ID(rawValue: content.hash)
+        repository.save(id: id, content: content, updateAt: 1)
+
+        #expect(repository.searchHistories(matching: "", includesThumbnailAsset: false, limit: 10).isEmpty)
+        #expect(repository.searchHistories(matching: "   \t\n  ", includesThumbnailAsset: false, limit: 10).isEmpty)
+    }
 }
 
 private extension PasteboardContent {

--- a/ClipyTests/Repositories/SnippetRepositoryTests.swift
+++ b/ClipyTests/Repositories/SnippetRepositoryTests.swift
@@ -208,4 +208,122 @@ struct SnippetRepositoryTests {
         #expect(repository.fetchFolderDetail(id: folder.id) == SnippetFolderDetail(folder: folder, snippets: []))
         #expect(repository.fetchSnippet(id: snippet.id) == nil)
     }
+
+    @Test
+    func searchSnippetsWithFTS5Query() throws {
+        let folder = try #require(repository.insertFolder())
+        repository.updateFolderTitle(folder.id, title: "Development")
+
+        let snippet1 = try #require(repository.insertSnippet(to: folder.id))
+        repository.updateSnippetTitle(snippet1.id, title: "xqa function helper")
+        repository.updateSnippetContent(snippet1.id, content: "let a = 1")
+
+        let snippet2 = try #require(repository.insertSnippet(to: folder.id))
+        repository.updateSnippetTitle(snippet2.id, title: "utility script")
+        repository.updateSnippetContent(snippet2.id, content: "nuv package manager")
+
+        // Match by title
+        let titleMatches = repository.searchSnippets(matching: "xqa function", limit: 10)
+        #expect(titleMatches.count == 1)
+        #expect(titleMatches.first?.snippet.id == snippet1.id)
+        #expect(titleMatches.first?.folder.id == folder.id)
+
+        // Match by content
+        let contentMatches = repository.searchSnippets(matching: "nuv package", limit: 10)
+        #expect(contentMatches.count == 1)
+        #expect(contentMatches.first?.snippet.id == snippet2.id)
+        #expect(contentMatches.first?.folder.id == folder.id)
+
+        // Non-matching
+        #expect(repository.searchSnippets(matching: "zztop", limit: 10).isEmpty)
+    }
+
+    @Test
+    func searchSnippetsWithShortQueryFallsBackToLIKE() throws {
+        let folder = try #require(repository.insertFolder())
+        let snippet1 = try #require(repository.insertSnippet(to: folder.id))
+        repository.updateSnippetTitle(snippet1.id, title: "ab title")
+        repository.updateSnippetContent(snippet1.id, content: "content")
+
+        let snippet2 = try #require(repository.insertSnippet(to: folder.id))
+        repository.updateSnippetTitle(snippet2.id, title: "other title")
+        repository.updateSnippetContent(snippet2.id, content: "ac body")
+
+        // 2 characters (below trigram length 3)
+        let matches2Chars = repository.searchSnippets(matching: "ab", limit: 10)
+        #expect(matches2Chars.map(\.snippet.id) == [snippet1.id])
+
+        let matchesContent2Chars = repository.searchSnippets(matching: "ac", limit: 10)
+        #expect(matchesContent2Chars.map(\.snippet.id) == [snippet2.id])
+
+        // 1 character
+        let matches1Char = repository.searchSnippets(matching: "a", limit: 10)
+        #expect(matches1Char.count == 2)
+    }
+
+    @Test
+    func searchSnippetsWithSpecialCharacters() throws {
+        let folder = try #require(repository.insertFolder())
+        let snippet = try #require(repository.insertSnippet(to: folder.id))
+        repository.updateSnippetTitle(snippet.id, title: "test \"quoted\" (special) -hyphen *star:colon")
+
+        #expect(!repository.searchSnippets(matching: "\"quoted\"", limit: 10).isEmpty)
+        #expect(!repository.searchSnippets(matching: "(special)", limit: 10).isEmpty)
+        #expect(!repository.searchSnippets(matching: "-hyphen", limit: 10).isEmpty)
+        #expect(!repository.searchSnippets(matching: "*star", limit: 10).isEmpty)
+        #expect(repository.searchSnippets(matching: "\"\"\"\"\"", limit: 10).isEmpty)
+        #expect(repository.searchSnippets(matching: "AND OR NOT", limit: 10).isEmpty)
+    }
+
+    @Test
+    func searchSnippetsFiltersDisabledSnippetsAndFolders() throws {
+        let enabledFolder = try #require(repository.insertFolder())
+        repository.updateFolderTitle(enabledFolder.id, title: "Enabled Folder")
+
+        let disabledFolder = try #require(repository.insertFolder())
+        repository.updateFolderTitle(disabledFolder.id, title: "Disabled Folder")
+        repository.updateFolderIsEnabled(disabledFolder.id, isEnabled: false)
+
+        // Enabled snippet in enabled folder
+        let validSnippet = try #require(repository.insertSnippet(to: enabledFolder.id))
+        repository.updateSnippetTitle(validSnippet.id, title: "target snippet valid")
+
+        // Disabled snippet in enabled folder
+        let disabledSnippet = try #require(repository.insertSnippet(to: enabledFolder.id))
+        repository.updateSnippetTitle(disabledSnippet.id, title: "target snippet disabled")
+        repository.updateSnippetIsEnabled(disabledSnippet.id, isEnabled: false)
+
+        // Enabled snippet in disabled folder
+        let snippetInDisabledFolder = try #require(repository.insertSnippet(to: disabledFolder.id))
+        repository.updateSnippetTitle(snippetInDisabledFolder.id, title: "target snippet in disabled folder")
+
+        // Search with FTS (3+ chars)
+        let ftsMatches = repository.searchSnippets(matching: "target snippet", limit: 10)
+        #expect(ftsMatches.map(\.snippet.id) == [validSnippet.id])
+
+        // Search with LIKE fallback (< 3 chars)
+        let likeMatches = repository.searchSnippets(matching: "ta", limit: 10)
+        #expect(likeMatches.map(\.snippet.id) == [validSnippet.id])
+    }
+
+    @Test
+    func searchSnippetsWithLimit() throws {
+        let folder = try #require(repository.insertFolder())
+        for i in 1...5 {
+            let snippet = try #require(repository.insertSnippet(to: folder.id))
+            repository.updateSnippetTitle(snippet.id, title: "multi search item \(i)")
+        }
+
+        let matches = repository.searchSnippets(matching: "multi search", limit: 2)
+        #expect(matches.count == 2)
+    }
+
+    @Test
+    func searchSnippetsWithEmptyOrWhitespaceQuery() throws {
+        let folder = try #require(repository.insertFolder())
+        _ = repository.insertSnippet(to: folder.id)
+
+        #expect(repository.searchSnippets(matching: "", limit: 10).isEmpty)
+        #expect(repository.searchSnippets(matching: "   \t\n  ", limit: 10).isEmpty)
+    }
 }

--- a/ClipyTests/Services/SearchServiceTests.swift
+++ b/ClipyTests/Services/SearchServiceTests.swift
@@ -1,0 +1,214 @@
+//
+//  SearchServiceTests.swift
+//
+//  Clipy
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Created by Shunsuke Furubayashi on 2026/08/25.
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+import AppKit
+import Dependencies
+import DependenciesTestSupport
+import SQLiteData
+import Testing
+@testable import Clipy
+
+@MainActor
+@Suite(
+    .dependencies {
+        try $0.bootstrapDatabase()
+    }
+)
+struct SearchServiceTests {
+    @Dependency(\.defaultAppStorage)
+    var appStorage
+    let service: SearchService
+    let historyRepository: PasteboardHistoryRepository
+    let snippetRepository: SnippetRepository
+
+    init() {
+        let historyRepository = PasteboardHistoryRepository()
+        let snippetRepository = SnippetRepository()
+        self.historyRepository = historyRepository
+        self.snippetRepository = snippetRepository
+        self.service = withDependencies {
+            $0.pasteboardHistoryRepository = historyRepository
+            $0.snippetRepository = snippetRepository
+        } operation: {
+            SearchService()
+        }
+    }
+
+    @Test
+    func searchReturnsSnippetsBeforeHistories() throws {
+        let content = try #require(PasteboardContent("search_keyword history item"))
+        let historyID = PasteboardHistory.ID(rawValue: content.hash)
+        historyRepository.save(id: historyID, content: content, updateAt: 1)
+
+        let folder = try #require(snippetRepository.insertFolder())
+        let snippet = try #require(snippetRepository.insertSnippet(to: folder.id))
+        snippetRepository.updateSnippetTitle(snippet.id, title: "search_keyword snippet item")
+
+        let results = service.search(query: "search_keyword", limit: 10)
+
+        #expect(results.count == 2)
+        guard results.count == 2 else { return }
+
+        switch results[0] {
+        case .snippet(let match):
+            #expect(match.snippet.id == snippet.id)
+        case .history:
+            Issue.record("Expected first item to be a snippet")
+        }
+
+        switch results[1] {
+        case .history(let detail):
+            #expect(detail.history.id == historyID)
+        case .snippet:
+            Issue.record("Expected second item to be a history")
+        }
+    }
+
+    @Test
+    func searchWithEmptyQueryReturnsRecentHistories() throws {
+        let content1 = try #require(PasteboardContent("First History"))
+        let content2 = try #require(PasteboardContent("Second History"))
+        let content3 = try #require(PasteboardContent("Third History"))
+        let id1 = PasteboardHistory.ID(rawValue: content1.hash)
+        let id2 = PasteboardHistory.ID(rawValue: content2.hash)
+        let id3 = PasteboardHistory.ID(rawValue: content3.hash)
+
+        historyRepository.save(id: id1, content: content1, updateAt: 1)
+        historyRepository.save(id: id2, content: content2, updateAt: 2)
+        historyRepository.save(id: id3, content: content3, updateAt: 3)
+
+        let folder = try #require(snippetRepository.insertFolder())
+        _ = snippetRepository.insertSnippet(to: folder.id)
+
+        // Empty query should return recent histories only (no snippets)
+        let emptyResults = service.search(query: "", limit: 10)
+        #expect(emptyResults.count == 3)
+        #expect(emptyResults.map(\.id) == ["history:\(id3.rawValue)", "history:\(id2.rawValue)", "history:\(id1.rawValue)"])
+
+        // Whitespace-only query should also return recent histories
+        let whitespaceResults = service.search(query: "   \t\n  ", limit: 10)
+        #expect(whitespaceResults.count == 3)
+    }
+
+    @Test
+    func searchResultItemProperties() throws {
+        let content = try #require(PasteboardContent("History Title"))
+        let historyID = PasteboardHistory.ID(rawValue: content.hash)
+        historyRepository.save(id: historyID, content: content, updateAt: 1)
+
+        let folder = try #require(snippetRepository.insertFolder())
+        snippetRepository.updateFolderTitle(folder.id, title: "Snippets Group")
+        let snippet = try #require(snippetRepository.insertSnippet(to: folder.id))
+        snippetRepository.updateSnippetTitle(snippet.id, title: "Snippet Title")
+
+        let historyDetail = try #require(historyRepository.fetchHistoryDetails(sortsByCreatedAt: false, includesThumbnailAsset: false, limit: 1).first)
+        let updatedFolder = try #require(snippetRepository.fetchFolderDetail(id: folder.id)?.folder)
+        let updatedSnippet = try #require(snippetRepository.fetchSnippet(id: snippet.id))
+        let snippetMatch = SnippetSearchMatch(snippet: updatedSnippet, folder: updatedFolder)
+
+        let historyItem = SearchResultItem.history(historyDetail)
+        #expect(historyItem.id == "history:\(historyID.rawValue)")
+        #expect(historyItem.title == "History Title")
+        #expect(!historyItem.subtitle.isEmpty)
+        #expect(historyItem.thumbnailImage == nil)
+
+        let snippetItem = SearchResultItem.snippet(snippetMatch)
+        #expect(snippetItem.id == "snippet:\(snippet.id.rawValue.uuidString)")
+        #expect(snippetItem.title == "Snippet Title")
+        #expect(snippetItem.subtitle == "Snippets Group")
+        #expect(snippetItem.thumbnailImage == nil)
+    }
+
+    @Test
+    func searchRespectsLimitAcrossCombinedResults() throws {
+        for i in 1...5 {
+            let content = try #require(PasteboardContent("combined_query history \(i)"))
+            let id = PasteboardHistory.ID(rawValue: content.hash)
+            historyRepository.save(id: id, content: content, updateAt: i)
+        }
+
+        let folder = try #require(snippetRepository.insertFolder())
+        for i in 1...5 {
+            let snippet = try #require(snippetRepository.insertSnippet(to: folder.id))
+            snippetRepository.updateSnippetTitle(snippet.id, title: "combined_query snippet \(i)")
+        }
+
+        let results = service.search(query: "combined_query", limit: 4)
+        #expect(results.count == 4)
+        // All 4 should be snippets since 5 snippets exist and snippets are returned first
+        #expect(results.allSatisfy { item in
+            if case .snippet = item { return true }
+            return false
+        })
+    }
+
+    @Test
+    func searchIncludesThumbnailAssetsWhenEnabled() throws {
+        let imageContent = try #require(
+            PasteboardContent(image: NSImage.create(with: .blue, size: NSSize(width: 20, height: 20)))
+        )
+        let imageID = PasteboardHistory.ID(rawValue: imageContent.hash)
+        historyRepository.save(id: imageID, content: imageContent, updateAt: 1)
+        historyRepository.updateOCRText(id: imageID, ocrText: "image_search_tag")
+
+        // Without showImageInTheMenu
+        appStorage.set(false, forKey: Constants.UserDefaults.showImageInTheMenu)
+        appStorage.set(false, forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+
+        let resultsWithoutThumbnail = service.search(query: "image_search_tag", limit: 10)
+        #expect(resultsWithoutThumbnail.count == 1)
+        #expect(resultsWithoutThumbnail.first?.thumbnailImage == nil)
+
+        // With showImageInTheMenu enabled
+        appStorage.set(true, forKey: Constants.UserDefaults.showImageInTheMenu)
+
+        let resultsWithThumbnail = service.search(query: "image_search_tag", limit: 10)
+        #expect(resultsWithThumbnail.count == 1)
+        #expect(resultsWithThumbnail.first?.thumbnailImage != nil)
+    }
+
+    @Test
+    func searchWithEmptyQueryRespectsReorderClipsAfterPasting() throws {
+        let content1 = try #require(PasteboardContent("First Item"))
+        let content2 = try #require(PasteboardContent("Second Item"))
+        let id1 = PasteboardHistory.ID(rawValue: content1.hash)
+        let id2 = PasteboardHistory.ID(rawValue: content2.hash)
+
+        // id1 created at 1, updated at 4
+        // id2 created at 2, updated at 2
+        historyRepository.save(id: id1, content: content1, updateAt: 1)
+        historyRepository.save(id: id2, content: content2, updateAt: 2)
+        historyRepository.save(id: id1, content: content1, updateAt: 4)
+
+        // reorderClipsAfterPasting = true -> sorts by updateAt desc -> [id1, id2]
+        appStorage.set(true, forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+        let resultsByUpdate = service.search(query: "", limit: 10)
+        #expect(resultsByUpdate.map(\.id) == ["history:\(id1.rawValue)", "history:\(id2.rawValue)"])
+
+        // reorderClipsAfterPasting = false -> sorts by createdAt desc -> [id2, id1]
+        appStorage.set(false, forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+        let resultsByCreate = service.search(query: "", limit: 10)
+        #expect(resultsByCreate.map(\.id) == ["history:\(id2.rawValue)", "history:\(id1.rawValue)"])
+    }
+}
+
+private extension PasteboardContent {
+    init?(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            return nil
+        }
+        guard let content = PasteboardContent(assets: [PasteboardContent.Asset(type: .string, data: data)]) else {
+            return nil
+        }
+        self = content
+    }
+}

--- a/ClipyTests/Services/SearchServiceTests.swift
+++ b/ClipyTests/Services/SearchServiceTests.swift
@@ -174,6 +174,26 @@ struct SearchServiceTests {
         let resultsWithThumbnail = service.search(query: "image_search_tag", limit: 10)
         #expect(resultsWithThumbnail.count == 1)
         #expect(resultsWithThumbnail.first?.thumbnailImage != nil)
+
+        let colorContent = try #require(
+            PasteboardContent(assets: [
+                .init(type: .string, data: Data("#ff0000".utf8))
+            ])
+        )
+        let colorID = PasteboardHistory.ID(rawValue: colorContent.hash)
+        historyRepository.save(id: colorID, content: colorContent, updateAt: 2)
+        historyRepository.updateOCRText(id: colorID, ocrText: "color_search_tag")
+
+        let imageOnlyColorResults = service.search(query: "color_search_tag", limit: 10)
+        #expect(imageOnlyColorResults.count == 1)
+        #expect(imageOnlyColorResults.first?.thumbnailImage == nil)
+
+        appStorage.set(false, forKey: Constants.UserDefaults.showImageInTheMenu)
+        appStorage.set(true, forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+
+        let colorResults = service.search(query: "color_search_tag", limit: 10)
+        #expect(colorResults.count == 1)
+        #expect(colorResults.first?.thumbnailImage != nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add search functionality for clipboard history and snippets
- Introduce a dedicated search panel and result views
- Add keyboard shortcut support for opening search
- Add localized strings and update related preferences
- Add unit tests for the search service and related behavior

## Implementation Details

- Search clipboard history and snippets using a shared search service
- Display results in a dedicated search panel
- Register the new source files in the Xcode project
- Preserve existing pasteboard and snippet workflows

## Testing

- Added `SearchServiceTests`
- Updated repository, hotkey, and string extension tests
- Manual verification of the search panel and keyboard shortcut

https://github.com/user-attachments/assets/28514a38-e7a8-4032-a32f-84dcf23485a8