### PR TITLE
Add global shortcut for editing snippets

### DIFF
--- a/Clipy/Sources/AppStorage/AppStorageKeys.swift
+++ b/Clipy/Sources/AppStorage/AppStorageKeys.swift
@@ -17,6 +17,7 @@ enum AppStorageKeys: String {
     case mainKeyCombo
     case historyKeyCombo
     case snippetKeyCombo
+    case editSnippetsKeyCombo
     case clearHistoryKeyCombo
     case folderKeyCombos
 }

--- a/Clipy/Sources/AppStorage/AppStorageValues.swift
+++ b/Clipy/Sources/AppStorage/AppStorageValues.swift
@@ -47,6 +47,10 @@ extension SharedKey where Self == AppStorageKey<KeyCombo?>.Default {
         ]
     }
 
+    static var editSnippetsKeyCombo: Self {
+        Self[.appStorage(AppStorageKeys.editSnippetsKeyCombo.rawValue), default: nil]
+    }
+
     static var clearHistoryKeyCombo: Self {
         Self[.appStorage(AppStorageKeys.clearHistoryKeyCombo.rawValue), default: nil]
     }

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
@@ -8,6 +8,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="CPYShortcutsPreferenceViewController" customModule="Clipy" customModuleProvider="target">
             <connections>
                 <outlet property="clearHistoryShortcutRecordView" destination="pCf-EG-Cp9" id="K22-8R-Gk9"/>
+                <outlet property="editSnippetsShortcutRecordView" destination="EdS-Rc-Vw1" id="EdS-Ou-T01"/>
                 <outlet property="historyShortcutRecordView" destination="hDA-gc-n3S" id="fzg-O8-Fze"/>
                 <outlet property="mainShortcutRecordView" destination="ABK-GW-Xwm" id="Jr7-Dz-hqZ"/>
                 <outlet property="snippetShortcutRecordView" destination="q8v-jS-CAr" id="Ay0-Zr-azr"/>
@@ -17,11 +18,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="275"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="323"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="5oP-dg-DwL">
-                    <rect key="frame" x="59" y="244" width="210" height="17"/>
+                    <rect key="frame" x="59" y="292" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Menu" id="X5L-5V-1eH">
                         <font key="font" metaFont="systemBold"/>
@@ -30,11 +31,11 @@
                     </textFieldCell>
                 </textField>
                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uTq-IP-dYk">
-                    <rect key="frame" x="44" y="96" width="392" height="140"/>
+                    <rect key="frame" x="44" y="96" width="392" height="188"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vzz-Iq-77h">
-                            <rect key="frame" x="15" y="62" width="121" height="17"/>
+                            <rect key="frame" x="15" y="110" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="History:" id="Abl-cO-JwU">
                                 <font key="font" metaFont="system"/>
@@ -43,7 +44,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oYq-Bg-KGQ">
-                            <rect key="frame" x="15" y="109" width="121" height="17"/>
+                            <rect key="frame" x="15" y="157" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Main:" id="5sL-G8-1io">
                                 <font key="font" metaFont="system"/>
@@ -52,7 +53,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ixj-RO-bKW">
-                            <rect key="frame" x="15" y="13" width="121" height="17"/>
+                            <rect key="frame" x="15" y="61" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Snippets:" id="fXr-ry-5ds">
                                 <font key="font" metaFont="system"/>
@@ -61,7 +62,7 @@
                             </textFieldCell>
                         </textField>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ABK-GW-Xwm" customClass="RecordView" customModule="KeyHolder">
-                            <rect key="frame" x="142" y="101" width="250" height="34"/>
+                            <rect key="frame" x="142" y="149" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
@@ -82,7 +83,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hDA-gc-n3S" customClass="RecordView" customModule="KeyHolder">
-                            <rect key="frame" x="142" y="53" width="250" height="34"/>
+                            <rect key="frame" x="142" y="101" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -100,6 +101,33 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q8v-jS-CAr" customClass="RecordView" customModule="KeyHolder">
+                            <rect key="frame" x="142" y="53" width="250" height="34"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="17"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
+                                    <color key="value" red="0.1647058824" green="0.51764705879999995" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                    <color key="value" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                    <real key="value" value="1"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </customView>
+                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EdS-Lb-L01">
+                            <rect key="frame" x="15" y="13" width="121" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Edit Snippets:" id="EdS-Lb-C01">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" red="0.26666666666666666" green="0.26666666666666666" blue="0.26666666666666666" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EdS-Rc-Vw1" customClass="RecordView" customModule="KeyHolder">
                             <rect key="frame" x="142" y="5" width="250" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <userDefinedRuntimeAttributes>

--- a/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
@@ -22,6 +22,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     @IBOutlet private weak var mainShortcutRecordView: RecordView!
     @IBOutlet private weak var historyShortcutRecordView: RecordView!
     @IBOutlet private weak var snippetShortcutRecordView: RecordView!
+    @IBOutlet private weak var editSnippetsShortcutRecordView: RecordView!
     @IBOutlet private weak var clearHistoryShortcutRecordView: RecordView!
 
     @Dependency(\.hotKeyService)
@@ -32,6 +33,8 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     private var historyKeyCombo
     @Shared(.snippetKeyCombo)
     private var snippetKeyCombo
+    @Shared(.editSnippetsKeyCombo)
+    private var editSnippetsKeyCombo
     @Shared(.clearHistoryKeyCombo)
     private var clearHistoryKeyCombo
 
@@ -41,6 +44,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
         mainShortcutRecordView.delegate = self
         historyShortcutRecordView.delegate = self
         snippetShortcutRecordView.delegate = self
+        editSnippetsShortcutRecordView.delegate = self
         clearHistoryShortcutRecordView.delegate = self
         prepareHotKeys()
     }
@@ -53,6 +57,7 @@ private extension CPYShortcutsPreferenceViewController {
         mainShortcutRecordView.keyCombo = mainKeyCombo
         historyShortcutRecordView.keyCombo = historyKeyCombo
         snippetShortcutRecordView.keyCombo = snippetKeyCombo
+        editSnippetsShortcutRecordView.keyCombo = editSnippetsKeyCombo
         clearHistoryShortcutRecordView.keyCombo = clearHistoryKeyCombo
     }
 }
@@ -75,6 +80,8 @@ extension CPYShortcutsPreferenceViewController: RecordViewDelegate {
             hotKeyService.change(with: .history, keyCombo: keyCombo)
         case snippetShortcutRecordView:
             hotKeyService.change(with: .snippet, keyCombo: keyCombo)
+        case editSnippetsShortcutRecordView:
+            hotKeyService.changeEditSnippetsKeyCombo(keyCombo)
         case clearHistoryShortcutRecordView:
             hotKeyService.changeClearHistoryKeyCombo(keyCombo)
         default: break

--- a/Clipy/Sources/Preferences/Panels/de.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/de.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "Snippets:";
+
+/* Class = "NSTextFieldCell"; title = "Edit Snippets:"; ObjectID = "EdS-Lb-C01"; */
+"EdS-Lb-C01.title" = "Snippets bearbeiten:";

--- a/Clipy/Sources/Preferences/Panels/it.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/it.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Clear History:"; ObjectID = "f3b-Ht-X5w"; */
 "f3b-Ht-X5w.title" = "Svuota:";
+
+/* Class = "NSTextFieldCell"; title = "Edit Snippets:"; ObjectID = "EdS-Lb-C01"; */
+"EdS-Lb-C01.title" = "Modifica snippet:";

--- a/Clipy/Sources/Preferences/Panels/ja.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/ja.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Clear History:"; ObjectID = "f3b-Ht-X5w"; */
 "f3b-Ht-X5w.title" = "履歴をクリア:";
+
+/* Class = "NSTextFieldCell"; title = "Edit Snippets:"; ObjectID = "EdS-Lb-C01"; */
+"EdS-Lb-C01.title" = "スニペットを編集:";

--- a/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/pt-BR.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "Snippets:";
+
+/* Class = "NSTextFieldCell"; title = "Edit Snippets:"; ObjectID = "EdS-Lb-C01"; */
+"EdS-Lb-C01.title" = "Editar Snippets:";

--- a/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYShortcutsPreferenceViewController.strings
+++ b/Clipy/Sources/Preferences/Panels/zh-Hans.lproj/CPYShortcutsPreferenceViewController.strings
@@ -16,3 +16,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Snippets:"; ObjectID = "fXr-ry-5ds"; */
 "fXr-ry-5ds.title" = "片断：";
+
+/* Class = "NSTextFieldCell"; title = "Edit Snippets:"; ObjectID = "EdS-Lb-C01"; */
+"EdS-Lb-C01.title" = "编辑片断：";

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -33,6 +33,8 @@ final class HotKeyService: NSObject {
     private var historyKeyCombo
     @Shared(.snippetKeyCombo)
     private var snippetKeyCombo
+    @Shared(.editSnippetsKeyCombo)
+    private var editSnippetsKeyCombo
     @Shared(.clearHistoryKeyCombo)
     private var clearHistoryKeyCombo
     @Shared(.folderKeyCombos)
@@ -51,6 +53,8 @@ extension HotKeyService {
         change(with: .history, keyCombo: historyKeyCombo)
         // Snippet menu
         change(with: .snippet, keyCombo: snippetKeyCombo)
+        // Edit Snippets
+        changeEditSnippetsKeyCombo(editSnippetsKeyCombo)
         // Clear History
         changeClearHistoryKeyCombo(clearHistoryKeyCombo)
     }
@@ -83,6 +87,19 @@ extension HotKeyService {
         guard let keyCombo = keyCombo else { return }
         let hotkey = HotKey(identifier: "ClearHistory", keyCombo: keyCombo) { [weak self] _ in
             self?.clipService.clearAllHistory()
+        }
+        hotkey.register()
+    }
+
+    func changeEditSnippetsKeyCombo(_ keyCombo: KeyCombo?) {
+        $editSnippetsKeyCombo.withLock { $0 = keyCombo }
+        // Reset hotkey
+        HotKeyCenter.shared.unregisterHotKey(with: "EditSnippets")
+        // Register new hotkey
+        guard let keyCombo = keyCombo else { return }
+        let hotkey = HotKey(identifier: "EditSnippets", keyCombo: keyCombo) { _ in
+            guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
+            appDelegate.showSnippetEditorWindow()
         }
         hotkey.register()
     }

--- a/ClipyTests/AppStorage/AppStorageValuesTests.swift
+++ b/ClipyTests/AppStorage/AppStorageValuesTests.swift
@@ -29,6 +29,7 @@ struct AppStorageValuesTests {
         @Shared(.mainKeyCombo) var mainKeyCombo
         @Shared(.historyKeyCombo) var historyKeyCombo
         @Shared(.snippetKeyCombo) var snippetKeyCombo
+        @Shared(.editSnippetsKeyCombo) var editSnippetsKeyCombo
         @Shared(.clearHistoryKeyCombo) var clearHistoryKeyCombo
         @Shared(.folderKeyCombos) var folderKeyCombos
 
@@ -44,6 +45,7 @@ struct AppStorageValuesTests {
         #expect(defaultSnippetKeyCombo.QWERTYKeyCode == 11)
         #expect(defaultSnippetKeyCombo.modifiers == 768)
 
+        #expect(editSnippetsKeyCombo == nil)
         #expect(clearHistoryKeyCombo == nil)
         #expect(folderKeyCombos.isEmpty)
     }

--- a/ClipyTests/HotKeyServiceTests.swift
+++ b/ClipyTests/HotKeyServiceTests.swift
@@ -12,6 +12,7 @@ final class HotKeyServiceTests {
     @Shared(.mainKeyCombo) var mainKeyCombo
     @Shared(.historyKeyCombo) var historyKeyCombo
     @Shared(.snippetKeyCombo) var snippetKeyCombo
+    @Shared(.editSnippetsKeyCombo) var editSnippetsKeyCombo
     @Shared(.clearHistoryKeyCombo) var clearHistoryKeyCombo
     @Shared(.folderKeyCombos) var folderKeyCombos
 
@@ -56,5 +57,22 @@ final class HotKeyServiceTests {
 
         service.changeClearHistoryKeyCombo(nil)
         #expect(clearHistoryKeyCombo == nil)
+    }
+
+    @Test
+    func addAndRemoveEditSnippetsHotkey() throws {
+        let service = HotKeyService()
+
+        #expect(editSnippetsKeyCombo == nil)
+
+        service.changeEditSnippetsKeyCombo(KeyCombo(QWERTYKeyCode: 14, carbonModifiers: cmdKey))
+
+        #expect(editSnippetsKeyCombo?.QWERTYKeyCode == 14)
+        #expect(editSnippetsKeyCombo?.modifiers == cmdKey)
+        #expect(editSnippetsKeyCombo?.doubledModifiers == false)
+        #expect(editSnippetsKeyCombo?.keyEquivalent.uppercased() == "E")
+
+        service.changeEditSnippetsKeyCombo(nil)
+        #expect(editSnippetsKeyCombo == nil)
     }
 }


### PR DESCRIPTION
## Summary

Add a configurable global shortcut for opening the existing Edit Snippets window.

The shortcut is available in Preferences → Shortcuts and uses the same behavior as the existing “Edit Snippets...” menu item.

## Changes

- Add a new Edit Snippets shortcut setting
- Persist the shortcut using the current AppStorage/Shared storage system
- Register and unregister the global hotkey through HotKeyService
- Add the new shortcut row to the Shortcuts preference panel
- Add tests for the new shortcut storage and registration behavior
- Add localization for the new shortcut label in:
  - German
  - Italian
  - Japanese
  - Portuguese (Brazil)
  - Simplified Chinese

## Verification

- Verified manually that the configured global shortcut opens the existing Edit Snippets window from another application
- Targeted HotKeyService tests passed before rebasing onto the latest develop branch
- Full test suite passed before rebasing onto the latest develop branch

After rebasing onto the latest develop branch, local xcodebuild test execution is currently blocked during package resolution by the existing sqlite-data trait configuration (`Tagged` vs `SQLiteDataTagged`).