### PR TITLE
Add clipboard history search to menus

### DIFF
--- a/Clipy/Resources/Localizable.xcstrings
+++ b/Clipy/Resources/Localizable.xcstrings
@@ -571,6 +571,40 @@
         }
       }
     },
+    "No Matching Clipboard Items" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine passenden Zwischenablageeinträge"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun elemento corrispondente negli appunti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一致するクリップボード項目がありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum item correspondente na área de transferência"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的剪贴板项目"
+          }
+        }
+      }
+    },
     "Preferences" : {
       "localizations" : {
         "de" : {
@@ -641,6 +675,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "退出 Clipy"
+          }
+        }
+      }
+    },
+    "Search Clipboard History" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischenablageverlauf durchsuchen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca nella cronologia degli appunti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボード履歴を検索"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar no histórico da área de transferência"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索剪贴板历史"
           }
         }
       }

--- a/Clipy/Sources/Extensions/NSMenu+Highlight.swift
+++ b/Clipy/Sources/Extensions/NSMenu+Highlight.swift
@@ -15,8 +15,21 @@ import AppKit
 /// Uses a private NSMenu API to highlight the first selectable item by default.
 /// ref: https://kazakov.life/2017/05/18/hacking-nsmenu-keyboard-navigation/
 extension NSMenu {
+    func addSearchField() -> NSSearchField {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 340, height: 34))
+        let searchField = NSSearchField(frame: NSRect(x: 8, y: 4, width: 324, height: 26))
+        searchField.autoresizingMask = [.width]
+        searchField.placeholderString = String(localized: "Search Clipboard History")
+        container.addSubview(searchField)
+
+        let item = NSMenuItem()
+        item.view = container
+        addItem(item)
+        return searchField
+    }
+
     func highlightingFirstItemIfPossible() {
-        guard let firstItem = items.first(where: { !$0.isSeparatorItem && !$0.isHidden && $0.isEnabled }) else { return }
+        guard let firstItem = items.first(where: { !$0.isSeparatorItem && !$0.isHidden && $0.isEnabled && $0.view == nil }) else { return }
 
         let selector = Selector(("highlightItem:"))
         guard responds(to: selector) else { return }

--- a/Clipy/Sources/Extensions/PasteboardHistoryExtensions.swift
+++ b/Clipy/Sources/Extensions/PasteboardHistoryExtensions.swift
@@ -15,6 +15,16 @@ import Dependencies
 import Sharing
 
 extension PasteboardHistory {
+    func matchesSearch(_ query: String) -> Bool {
+        let searchableText = [title, ocrText]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        let terms = query.split(whereSeparator: \.isWhitespace)
+        return terms.allSatisfy {
+            searchableText.range(of: String($0), options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        }
+    }
+
     var typedTitle: String {
         let primaryType = pasteboardTypes.first
         let prefix: String?

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -16,24 +16,23 @@ import Dependencies
 import RxCocoa
 import RxSwift
 
-final class MenuManager: NSObject {
-
+final class MenuManager: NSObject, NSSearchFieldDelegate, NSMenuDelegate {
     // MARK: - Properties
-    // Menus
     private var clipMenu: NSMenu?
     private var historyMenu: NSMenu?
     private var snippetMenu: NSMenu?
-    // StatusMenu
+    private weak var openMenu: NSMenu?
+    private var needsMenuRebuild = false
+    private var clipSearchField: NSSearchField?
+    private var historySearchField: NSSearchField?
     private lazy var statusBarItem: NSStatusItem = {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.toolTip = "\(Constants.Application.name)\(Bundle.main.appVersion ?? "")"
         item.menu = clipMenu
         return item
     }()
-    // Icon Cache
     private let folderIcon = NSImage(resource: .iconFolder)
     private let snippetIcon = NSImage(resource: .iconText)
-    // Other
     private let disposeBag = DisposeBag()
     private let kMaxKeyEquivalents = 10
 
@@ -46,6 +45,7 @@ final class MenuManager: NSObject {
     @Dependency(\.defaultAppStorage)
     private var appStorage
     private var cancellables: Set<AnyCancellable> = []
+    private var historyDetails = [PasteboardHistoryDetail]()
     private var snippetFolderDetails = [SnippetFolderDetail]()
 
     // MARK: - Enum Values
@@ -66,6 +66,32 @@ final class MenuManager: NSObject {
         bind()
     }
 
+    func controlTextDidChange(_ notification: Notification) {
+        guard let searchField = notification.object as? NSSearchField else { return }
+        if searchField === clipSearchField, let clipMenu {
+            rebuildClipMenu(clipMenu, query: searchField.stringValue)
+        } else if searchField === historySearchField, let historyMenu {
+            rebuildHistoryMenu(historyMenu, query: searchField.stringValue)
+        }
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        guard let searchField = searchField(for: menu) else { return }
+        openMenu = menu
+        searchField.stringValue = ""
+        rebuildSearchableMenu(menu, query: "")
+        RunLoop.current.perform(inModes: [.eventTracking]) { [weak searchField] in
+            searchField?.window?.makeFirstResponder(searchField)
+        }
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        searchField(for: menu)?.stringValue = ""
+        openMenu = nil
+        guard needsMenuRebuild else { return }
+        needsMenuRebuild = false
+        createClipMenu()
+    }
 }
 
 // MARK: - Popup Menu
@@ -174,29 +200,78 @@ private extension MenuManager {
 
 // MARK: - Menus
 private extension MenuManager {
-     func createClipMenu() {
+    func createClipMenu() {
+        guard openMenu == nil else {
+            needsMenuRebuild = true
+            return
+        }
         clipMenu = NSMenu(title: Constants.Application.name)
         historyMenu = NSMenu(title: Constants.Menu.history)
         snippetMenu = NSMenu(title: Constants.Menu.snippet)
 
-        addHistoryItems(clipMenu!)
-        addHistoryItems(historyMenu!)
-
-        addSnippetItems(clipMenu!, separateMenu: true, details: snippetFolderDetails)
+        historyDetails = fetchHistoryDetails()
+        clipSearchField = clipMenu?.addSearchField()
+        clipSearchField?.delegate = self
+        clipMenu?.delegate = self
+        historySearchField = historyMenu?.addSearchField()
+        historySearchField?.delegate = self
+        historyMenu?.delegate = self
+        rebuildClipMenu(clipMenu!, query: "")
+        rebuildHistoryMenu(historyMenu!, query: "")
         addSnippetItems(snippetMenu!, separateMenu: false, details: snippetFolderDetails)
 
-        clipMenu?.addItem(NSMenuItem.separator())
+        statusBarItem.menu = clipMenu
+    }
 
-        if appStorage.bool(forKey: Constants.UserDefaults.addClearHistoryMenuItem) {
-            clipMenu?.addItem(NSMenuItem(title: String(localized: "Clear History"), action: #selector(AppDelegate.clearAllHistory)))
+    func rebuildSearchableMenu(_ menu: NSMenu, query: String) {
+        if menu === clipMenu {
+            rebuildClipMenu(menu, query: query)
+        } else if menu === historyMenu {
+            rebuildHistoryMenu(menu, query: query)
+        }
+    }
+
+    func rebuildClipMenu(_ menu: NSMenu, query: String) {
+        removeItemsAfterSearchField(from: menu)
+        addHistoryItems(menu, query: query)
+        guard query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            menu.highlightingFirstItemIfPossible()
+            return
         }
 
-        clipMenu?.addItem(NSMenuItem(title: String(localized: "Edit Snippets"), action: #selector(AppDelegate.showSnippetEditorWindow)))
-        clipMenu?.addItem(NSMenuItem(title: String(localized: "Preferences"), action: #selector(AppDelegate.showPreferenceWindow)))
-        clipMenu?.addItem(NSMenuItem.separator())
-        clipMenu?.addItem(NSMenuItem(title: String(localized: "Quit Clipy"), action: #selector(AppDelegate.terminate)))
+        addSnippetItems(menu, separateMenu: true, details: snippetFolderDetails)
+        menu.addItem(NSMenuItem.separator())
+        if appStorage.bool(forKey: Constants.UserDefaults.addClearHistoryMenuItem) {
+            menu.addItem(NSMenuItem(title: String(localized: "Clear History"), action: #selector(AppDelegate.clearAllHistory)))
+        }
+        menu.addItem(NSMenuItem(title: String(localized: "Edit Snippets"), action: #selector(AppDelegate.showSnippetEditorWindow)))
+        menu.addItem(NSMenuItem(title: String(localized: "Preferences"), action: #selector(AppDelegate.showPreferenceWindow)))
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(NSMenuItem(title: String(localized: "Quit Clipy"), action: #selector(AppDelegate.terminate)))
+    }
 
-        statusBarItem.menu = clipMenu
+    func rebuildHistoryMenu(_ menu: NSMenu, query: String) {
+        removeItemsAfterSearchField(from: menu)
+        addHistoryItems(menu, query: query)
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            menu.highlightingFirstItemIfPossible()
+        }
+    }
+
+    func removeItemsAfterSearchField(from menu: NSMenu) {
+        while menu.numberOfItems > 1 {
+            menu.removeItem(at: 1)
+        }
+    }
+
+    func searchField(for menu: NSMenu) -> NSSearchField? {
+        if menu === clipMenu {
+            return clipSearchField
+        }
+        if menu === historyMenu {
+            return historySearchField
+        }
+        return nil
     }
 
     func makeSubmenuItem(_ count: Int, start: Int, end: Int, numberOfItems: Int) -> NSMenuItem {
@@ -228,10 +303,10 @@ private extension MenuManager {
 
 // MARK: - Clips
 private extension MenuManager {
-    func addHistoryItems(_ menu: NSMenu) {
+    func addHistoryItems(_ menu: NSMenu, query: String) {
         let placeInLine = appStorage.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInline)
         let placeInsideFolder = appStorage.integer(forKey: Constants.UserDefaults.numberOfItemsPlaceInsideFolder)
-        let maxHistory = appStorage.integer(forKey: Constants.UserDefaults.maxHistorySize)
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // History title
         let labelItem = NSMenuItem(title: String(localized: "History"), action: nil)
@@ -242,29 +317,32 @@ private extension MenuManager {
         let firstIndex = firstIndexOfMenuItems()
         var listNumber = firstIndex
         var subMenuCount = placeInLine
-        var subMenuIndex = 1 + placeInLine
+        var currentSubMenu: NSMenu?
 
-        let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
-        let isShowImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
-        let isShowColorCode = appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
-        let historyDetails = pasteboardHistoryRepository.fetchHistoryDetails(
-            sortsByCreatedAt: !reorderClipsAfterPasting,
-            includesThumbnailAsset: isShowImage || isShowColorCode,
-            limit: maxHistory
-        )
-        let currentSize = historyDetails.count
+        let filteredHistoryDetails = normalizedQuery.isEmpty
+            ? historyDetails
+            : historyDetails.filter { $0.history.matchesSearch(normalizedQuery) }
+        if filteredHistoryDetails.isEmpty, !normalizedQuery.isEmpty {
+            let noMatchesItem = NSMenuItem(title: String(localized: "No Matching Clipboard Items"), action: nil)
+            noMatchesItem.isEnabled = false
+            menu.addItem(noMatchesItem)
+            return
+        }
+
+        let currentSize = filteredHistoryDetails.count
         var i = 0
-        historyDetails.forEach { historyDetail in
-            if placeInLine < 1 || placeInLine - 1 < i {
+        filteredHistoryDetails.forEach { historyDetail in
+            if normalizedQuery.isEmpty && (placeInLine < 1 || placeInLine - 1 < i) {
                 // Folder
                 if i == subMenuCount {
                     let subMenuItem = makeSubmenuItem(subMenuCount, start: firstIndex, end: currentSize, numberOfItems: placeInsideFolder)
                     menu.addItem(subMenuItem)
+                    currentSubMenu = subMenuItem.submenu
                     listNumber = firstIndex
                 }
 
                 // Clip
-                if let subMenu = menu.item(at: subMenuIndex)?.submenu {
+                if let subMenu = currentSubMenu {
                     let menuItem = makeClipMenuItem(historyDetail, index: i, listNumber: listNumber)
                     subMenu.addItem(menuItem)
                     listNumber += 1
@@ -279,9 +357,19 @@ private extension MenuManager {
             i += 1
             if i == subMenuCount + placeInsideFolder {
                 subMenuCount += placeInsideFolder
-                subMenuIndex += 1
             }
         }
+    }
+
+    func fetchHistoryDetails() -> [PasteboardHistoryDetail] {
+        let reorderClipsAfterPasting = appStorage.bool(forKey: Constants.UserDefaults.reorderClipsAfterPasting)
+        let isShowImage = appStorage.bool(forKey: Constants.UserDefaults.showImageInTheMenu)
+        let isShowColorCode = appStorage.bool(forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
+        return pasteboardHistoryRepository.fetchHistoryDetails(
+            sortsByCreatedAt: !reorderClipsAfterPasting,
+            includesThumbnailAsset: isShowImage || isShowColorCode,
+            limit: appStorage.integer(forKey: Constants.UserDefaults.maxHistorySize)
+        )
     }
 
     func makeClipMenuItem(_ historyDetail: PasteboardHistoryDetail, index: Int, listNumber: Int) -> NSMenuItem {

--- a/ClipyTests/Extensions/PasteboardHistoryExtensionsTests.swift
+++ b/ClipyTests/Extensions/PasteboardHistoryExtensionsTests.swift
@@ -141,17 +141,37 @@ struct PasteboardHistoryExtensionsTests {
             #expect(history.toolTip == nil)
         }
     }
+
+    @Test
+    func searchMatchesTitleIgnoringCaseAndDiacritics() {
+        let history = Self.pasteboardHistory(title: "R\u{00E9}sum\u{00E9} from Clipboard", pasteboardTypes: [.string])
+
+        #expect(history.matchesSearch("resume clipboard"))
+        #expect(!history.matchesSearch("resume image"))
+    }
+
+    @Test
+    func searchMatchesOCRText() {
+        let history = Self.pasteboardHistory(
+            title: "",
+            ocrText: "Invoice number 12345",
+            pasteboardTypes: [.png]
+        )
+
+        #expect(history.matchesSearch("invoice 12345"))
+    }
 }
 
 private extension PasteboardHistoryExtensionsTests {
     static func pasteboardHistory(
         title: String,
+        ocrText: String? = nil,
         pasteboardTypes: [NSPasteboard.PasteboardType]
     ) -> PasteboardHistory {
         PasteboardHistory(
             id: PasteboardHistory.ID(rawValue: UUID().uuidString),
             title: title,
-            ocrText: nil,
+            ocrText: ocrText,
             pasteboardTypes: pasteboardTypes,
             createdAt: 1,
             updateAt: 1,


### PR DESCRIPTION
## Summary

- add an automatically focused search field to the existing main and history menus
- filter clipboard titles and OCR text live with case-insensitive, diacritic-insensitive, multi-term matching
- show matching clips inline, preserve normal grouped menus when the query is empty, and defer menu reconstruction while a menu is open
- localize the new UI strings for all currently supported languages

<img width="759" height="561" alt="image" src="https://github.com/user-attachments/assets/bef01ac3-cc24-43a0-bd29-2e10e4e55f46" />
<img width="433" height="235" alt="image" src="https://github.com/user-attachments/assets/0b7203ff-20ae-4e7a-9735-761f8a3c0baf" />

## Related work

This is a focused alternative to #672 and #707. Those changes introduce dedicated search windows or panels; this PR keeps the existing shortcut and menu workflow and adds search directly to the clipboard menu.

## Testing

- `xcodebuild -project Clipy.xcodeproj -scheme Clipy -configuration Debug -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation test CODE_SIGNING_ALLOWED=NO`
- 98 tests passed
- manually launched the debug app and verified that the existing clipboard shortcut opens the menu with keyboard focus and live filtering