### PR TITLE
Update Screeen to 3.0.0 and use default screenshot paths

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -1610,7 +1610,7 @@
 			repositoryURL = "https://github.com/Clipy/Screeen";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.1.0;
+				minimumVersion = 3.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Clipy/Screeen",
       "state" : {
-        "revision" : "357a72be0060765a8e93b9a70b283fc63c75f4a9",
-        "version" : "2.1.0"
+        "revision" : "f8f4bfa6cb38cb69ec1ee104fb5ad949a92b2ae3",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -22,7 +22,7 @@ import Sharing
 class AppDelegate: NSObject, NSMenuItemValidation {
 
     // MARK: - Properties
-    private let screenshotObserver = ScreenShotObserver(searchDirectoryPaths: AppDelegate.screenshotSearchDirectoryPaths())
+    private let screenshotObserver = ScreenShotObserver()
     private var cancellables: Set<AnyCancellable> = []
 
     @Dependency(\.context)
@@ -232,29 +232,5 @@ extension AppDelegate: ScreenShotObserverDelegate {
         guard let path = item.value(forAttribute: NSMetadataItemPathKey) as? String else { return }
         guard let image = NSImage(contentsOfFile: path) else { return }
         clipService.create(with: image)
-    }
-}
-
-// MARK: - Screenshot Search Paths
-private extension AppDelegate {
-    /// Directories the screenshot observer watches via Spotlight.
-    ///
-    /// Screeen's default scope is the Desktop only, so screenshots saved to a
-    /// custom location (configured via `defaults write com.apple.screencapture
-    /// location <path>`) are never detected. Read that configured destination
-    /// and watch it in addition to the Desktop.
-    static func screenshotSearchDirectoryPaths() -> [String] {
-        var paths: [String] = []
-        if let location = CFPreferencesCopyAppValue("location" as CFString,
-                                                    "com.apple.screencapture" as CFString) as? String {
-            paths.append((location as NSString).expandingTildeInPath)
-        }
-        if let desktop = NSSearchPathForDirectoriesInDomains(.desktopDirectory, .userDomainMask, true).first {
-            paths.append(desktop)
-        }
-        // Deduplicate while preserving order. When empty, Screeen leaves the
-        // query scope unset and searches all indexed locations as a fallback.
-        var seen = Set<String>()
-        return paths.filter { seen.insert($0).inserted }
     }
 }


### PR DESCRIPTION
Screeen 3.0.0 monitors the Desktop and the user's custom macOS screenshot save location by default. Update the dependency and resolved package revision, and initialize the observer with `ScreenShotObserver()`.

Remove Clipy's duplicate screenshot path discovery, tilde expansion, and deduplication logic now handled by Screeen.