### PR TITLE
Update Swift package dependencies

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -1507,7 +1507,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-sharing";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.8.0;
+				minimumVersion = 2.10.0;
 			};
 		};
 		C5700B4A2FC5C3D500C8F965 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
@@ -1515,7 +1515,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.15.0;
+				minimumVersion = 1.17.1;
 			};
 			traits = (
 				Clocks,
@@ -1527,7 +1527,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 12.17.0;
+				minimumVersion = 12.18.0;
 			};
 		};
 		C587AF4F2FBF4E040043D5E7 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
@@ -1535,7 +1535,7 @@
 			repositoryURL = "https://github.com/pointfreeco/sqlite-data";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.10.0;
+				minimumVersion = 1.11.2;
 			};
 			traits = (
 				Tagged,
@@ -1546,7 +1546,7 @@
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.65.0;
+				minimumVersion = 0.65.1;
 			};
 		};
 		C5A6BA722FBC5A6E00C8B9EB /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clipy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
-        "version" : "12.17.0"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "fcd8dced6edad0f1f97b1141de528116cd19eadb",
-        "version" : "1.10.0"
+        "revision" : "3dad73435eb0c88c5f0e3b753cf7f855a51d6755",
+        "version" : "1.11.2"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "9381ab822de01c4e9f3a7eb8eabb6ae808febed3",
-        "version" : "1.15.0"
+        "revision" : "b476cc5761057d8d857de063fe7ac8daecf5c06b",
+        "version" : "1.17.1"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
-        "version" : "2.8.0"
+        "revision" : "4dfe1b9751bb6cd1a34b363310f43b634f8b5645",
+        "version" : "2.10.0"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "3292bab28e6e92000161348003fdef8edc4e582d",
-        "version" : "0.65.0"
+        "revision" : "ef7d692fc6706e8f5628e26bcafaefa445c58a97",
+        "version" : "0.65.1"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "d9308ad679143c26a30dec52daefe82f54af2b82",
+        "version" : "1.13.1"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Update Clipy's eligible Swift Package dependencies to the newest stable versions that had been public for at least 168 hours at the 2026-09-05 05:48:55 UTC evaluation time.

Realm remains intentionally frozen. Releases still inside the observation window are documented below and were not adopted.

## Dependency updates

| Dependency | Previous | New | Update type | Release date (UTC) | Age at evaluation |
| --- | --- | --- | --- | --- | --- |
| swift-sharing | 2.8.0 | 2.10.0 | Direct, minor | 2026-08-28 20:03 | 177.76 hours |
| swift-dependencies | 1.15.0 | 1.17.1 | Direct, minor/patch | 2026-08-28 20:25 | 177.39 hours |
| firebase-ios-sdk | 12.17.0 | 12.18.0 | Direct, minor | 2026-08-19 15:12 | 398.60 hours |
| sqlite-data | 1.10.0 | 1.11.2 | Direct, minor/patch | 2026-08-29 00:11 | 173.62 hours |
| SwiftLintPlugins | 0.65.0 | 0.65.1 | Direct, patch | 2026-08-21 20:30 | 345.30 hours |
| GoogleAppMeasurement | 12.17.0 | 12.18.0 | Transitive, aligned with Firebase | 2026-08-19 15:12 | 398.60 hours |
| xctest-dynamic-overlay | 1.9.0 | 1.13.1 | Transitive, minor/patch | 2026-08-27 20:23 | 201.42 hours |

## Notable changes

### swift-sharing 2.10.0

- Removes the dependency on CombineSchedulers.
- Adds optional CasePaths, IdentifiedCollections, and CustomDump package traits.
- Fixes `FileStorageKey` writes being dropped when using an immediate scheduler.
- Fixes shared-reader loading with a default key base and updates IssueReporting compatibility.

Links: [2.10.0 release notes](https://github.com/pointfreeco/swift-sharing/releases/tag/2.10.0), [2.8.0...2.10.0 comparison](https://github.com/pointfreeco/swift-sharing/compare/2.8.0...2.10.0)

### swift-dependencies 1.17.1

- Restores preview traits and improves `@DependencyEntry` diagnostics.
- Adds `DependencyValues.preferredLocales`.
- Initializes dependency endpoints through storage and eagerly prepares preview dependencies.
- Removes the dependency on XCTestDynamicOverlay and updates IssueReporting compatibility.

Links: [1.17.1 release notes](https://github.com/pointfreeco/swift-dependencies/releases/tag/1.17.1), [1.15.0...1.17.1 comparison](https://github.com/pointfreeco/swift-dependencies/compare/1.15.0...1.17.1)

### sqlite-data 1.11.2

- Adds the `ColumnCoding` passthrough trait and StructuredQueries 0.38 support.
- Supports strings containing non-terminating NUL characters.
- Caches `@FetchAll` and `@FetchOne` statements and improves String, Date, and UUID coding performance.
- Improves `@Fetch*` SwiftUI state handling and fixes shared CloudKit database resolution.
- Improves temporary database cleanup.

Links: [1.11.2 release notes](https://github.com/pointfreeco/sqlite-data/releases/tag/1.11.2), [1.10.0...1.11.2 comparison](https://github.com/pointfreeco/sqlite-data/compare/1.10.0...1.11.2)

### Firebase 12.18.0

- Removes Crashlytics integration with the deprecated MetricKit API.
- Includes Analytics 12.18.0 and Swift Package manifest improvements.
- Includes fixes in other Firebase products that Clipy does not currently link directly.

Links: [12.18.0 release notes](https://github.com/firebase/firebase-ios-sdk/releases/tag/12.18.0), [official Firebase Apple SDK changelog](https://firebase.google.com/support/release-notes/ios#12.18.0), [12.17.0...12.18.0 comparison](https://github.com/firebase/firebase-ios-sdk/compare/12.17.0...12.18.0)

### SwiftLintPlugins 0.65.1

- Tracks SwiftLint 0.65.1, including rule-performance improvements and fixes for line-length URL handling, portable baseline paths, closure corrections, and CRLF correction behavior.
- Clipy's current SwiftLint configuration does not use the removed `allow_multiline_func` option, so no configuration migration is needed.

Links: [SwiftLintPlugins 0.65.1 release notes](https://github.com/SimplyDanny/SwiftLintPlugins/releases/tag/0.65.1), [plugin comparison](https://github.com/SimplyDanny/SwiftLintPlugins/compare/0.65.0...0.65.1), [SwiftLint 0.65.1 release notes](https://github.com/realm/SwiftLint/releases/tag/0.65.1)

### xctest-dynamic-overlay 1.13.1

- Updates the compatibility shim for the package's move to swift-issue-reporting.
- Includes Xcode compatibility, IssueReporting 2.x support, and corrected platform minimums in the Swift 6.4 manifest.

Links: [1.13.1 release notes](https://github.com/pointfreeco/xctest-dynamic-overlay/releases/tag/1.13.1), [1.9.0...1.13.1 comparison](https://github.com/pointfreeco/xctest-dynamic-overlay/compare/1.9.0...1.13.1)

## Clipy integration

- Updated the direct package requirements in `project.pbxproj`.
- Regenerated `Package.resolved` through Xcode's Swift Package resolver and validated the resolved graph from the lock file.
- No Clipy source migration was required for the selected APIs and configurations.
- Realm remains unchanged at 10.7.2 (`ae8e646590396dfc13c1abbf8aa2e48c43766dce`).
- No upstream migration guide applies to the Clipy APIs used by these selected versions.

## Deferred releases

| Dependency | Deferred version | Published (UTC) | Eligible after (UTC) | Reason |
| --- | --- | --- | --- | --- |
| swift-sharing | 2.10.1 | 2026-08-31 17:58 | 2026-09-07 17:58 | Still inside the 168-hour observation window. Its primary regression fix concerns non-Apple platforms and does not justify early adoption for Clipy. |
| sqlite-data | 1.12.0 | 2026-08-31 20:34 | 2026-09-07 20:34 | Still inside the 168-hour observation window. It adds user-defined collating sequences but contains no urgent fix requiring early adoption. |

This pull request was created via Hermes Agent.
