### PR TITLE
Add global shortcut to paste the 2nd most recent history item

### DIFF
--- a/Clipy/Sources/AppStorage/AppStorageKeys.swift
+++ b/Clipy/Sources/AppStorage/AppStorageKeys.swift
@@ -53,5 +53,6 @@ enum AppStorageKeys: String {
     case historyKeyCombo
     case snippetKeyCombo
     case clearHistoryKeyCombo
+    case pasteSecondHistoryItemKeyCombo
     case folderKeyCombos
 }

--- a/Clipy/Sources/AppStorage/AppStorageValues.swift
+++ b/Clipy/Sources/AppStorage/AppStorageValues.swift
@@ -240,6 +240,10 @@ extension SharedKey where Self == AppStorageKey<KeyCombo?>.Default {
     static var clearHistoryKeyCombo: Self {
         Self[.appStorage(AppStorageKeys.clearHistoryKeyCombo.rawValue), default: nil]
     }
+
+    static var pasteSecondHistoryItemKeyCombo: Self {
+        Self[.appStorage(AppStorageKeys.pasteSecondHistoryItemKeyCombo.rawValue), default: nil]
+    }
 }
 
 extension SharedKey where Self == AppStorageKey<[String: KeyCombo]>.Default {

--- a/Clipy/Sources/Dependencies/Firebase.swift
+++ b/Clipy/Sources/Dependencies/Firebase.swift
@@ -23,6 +23,7 @@ struct Firebase {
     enum Event {
         case popUpMenu(MenuType)
         case popUpSnippetFolderMenu
+        case pasteSecondHistoryItem
 
         var name: String {
             switch self {
@@ -30,13 +31,15 @@ struct Firebase {
                 return "pop_up_menu"
             case .popUpSnippetFolderMenu:
                 return "pop_up_snippet_folder_menu"
+            case .pasteSecondHistoryItem:
+                return "paste_second_history_item"
             }
         }
         var parameters: [String: Any]? {
             switch self {
             case .popUpMenu(let type):
                 return ["type": type.rawValue]
-            case .popUpSnippetFolderMenu:
+            case .popUpSnippetFolderMenu, .pasteSecondHistoryItem:
                 return nil
             }
         }

--- a/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
+++ b/Clipy/Sources/Preferences/Panels/Base.lproj/CPYShortcutsPreferenceViewController.xib
@@ -10,6 +10,7 @@
                 <outlet property="clearHistoryShortcutRecordView" destination="pCf-EG-Cp9" id="K22-8R-Gk9"/>
                 <outlet property="historyShortcutRecordView" destination="hDA-gc-n3S" id="fzg-O8-Fze"/>
                 <outlet property="mainShortcutRecordView" destination="ABK-GW-Xwm" id="Jr7-Dz-hqZ"/>
+                <outlet property="pasteSecondHistoryItemShortcutRecordView" destination="p2H-Ik-Rv1" id="p2H-Ok-Rv2"/>
                 <outlet property="snippetShortcutRecordView" destination="q8v-jS-CAr" id="Ay0-Zr-azr"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -17,11 +18,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="275"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="323"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="5oP-dg-DwL">
-                    <rect key="frame" x="59" y="244" width="210" height="17"/>
+                    <rect key="frame" x="59" y="292" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Menu" id="X5L-5V-1eH">
                         <font key="font" metaFont="systemBold"/>
@@ -30,7 +31,7 @@
                     </textFieldCell>
                 </textField>
                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uTq-IP-dYk">
-                    <rect key="frame" x="44" y="96" width="392" height="140"/>
+                    <rect key="frame" x="44" y="144" width="392" height="140"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vzz-Iq-77h">
@@ -120,7 +121,7 @@
                     </subviews>
                 </view>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" preferredMaxLayoutWidth="206" translatesAutoresizingMaskIntoConstraints="NO" id="fZN-Ox-42G">
-                    <rect key="frame" x="59" y="66" width="210" height="17"/>
+                    <rect key="frame" x="59" y="114" width="210" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="History" id="Txl-Qh-RzP">
                         <font key="font" metaFont="systemBold"/>
@@ -129,9 +130,39 @@
                     </textFieldCell>
                 </textField>
                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zgf-1z-HW3">
-                    <rect key="frame" x="44" y="14" width="392" height="44"/>
+                    <rect key="frame" x="44" y="14" width="392" height="92"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
+                        <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p2L-Ik-Rv3">
+                            <rect key="frame" x="15" y="62" width="121" height="17"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Paste 2nd Item:" id="p2C-Ik-Rv4">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" red="0.2666666667" green="0.2666666667" blue="0.2666666667" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p2H-Ik-Rv1" customClass="RecordView" customModule="KeyHolder">
+                            <rect key="frame" x="142" y="53" width="250" height="34"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="color" keyPath="tintColor">
+                                    <color key="value" red="0.1647058824" green="0.51764705879999995" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                    <color key="value" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="17"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                    <color key="value" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                    <real key="value" value="1"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </customView>
                         <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qah-qM-yU1">
                             <rect key="frame" x="15" y="14" width="121" height="17"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
+++ b/Clipy/Sources/Preferences/Panels/CPYShortcutsPreferenceViewController.swift
@@ -23,6 +23,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     @IBOutlet private weak var historyShortcutRecordView: RecordView!
     @IBOutlet private weak var snippetShortcutRecordView: RecordView!
     @IBOutlet private weak var clearHistoryShortcutRecordView: RecordView!
+    @IBOutlet private weak var pasteSecondHistoryItemShortcutRecordView: RecordView!
 
     @Dependency(\.hotKeyService)
     private var hotKeyService
@@ -34,6 +35,8 @@ class CPYShortcutsPreferenceViewController: NSViewController {
     private var snippetKeyCombo
     @Shared(.clearHistoryKeyCombo)
     private var clearHistoryKeyCombo
+    @Shared(.pasteSecondHistoryItemKeyCombo)
+    private var pasteSecondHistoryItemKeyCombo
 
     // MARK: - Initialize
     override func loadView() {
@@ -42,6 +45,7 @@ class CPYShortcutsPreferenceViewController: NSViewController {
         historyShortcutRecordView.delegate = self
         snippetShortcutRecordView.delegate = self
         clearHistoryShortcutRecordView.delegate = self
+        pasteSecondHistoryItemShortcutRecordView.delegate = self
         prepareHotKeys()
     }
 
@@ -54,6 +58,7 @@ private extension CPYShortcutsPreferenceViewController {
         historyShortcutRecordView.keyCombo = historyKeyCombo
         snippetShortcutRecordView.keyCombo = snippetKeyCombo
         clearHistoryShortcutRecordView.keyCombo = clearHistoryKeyCombo
+        pasteSecondHistoryItemShortcutRecordView.keyCombo = pasteSecondHistoryItemKeyCombo
     }
 }
 
@@ -77,6 +82,8 @@ extension CPYShortcutsPreferenceViewController: RecordViewDelegate {
             hotKeyService.change(with: .snippet, keyCombo: keyCombo)
         case clearHistoryShortcutRecordView:
             hotKeyService.changeClearHistoryKeyCombo(keyCombo)
+        case pasteSecondHistoryItemShortcutRecordView:
+            hotKeyService.changePasteSecondHistoryItemKeyCombo(keyCombo)
         default: break
         }
     }

--- a/Clipy/Sources/Services/HotKeyService.swift
+++ b/Clipy/Sources/Services/HotKeyService.swift
@@ -26,6 +26,8 @@ final class HotKeyService: NSObject {
     private var menuManager
     @Dependency(\.clipService)
     private var clipService
+    @Dependency(\.pasteService)
+    private var pasteService
 
     @Shared(.mainKeyCombo)
     private var mainKeyCombo
@@ -35,6 +37,8 @@ final class HotKeyService: NSObject {
     private var snippetKeyCombo
     @Shared(.clearHistoryKeyCombo)
     private var clearHistoryKeyCombo
+    @Shared(.pasteSecondHistoryItemKeyCombo)
+    private var pasteSecondHistoryItemKeyCombo
     @Shared(.folderKeyCombos)
     private var folderKeyCombos
 }
@@ -53,6 +57,8 @@ extension HotKeyService {
         change(with: .snippet, keyCombo: snippetKeyCombo)
         // Clear History
         changeClearHistoryKeyCombo(clearHistoryKeyCombo)
+        // Paste 2nd history item
+        changePasteSecondHistoryItemKeyCombo(pasteSecondHistoryItemKeyCombo)
     }
 
     func change(with type: MenuType, keyCombo: KeyCombo?) {
@@ -77,13 +83,25 @@ extension HotKeyService {
 
     func changeClearHistoryKeyCombo(_ keyCombo: KeyCombo?) {
         $clearHistoryKeyCombo.withLock { $0 = keyCombo }
-        // Reset hotkey
-        HotKeyCenter.shared.unregisterHotKey(with: "ClearHistory")
-        // Register new hotkey
-        guard let keyCombo = keyCombo else { return }
-        let hotkey = HotKey(identifier: "ClearHistory", keyCombo: keyCombo) { [weak self] _ in
+        register(identifier: "ClearHistory", keyCombo: keyCombo) { [weak self] in
             self?.clipService.clearAllHistory()
         }
+    }
+
+    func changePasteSecondHistoryItemKeyCombo(_ keyCombo: KeyCombo?) {
+        $pasteSecondHistoryItemKeyCombo.withLock { $0 = keyCombo }
+        register(identifier: "PasteSecondHistoryItem", keyCombo: keyCombo) { [weak self] in
+            guard let self, pasteService.pasteHistoryItem(at: 1) else { return }
+            firebase.logEvent(event: .pasteSecondHistoryItem)
+        }
+    }
+
+    private func register(identifier: String, keyCombo: KeyCombo?, handler: @escaping () -> Void) {
+        // Reset hotkey
+        HotKeyCenter.shared.unregisterHotKey(with: identifier)
+        // Register new hotkey
+        guard let keyCombo = keyCombo else { return }
+        let hotkey = HotKey(identifier: identifier, keyCombo: keyCombo) { _ in handler() }
         hotkey.register()
     }
 }

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -28,6 +28,8 @@ final class PasteService {
 
     @Dependency(\.clipService)
     private var clipService
+    @Dependency(\.pasteboardHistoryRepository)
+    private var pasteboardHistoryRepository
 
     @Shared(.pastesPlainTextWithModifier)
     private var pastesPlainTextWithModifier
@@ -43,6 +45,8 @@ final class PasteService {
     private var pasteAndDeleteHistoryModifier
     @Shared(.pastesAutomatically)
     private var pastesAutomatically
+    @Shared(.reordersClipsAfterPasting)
+    private var reordersClipsAfterPasting
 
     private var isPastePlainText: Bool {
         guard pastesPlainTextWithModifier else { return false }
@@ -104,6 +108,26 @@ extension PasteService {
         }
     }
 
+    /// Pastes the history item at `index` (0 = most recent) using the same ordering as the history menu.
+    /// Modifier actions (plain text, delete) are skipped because the triggering hotkey's own modifiers are still held.
+    /// Returns `false` when no item exists at `index`.
+    @discardableResult
+    func pasteHistoryItem(at index: Int) -> Bool {
+        let historyDetails = pasteboardHistoryRepository.fetchHistoryDetails(
+            sortsByCreatedAt: !reordersClipsAfterPasting,
+            includesThumbnailAsset: false,
+            limit: index + 1
+        )
+        guard historyDetails.indices.contains(index),
+              let content = pasteboardHistoryRepository.fetchContent(id: historyDetails[index].history.id) else {
+            NSSound.beep()
+            return false
+        }
+        writeToPasteboard(content)
+        paste()
+        return true
+    }
+
     func copyToPasteboard(with string: String) {
         lock.lock(); defer { lock.unlock() }
 
@@ -119,6 +143,12 @@ extension PasteService {
             copyToPasteboard(with: content.stringValue ?? "")
             return
         }
+
+        writeToPasteboard(content)
+    }
+
+    private func writeToPasteboard(_ content: PasteboardContent) {
+        lock.lock(); defer { lock.unlock() }
 
         let pasteboard = NSPasteboard.general
         content.writeObjects(to: pasteboard)

--- a/ClipyTests/AppStorage/AppStorageValuesTests.swift
+++ b/ClipyTests/AppStorage/AppStorageValuesTests.swift
@@ -110,6 +110,7 @@ struct AppStorageValuesTests {
         @Shared(.historyKeyCombo) var historyKeyCombo
         @Shared(.snippetKeyCombo) var snippetKeyCombo
         @Shared(.clearHistoryKeyCombo) var clearHistoryKeyCombo
+        @Shared(.pasteSecondHistoryItemKeyCombo) var pasteSecondHistoryItemKeyCombo
         @Shared(.folderKeyCombos) var folderKeyCombos
 
         let defaultMainKeyCombo = try #require(mainKeyCombo)
@@ -125,6 +126,7 @@ struct AppStorageValuesTests {
         #expect(defaultSnippetKeyCombo.modifiers == 768)
 
         #expect(clearHistoryKeyCombo == nil)
+        #expect(pasteSecondHistoryItemKeyCombo == nil)
         #expect(folderKeyCombos.isEmpty)
     }
 

--- a/ClipyTests/HotKeyServiceTests.swift
+++ b/ClipyTests/HotKeyServiceTests.swift
@@ -13,6 +13,7 @@ final class HotKeyServiceTests {
     @Shared(.historyKeyCombo) var historyKeyCombo
     @Shared(.snippetKeyCombo) var snippetKeyCombo
     @Shared(.clearHistoryKeyCombo) var clearHistoryKeyCombo
+    @Shared(.pasteSecondHistoryItemKeyCombo) var pasteSecondHistoryItemKeyCombo
     @Shared(.folderKeyCombos) var folderKeyCombos
 
     @Test
@@ -56,5 +57,22 @@ final class HotKeyServiceTests {
 
         service.changeClearHistoryKeyCombo(nil)
         #expect(clearHistoryKeyCombo == nil)
+    }
+
+    @Test
+    func addAndRemovePasteSecondHistoryItemHotkey() throws {
+        let service = HotKeyService()
+
+        #expect(pasteSecondHistoryItemKeyCombo == nil)
+
+        service.changePasteSecondHistoryItemKeyCombo(KeyCombo(QWERTYKeyCode: 9, carbonModifiers: cmdKey | optionKey))
+
+        #expect(pasteSecondHistoryItemKeyCombo?.QWERTYKeyCode == 9)
+        #expect(pasteSecondHistoryItemKeyCombo?.modifiers == cmdKey | optionKey)
+        #expect(pasteSecondHistoryItemKeyCombo?.doubledModifiers == false)
+        #expect(pasteSecondHistoryItemKeyCombo?.keyEquivalent.uppercased() == "V")
+
+        service.changePasteSecondHistoryItemKeyCombo(nil)
+        #expect(pasteSecondHistoryItemKeyCombo == nil)
     }
 }


### PR DESCRIPTION
## Summary

Adds a global shortcut that pastes the **2nd most recent** history item directly, without opening the menu. It appears as a new "Paste 2nd Item" recorder in the Shortcuts preference pane, alongside Clear History. Unset by default, so nothing is registered until a combo is recorded.

Motivation: the common multi-clip workflow is "copy A, copy B, paste B, paste A". Today that needs the History hotkey plus a digit, with numeric key equivalents enabled. This makes it one keystroke. Related discussion in #295, where a commenter noted that most of the time the item they want is the 2nd one.

## Behaviour

- Ordering matches the history menu: newest first, by `createdAt` or `updateAt` depending on "Reorder clips after pasting".
- Pasting re-records the item as the newest entry, so repeated presses alternate between the two most recent clips.
- Beeps if there is no 2nd item.
- The plain-text and delete modifier actions are not applied on this path, since the hotkey's own modifiers are still held when it fires and would collide.

## Known limitation

Pressing the shortcut twice within about 500ms pastes the same item twice instead of alternating. `ClipService` polls `NSPasteboard.changeCount` on a 500ms timer, so the history order has not been updated yet when the second press reads it. Making the reorder synchronous, or tracking a cursor in memory, would fix it. Both felt out of scope here, and I am happy to follow up if you have a preference on the approach.

## Implementation

- `PasteService.pasteHistoryItem(at:)` is index-based, so further positions can be added without new plumbing.
- `HotKeyService` registration is extracted into a shared `register(identifier:keyCombo:handler:)` helper, now that Clear History and this shortcut have the same shape.
- New `AppStorageKeys.pasteSecondHistoryItemKeyCombo`, defaulting to nil.
- Firebase event `paste_second_history_item`, logged only when a paste actually happens.
- Xib: the Shortcuts pane grows by one row and existing rows shift up.
- Tests added to `HotKeyServiceTests` and `AppStorageValuesTests`.

Localised `.strings` for the new label are not included, so it falls back to the Base English until translators pick it up.

## Testing

- CI green: build plus the full test suite.
- Verified by hand on macOS 26.2 with a local debug build. The new row records a combo, the shortcut pastes the 2nd item, and repeated presses alternate as described.
